### PR TITLE
docs: queue planned code review lens contract

### DIFF
--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -27,7 +27,39 @@ parity evidence.
 
 ## P2
 
-No items.
+### Make code-review lens selection an operator-approved planning contract
+
+**Author.** Jeff Cox and Codex
+
+**Priority.** P2
+
+**Effort.** One focused design and implementation unit during the future Saga
+port, followed by cross-vendor compatibility proof.
+
+**Worth it when.** Before Saga Plan and Saga Code Review become authoritative
+from this repository.
+
+**Context.** The current Claude Saga Plan does not select the later code-review
+lenses. Saga Code Review instead loads the canonical roster, runs its four
+always-on lenses, and judgment-selects conditional lenses from the completed
+diff. Preserve that diff check, but move the operator decision earlier: Saga
+Plan should recommend applicable conditional lenses with reasons and ask the
+operator once. The approved roster, roster version, and reasons become part of
+the plan contract. The review Arbiter (the Code Review coordinator) compares
+the final diff with that contract and asks again only when implementation adds
+material scope. Any later roster change must be an operator-approved, versioned
+addendum created before findings influence lens selection; the Arbiter must not
+silently add or remove lenses after seeing review results. Do not add a ritual
+operator question when the approved contract still matches the diff.
+
+**Guardrail.** This entry defers implementation. Do not change the current
+vendor Saga plugins or transfer their custody until the relevant portability
+pilot and custody decision authorize that work.
+
+**Refs.** [Architecture brief](../cross-vendor-plugin-architecture-brief.md),
+[queued pilot decision](#choose-the-first-portability-pilot-and-custody-gate),
+[current Saga Plan](https://github.com/infiquetra/infiquetra-claude-plugins/blob/main/plugins/saga/skills/plan/SKILL.md),
+[current Saga Code Review](https://github.com/infiquetra/infiquetra-claude-plugins/blob/main/plugins/saga/skills/code-review/SKILL.md).
 
 ## P3
 


### PR DESCRIPTION
## Summary

- record operator-approved lens selection as a future Saga Plan contract
- require the review Arbiter to reopen selection only for material scope change
- defer implementation and vendor-plugin custody changes until the Saga portability work is authorized

## Validation

- `python3 scripts/check_repo.py`
- `python3 -m unittest discover -s tests -v`
- `git diff --check`