### PR TITLE
docs(plans): UniFi and portable Fleet Core portability pilot plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,15 @@
   records the research, proposed boundaries, compatibility observations, and
   decisions that remain open.
 
+## Plans and reviews
+
+- [UniFi and portable Fleet Core portability pilot plan](plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md)
+  is the first portability pilot: decision-complete, planning only, and not yet executed.
+- [Document review of that plan](reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review.md)
+  is preserved unmodified as incoming evidence, with its
+  [validation and repair record](reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review-disposition.md)
+  alongside it.
+
 ## Repository guidance
 
 - [Public-safe Infiquetra summary](public-safe-summary.md) gives contributors

--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -1,6 +1,34 @@
 # Archive - shipped, rejected, and superseded items
 
-No archived items yet.
+## 2026-08-21
+
+### Void parity baseline recorded in error
+
+**Status.** Void. Never a valid decision at any point.
+
+**Original text.** "Parity with code; correct the ported docs downstream." Under this
+reading the portable skill and reference documents would have been corrected in this
+repository only, the Claude source would have kept its stale documentation, and the
+provenance manifest would have carried a per-file `intentional-deviation` status to
+legitimize the difference.
+
+**Why it was invalid.** It was not the operator's selection. The controlling client
+mis-entered the choice: the operator selected "fix the authoritative source first, then
+port," and the downstream-correction option was recorded instead. Nothing downstream of
+the mis-entered option was ever approved. Downstream-only documentation correction and
+intentional target divergence are both explicitly unapproved.
+
+**Replacement.** The authoritative source is repaired, verified, and released before the
+port synchronizes from it. See
+[the pilot decision](DECISIONS.md#choose-unifi-plus-a-portable-fleet-core-slice-as-the-first-portability-pilot)
+and the [pilot plan](../plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md).
+
+**Preserved because.** The repository's supersession convention requires the original
+text to survive rather than be erased, and an audit trail that hides a mis-entry teaches
+nothing about how the mis-entry happened.
+
+---
+
 
 When an item reaches a terminal state, preserve the original entry, its outcome,
 the date, and the validating commit, pull request, issue, or evidence link.

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -2,6 +2,54 @@
 
 ## 2026-08-21
 
+### Choose UniFi plus a portable Fleet Core slice as the first portability pilot
+
+**Author.** Jeff Cox and Claude
+
+**Decision.** Port the Claude `unifi` plugin into a portable Agent Plugins 1.0 package
+in this repository, together with a new portable Fleet Core source carrying only the
+`retry_backoff` module. The Claude repository is repaired first, released second, and
+synchronized from third. Custody does not move.
+
+The load-bearing choices, each recorded in full in the
+[pilot plan](../plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md):
+
+- The portable copy is derived and digest-verified, never a second writable source.
+- The authoritative source is repaired before the port consumes it; downstream-only
+  correction and intentional target divergence are both rejected.
+- Extract means relocate, not delete: the embedded lab topology moves into an operator
+  site profile, and the repaired release is gated on that replacement path being
+  verified so the Claude agent never loses site context.
+- Fleet Core becomes a first-class portable source, but only one vertical slice is
+  ported; the required module is bundled into consuming artifacts at build time, since
+  Agent Plugins 1.0 has no dependency mechanism.
+- Compatibility coverage across all ten installed clients is mandatory; passing is not.
+  The matrix is a deliverable ending in an operator pause, not a release gate.
+
+**Rejected alternatives.** A hand-port with no drift detection; a subtree or submodule of
+the vendor repository; porting the documentation defect verbatim; inlining the retry
+primitive and reversing the fleet-wide shared-primitive decision; inventing an Agent
+Plugins dependency field; and requiring an environment variable that would resolve to
+nothing on a non-Claude host.
+
+**Rationale.** UniFi is small enough to finish and real enough to exercise the actual
+architecture boundary. Investigation found three problems the file listing could not
+show — an undeclared cross-plugin dependency resolved through Claude-specific discovery,
+documentation describing capabilities removed five months earlier, and one operator's
+controller address hard-coded as a universal default — and each of them is exactly the
+kind of thing a pilot exists to surface before a larger port inherits it.
+
+**Revisit when.** The ten-client compatibility matrix is complete and the operator has
+made the per-client decisions that follow it, or evidence shows the build-time bundling
+model does not generalize to a second consumer.
+
+**Refs.** [Pilot plan](../plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md),
+[architecture brief](../cross-vendor-plugin-architecture-brief.md),
+[superseded parity decision](ARCHIVE.md#void-parity-baseline-recorded-in-error),
+[queued pilot item](QUEUED.md#choose-the-first-portability-pilot-and-custody-gate)
+
+---
+
 ### Establish a public cross-vendor plugin source repository
 
 **Author.** Jeff Cox and Codex

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -2,6 +2,56 @@
 
 ## 2026-08-21
 
+### A plugin's tracked file list does not reveal what it needs to run
+
+**Author.** Jeff Cox and Claude
+
+**Context.** Scoping the UniFi portability pilot from its thirteen tracked files.
+
+**Evidence.** Both UniFi clients call a loader at module import time, not inside a
+function, which reaches into a separate plugin the manifest never declares as a
+dependency. The loader resolves that plugin four ways and three are host-specific: a
+walk-up for the Claude marketplace manifest, a read of Claude Code's installed-plugin
+registry, and a scan of a Claude-injected environment variable. Only one path is
+host-neutral. Details and line citations are in the [pilot plan](../plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md).
+
+**Mechanism.** Because the call runs at import rather than at use, the failure lands
+before argument parsing. On a host where the loader finds nothing, every command fails,
+including read-only ones that never needed the dependency. Nothing in the file list, the
+manifest, or the directory layout shows this; only reading the imports does.
+
+**Generalizable rule.** Before scoping any port, read the target's import statements, not
+its file list. An import-time dependency resolved through host-specific discovery is
+invisible to packaging and fatal to portability, and a manifest that declares no
+dependencies is not evidence that there are none.
+
+---
+
+### Documentation drifts in both directions, and the dangerous direction is over-promising
+
+**Author.** Jeff Cox and Claude
+
+**Context.** Building a behavior-parity inventory for the same pilot.
+
+**Evidence.** A commit five months before the port removed four Protect capabilities
+because the older API path rejects key-based authentication. Eighty-one references to
+those capabilities survive across six documentation surfaces, including the plugin
+manifest's own description. Separately, both API reference documents disagree with the
+shipped code on multiple endpoint paths, and the network skill omits four capabilities
+that do work.
+
+**Mechanism.** Under-documentation costs a reader a discovery; over-documentation costs
+an agent a failed invocation it was told would succeed. An agent loads the skill file,
+not the source, so documentation that promises absent commands is not merely stale, it is
+an instruction to do something impossible.
+
+**Generalizable rule.** Derive a parity inventory from the code and treat every
+documentation surface as a claim to be checked against it. When a port finds drift,
+repair it in the authoritative source rather than in the copy, or the two diverge
+permanently and neither can be trusted afterwards.
+
+---
+
 ### Portable plugin standards do not replace vendor runtimes
 
 **Author.** Jeff Cox and Codex

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -17,7 +17,19 @@ No items.
 **Worth it when.** Before any existing vendor plugin is migrated or generated
 from this repository.
 
-**Context.** The architecture research recommends `home-lab-ops`,
+**Status update, 2026-08-21.** The design session is complete and its output is the
+[UniFi and portable Fleet Core portability pilot plan](../plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md). The pilot is `unifi`
+plus a one-module portable Fleet Core slice; the client matrix is all ten installed
+clients as mandatory coverage rather than a pass gate; and the source-custody rule is
+that the Claude repository stays authoritative, is repaired and released first, and is
+then synchronized from by a digest-verified derivation. This item stays queued until the
+pilot itself is executed and its compatibility matrix reaches the operator pause.
+
+**Still open.** The Herdr execution boundary is untouched by this pilot, and the
+custody-transfer question remains deliberately unanswered until the pilot produces
+evidence.
+
+**Original context.** The architecture research recommends `home-lab-ops`,
 `mission-control`, or `unifi` as the first pilot. The work still needs a chosen
 pilot, required client matrix, Herdr boundary, source-custody rule, and semantic
 parity evidence.

--- a/docs/engineering-journal/audits/2026-08-22-unifi-pilot-plan-doc-review.md
+++ b/docs/engineering-journal/audits/2026-08-22-unifi-pilot-plan-doc-review.md
@@ -1,0 +1,46 @@
+# Document review of the UniFi and portable Fleet Core pilot plan
+
+Date: 2026-08-22
+Author: Codex GPT-5.6 Sol document review; validated and repaired by Jeff Cox and Claude
+Scope: `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md` at pull request #2 head `43b4cc8`, against `infiquetra-claude-plugins` at `995a475`, the installed Orchestrate contract, and the published Agent Plugins 1.0.0 specification
+Related entries:
+
+- [Pilot decision](../DECISIONS.md#choose-unifi-plus-a-portable-fleet-core-slice-as-the-first-portability-pilot)
+- [Queued pilot item](../QUEUED.md#choose-the-first-portability-pilot-and-custody-gate)
+- [Void parity baseline](../ARCHIVE.md#void-parity-baseline-recorded-in-error)
+
+## Question
+
+Whether the first portability pilot plan was decision-complete enough to execute, or whether an
+implementer would have to invent behavior or exceed an authority boundary.
+
+## Evidence reviewed
+
+- Immutable incoming review artifact: [`docs/reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review.md`](../../reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review.md), SHA-256 `3d50ae5ae128d3f15fcf4750c43a747d3c8dee123369997a4584e62eb24f01e5`, 228 lines.
+- Independent validation and repair record: [`docs/reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review-disposition.md`](../../reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review-disposition.md).
+
+## Findings
+
+- Verdict was NOT READY, blocked by ten priority-1 findings with two priority-2 findings alongside.
+- All twelve were independently confirmed against primary evidence. None was refuted or narrowed.
+- The failures clustered in four places: a self-contradiction about execution ownership, a
+  dependency graph that no single controller run could carry, contracts promised in requirements but
+  owned by no file or test, and evidence gates that proved counts rather than coverage.
+- None of the repairs required a new operator decision. Every one was either a correction of the
+  document to match an already-settled ruling, or an application of a standing repository rule.
+
+## Recommendations
+
+- Treat "which file and which test own this promise?" as a first-class planning check. Most of the
+  priority-1 findings were requirements no unit's file list could satisfy, which document validation
+  cannot detect because the prose reads as complete.
+- Prefer deriving inventories and counts from a pinned source tree over writing them down. Both
+  priority-2 findings were handwritten numbers that were wrong on the day they were written.
+- When a digest attests to a file, define what the digest covers before defining where it is stored.
+  A stamp inside the bytes it hashes cannot be computed.
+
+## Follow-up
+
+- Repairs landed on the `docs/unifi-portability-pilot-plan` branch and pull request #2.
+- The plan is ready for a fresh document review; requirements grew from 29 to 45 and decisions from
+  8 to 15, with no identifier renumbered.

--- a/docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md
+++ b/docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md
@@ -33,7 +33,7 @@ R2. Repository validation verifies the portable tree against its own provenance 
 
 R3. The authoritative Claude source repair is authored, verified, and released before any synchronization unit runs. The pinned source commit in the provenance manifest is the corrected revision, never 995a475.
 
-R4. No portable file diverges from its authoritative source by intent. Where the portable tree must differ, the difference is produced by the upstream repair first, not by editing the copy.
+R4. Every path in the portable tree is classified as exactly one of three kinds, and the classification is recorded in the provenance manifest: an upstream byte copy, a versioned deterministic transform, or target-owned portable source. A byte copy never diverges from its source; where it would need to, the upstream repair produces the difference first. A transform records its source digest, its output digest, and its transform version. Target-owned source has no upstream counterpart and is never overwritten or removed by synchronization.
 
 ### Upstream repair, authored and released before the port
 
@@ -95,7 +95,51 @@ R27. Raw read output is default-deny for persistence to any committable path, be
 
 R28. The portable manifest lives at the plugin root and carries the two fields Agent Plugins 1.0 requires: the exact canonical `$schema` identifier and `name`. Claude-specific files live under the `com.infiquetra.claude/` client extension directory.
 
-R29. Portable skill frontmatter conforms to the open Agent Skills specification's six permitted fields, and each skill's `name` matches its parent directory name.
+R29. Portable skill frontmatter conforms to the open Agent Skills specification's six permitted fields, and each skill's `name` matches its parent directory name. The frontmatter is corrected upstream before synchronization, so the portable skill files stay byte copies rather than transforms.
+
+### Execution ownership and run topology
+
+R30. Orchestrate, driving Herdr sessions, is the outer controller. Every dispatched unit runs Saga with `backend: inline`, so no unit starts a nested orchestration inside a session that is already one of several parallel sessions.
+
+R31. Each Orchestrate run owns exactly one repository. Cross-repository dependencies are released by a named receipt rather than by ambient access, the controller pauses at every authority boundary, and the target-repository run resumes at U10 once the Claude and home-lab work has landed.
+
+### Fleet Core custody and lifecycle
+
+R32. Custody of `retry_backoff` does not move. The portable Fleet Core copy is derived under the same synchronization rule as UniFi, its initial portable version and provenance are derived from Fleet Core 0.25.0, and a future retry fix lands upstream first and reaches this repository by re-synchronization.
+
+R33. Fleet Core's release surface is named explicitly: its portable manifest, its provenance manifest, its changelog, the ported module, and the ported test. A promise of versioning and provenance that no file carries is not a lifecycle.
+
+### Build declaration and digest domains
+
+R34. The set of modules a consumer bundles is declared in a separate portable build-declaration file with a closed schema, never as an unknown top-level field in the Agent Plugins manifest, which is a closed schema that forbids assigning semantics to unrecognized fields.
+
+R35. Two digest domains exist and fail for different reasons. The source-payload digest covers the Fleet Core module's bytes and detects a stale bundle; the generated-output digest covers the generated file's content excluding its own stamp block and detects a hand edit. A digest is never computed over bytes that contain it.
+
+### Site profile execution contract
+
+R36. The portable profile format is JSON, parsed with the standard library, so a runtime with no third-party parser can read it. An operator may author in another format, but what the portable core reads is JSON.
+
+R37. A named entrypoint owns presenting the three first-setup paths and remembering the chosen one. A contract no component presents is not reachable by a user.
+
+R38. The Claude adapter carries its own profile loader, so the upstream agent can consume the profile contract without depending on a file that lives only in this repository.
+
+R39. A proposed profile contains observed fields plus explicit unknown intent, and never prefills a trust role, ownership, criticality, or intended policy. A test asserts every intent field of a generated proposal is unknown.
+
+### Release activation and rollback
+
+R40. Every release surface is named: the plugin manifest, its marketplace entry, and the changelog, whose versions the upstream repository's tri-lock parity gate requires to be equal. Activation is preceded by a staged load and followed by an installed-version and digest readback.
+
+R41. A fresh client session proves all three profile states after activation: profile present, profile absent, and profile unreadable. Source-tree evidence alone does not satisfy this, because an active client can remain cached.
+
+R42. Rollback names its trigger, its reachable prior version, the marketplace refresh it requires, and repeats the fresh-session proof. An undefined rollback is not a rollback.
+
+### Evidence completeness and sanitization
+
+R43. Each client's matrix row carries four stage results — placement, discovery, load, and invocation — each marked executed, blocked, or not applicable with its command and evidence, followed by exactly one overall status. Ten rows are not ten assessments.
+
+R44. Public evidence records field names, counts, pass or fail comparisons, and source and result digests, with redacted commands and no raw topology or controller responses. Any sensitive receipt stays outside this repository and is linked only by a non-sensitive digest or identifier.
+
+R45. The upstream documentation repair owns named test paths, and every surface named in R5 through R7 maps to an assertion or to an explicitly recorded review gate.
 
 ## Key Technical Decisions
 
@@ -121,7 +165,60 @@ The load-bearing choices that constrain implementation. Each is a decision with 
 
 **KTD7 — The portable package targets Python 3.10 or newer.** Neither client carries a `__future__` annotations import, so the bare union annotation on both constructors is evaluated at definition time and requires Python 3.10. This is read off the code rather than chosen, and it is declared in the skills' `compatibility` frontmatter field so a consuming client can see it before running anything.
 
+**KTD8 — Orchestrate through Herdr is the outer controller; `inline` is the inner backend.** These are two layers, not two candidates. Orchestrate dispatches and monitors Herdr sessions, and every dispatched unit runs Saga inline because a dispatched unit is already one of several parallel sessions and nesting a workflow inside one is the orchestration-of-orchestration that Orchestrate exists to avoid. Rejected: reading `backend: inline` as "one agent does everything in the main session," which would discard the outer controller entirely.
+
+**KTD9 — One Orchestrate run per repository, joined by receipts.** Orchestrate resolves a single repository root from its checkout and runs one branch and worktree per unit within it, so a three-repository graph is three runs rather than one run reaching sideways. Each cross-repository edge is released by a named receipt the next run consumes. Rejected: placing an outside-repository unit in the target run, which would either launch it in the wrong worktree or require ambient writes beyond that unit's declared authority.
+
+**KTD10 — Custody of the Fleet Core slice does not move.** The portable copy is derived under the same rule as UniFi, because this repository's standing rule is that existing vendor repositories stay authoritative until a recorded custody decision moves them, and no such decision has been made. First-class portable source means the package gets a real lifecycle — version, provenance, release surface, compatibility contract — not that authorship relocates. Rejected: a bounded custody transfer for one module, which would create two writable sources for `retry_backoff` the first time it needs a fix.
+
+**KTD11 — A stamp is never inside the bytes it hashes.** The source-payload digest covers the upstream module and detects staleness; the generated-output digest covers the generated file excluding its stamp block and detects tampering. Two domains mean stale source and hand-edited output fail as different, deterministic signals rather than as one ambiguous mismatch. Rejected: a single digest over the whole generated file, which is self-referential and cannot be computed.
+
+**KTD12 — The portable profile is JSON.** The portable core parses it with the standard library, so a runtime with no third-party parser can read a profile, which keeps the optional-profile promise true on a minimal host. An operator may author in a friendlier format and render JSON at deployment time, which is what the Infiquetra instance does with its existing Ansible harness. Rejected: making the portable core depend on a YAML parser, which would add a runtime dependency to satisfy an authoring preference.
+
 ## High-Level Technical Design
+
+### Execution ownership
+
+Two layers, settled and not open.
+
+Orchestrate is the outer controller and uses Herdr to dispatch, monitor, and land the work. Inside every dispatched unit, Saga runs with `backend: inline`, which is why the plan's frontmatter carries that value. The frontmatter is an instruction to each unit, not a claim that the whole plan runs in one session.
+
+Where the scope boundaries say Saga and Team Execution are untouched, that means their source is not modified by this pilot. It does not mean the approved controller goes unused.
+
+### Run topology across three repositories
+
+Three Orchestrate runs, joined by receipts rather than by ambient access.
+
+| Run | Repository | Units | Releases on completion | Consumed by |
+|---|---|---|---|---|
+| Run A | `infiquetra-agent-plugins` | U1, U2, U3, U4, U5 | Portable profile contract receipt, naming the schema version and the contract digest | Run B, at U7 |
+| Run B | `infiquetra-claude-plugins` | U6, U7, U9 | Corrected-revision receipt, naming the released version and its commit | Run C, at U10 |
+| Run C | `home-lab` | U8 | Deployed-profile receipt, naming the runtime path and the deployed digest | Run B, at U9 |
+| Run A resumes | `infiquetra-agent-plugins` | U10, U11, U12 | Pilot assessment, ending at the operator pause | The operator |
+
+Run A pauses after U5 and waits. Run B pauses before U9's activation until Run C's deployed-profile receipt exists, which is how the no-capability-gap rule survives being split across repositories. Run A resumes at U10 only once Run B's corrected-revision receipt names a released version.
+
+The controller stops at every authority boundary rather than crossing it. Runs B and C are not authorized by the session that produced this plan.
+
+### Path classification in the portable tree
+
+Every path is one of three kinds, and the provenance manifest records which.
+
+| Kind | Meaning | Examples | Synchronization behavior |
+|---|---|---|---|
+| Upstream byte copy | Identical to its source at the pinned commit | both clients, both skill files, both reference documents, README, CHANGELOG | Overwritten from source; digest must match exactly |
+| Deterministic transform | Derived from a source file by a versioned, repeatable rule | the Claude manifest relocated under the client extension directory | Regenerated; records source digest, output digest, and transform version |
+| Target-owned portable source | No upstream counterpart; authored here | the profile library, schema, and reference; discovery and drift; the build declaration; the generated bundle | Never overwritten and never removed by synchronization |
+
+The skill frontmatter is deliberately **not** a transform. The disallowed `triggers` and `script` fields are corrected upstream in U6, so the portable skill files remain byte copies. This is what keeps the repair-upstream-first decision and the no-divergence rule consistent with each other.
+
+### Public evidence schema
+
+Evidence proves a comparison happened without republishing what was compared.
+
+A public evidence record carries the field names compared, the count of fields compared, the pass or fail result per field, a digest of the private input and a digest of the result, and the command with its site-identifying arguments redacted. It never carries a raw controller response, a raw topology, an address, a hostname, a hardware address, or a camera name.
+
+The private receipt holding the actual compared values stays outside this repository and is referenced only by its digest. A test validates the public artifact against inert example values, so the schema is enforced rather than remembered.
 
 Three things need shape that prose alone does not carry: which file belongs to which custody, what the portable package looks like when assembled, and why the unit order has one constraint that cannot be reordered.
 
@@ -240,19 +337,25 @@ Establish Fleet Core as a portable source carrying exactly one module, and name 
 
 **Goal:** Create `plugins/fleet-core/` as a conformant Agent Plugins 1.0 package containing `retry_backoff` and its tests, with an explicit inventory of the sixteen modules deliberately left unported.
 
-**Requirements:** R16, R17, R21.
+**Requirements:** R16, R17, R21, R32, R33.
 
 **Dependencies:** U1.
 
-**Files:** `plugins/fleet-core/plugin.json`, `plugins/fleet-core/DEFERRED.md`, `plugins/fleet-core/README.md`, `plugins/fleet-core/scripts/fleet_commons/retry_backoff.py`, `tests/test_retry_backoff.py`.
+**Files:** `plugins/fleet-core/plugin.json`, `plugins/fleet-core/PROVENANCE.json`, `plugins/fleet-core/CHANGELOG.md`, `plugins/fleet-core/DEFERRED.md`, `plugins/fleet-core/README.md`, `plugins/fleet-core/scripts/fleet_commons/retry_backoff.py`, `tests/test_retry_backoff.py`, `scripts/generate_deferred_inventory.py`, `tests/test_generate_deferred_inventory.py`.
 
-**Approach:** The slice is genuinely self-contained, so this is a copy plus a manifest rather than a refactor: `retry_backoff.py` imports only `random`, `time`, `collections.abc.Callable`, and `typing.Any`, and its single textual mention of the wider package is prose in a docstring. Port its 220-line, 10-test pytest suite alongside it. Write `DEFERRED.md` naming all sixteen unported modules with their line counts, so no reader can mistake a 177-line slice for the 5,548-line whole.
+**Approach:** The slice is genuinely self-contained, so this is a copy plus a manifest rather than a refactor: `retry_backoff.py` imports only `random`, `time`, `collections.abc.Callable`, and `typing.Any`, and its single textual mention of the wider package is prose in a docstring. Port its 220-line, 10-test pytest suite alongside it.
+
+Custody does not move. The ported module is an upstream byte copy under the same synchronization rule as UniFi, its provenance manifest pins Fleet Core 0.25.0 and the source commit, and its portable version derives from that upstream version rather than starting a parallel numbering. A future retry fix lands upstream first and arrives here by re-synchronization, which is what stops the module acquiring two writable sources.
+
+`DEFERRED.md` is generated from the pinned source tree rather than typed, because a handwritten count is exactly what drifts. The counting basis is stated in the file: every path under the upstream `fleet_commons` package plus the shim module beside it, split into Python modules and data files, minus what this slice ports.
+
+**Fleet Core release surface:** the portable manifest, the provenance manifest, the changelog, the ported module, and the ported test. Nothing outside that list is part of a Fleet Core release.
 
 **Patterns to follow:** the upstream module and test at `plugins/fleet-core/scripts/fleet_commons/retry_backoff.py` and `tests/test_retry_backoff.py` in the Claude repository.
 
-**Test scenarios:** All ten upstream tests pass unchanged against the ported module. A retryable failure followed by success returns the success value. A non-retryable failure propagates immediately without a second attempt. The attempt cap is honored exactly. Computed jitter stays within its documented bounds. A server-supplied retry hint overrides the computed backoff, and an excessive hint is clamped to the maximum delay. The manifest validates against the published Agent Plugins 1.0 schema.
+**Test scenarios:** All ten upstream tests pass unchanged against the ported module. A retryable failure followed by success returns the success value. A non-retryable failure propagates immediately without a second attempt. The attempt cap is honored exactly. Computed jitter stays within its documented bounds. A server-supplied retry hint overrides the computed backoff, and an excessive hint is clamped to the maximum delay. The manifest validates against the published Agent Plugins 1.0 schema. The generated inventory names every upstream item absent from this package, verified by set difference against the pinned tree rather than against a literal number, so adding a module upstream fails the check until the inventory is regenerated. The ported module's digest equals its upstream source digest, proving it is a byte copy and not an edited one.
 
-**Verification:** `plugins/fleet-core/plugin.json` passes the repository validator, the ported test suite passes, and `DEFERRED.md` names every module present upstream but absent here.
+**Verification:** `plugins/fleet-core/plugin.json` passes the repository validator, the ported test suite passes, the generated inventory matches a fresh derivation from the pinned source tree, and the provenance manifest names Fleet Core 0.25.0 and the pinned commit.
 
 ### U3. Build-time bundling, provenance stamping, and staleness rejection
 
@@ -260,19 +363,25 @@ Make the UniFi artifact complete at build time so no user ever installs Fleet Co
 
 **Goal:** A build step that copies the required Fleet Core module into the consuming plugin as a generated, read-only, stamped artifact, and a validation path that rejects a stale or hand-edited bundle.
 
-**Requirements:** R18, R19, R20, R21.
+**Requirements:** R18, R19, R20, R21, R34, R35.
 
 **Dependencies:** U2.
 
-**Files:** `scripts/bundle_fleet_module.py`, `tests/test_bundle_fleet_module.py`, `scripts/check_repo.py`.
+**Files:** `scripts/bundle_fleet_module.py`, `tests/test_bundle_fleet_module.py`, `scripts/check_repo.py`, `plugins/unifi/fleet-bundle.json`, `schemas/fleet-bundle.schema.json`, `tests/test_fleet_bundle_schema.py`.
 
-**Approach:** The bundler reads a declared module list from the consuming plugin, copies each named module from `plugins/fleet-core/`, and writes it under the consumer's `scripts/_bundled/` with a header stamping the Fleet Core version, the module's content digest, and its provenance. The stamp is what makes staleness detectable, so it is the load-bearing output rather than the copy itself. Bundling only the declared subset is what lets a later plugin port reuse this model unchanged.
+**Approach:** The declaration lives in its own file, `fleet-bundle.json` at the consuming plugin's root, governed by a closed schema. It cannot live in the Agent Plugins manifest, whose schema is closed and which forbids assigning semantics to unrecognized top-level fields, and inventing a dependency field there is prohibited outright.
+
+The bundler reads that declaration, copies each named module from `plugins/fleet-core/`, and writes it under the consumer's `scripts/_bundled/` with a stamp block carrying the Fleet Core version, the source-payload digest, and the source commit. The version comes from the portable Fleet Core provenance manifest, so there is one version source rather than a second hand-maintained one.
+
+Two digest domains exist because a stamp cannot hash the bytes that contain it. The source-payload digest covers the upstream module's bytes and answers "is this bundle stale?". The generated-output digest covers the generated file with its stamp block excluded and answers "has this bundle been hand-edited?". They fail as separate signals.
+
+Two commands: a generate mode that writes, and a check mode that writes nothing and exits non-zero on either failure, which is what continuous integration runs.
 
 **Patterns to follow:** the provenance-manifest shape introduced in U1, so bundle stamps and sync manifests use one digest convention rather than two.
 
-**Test scenarios:** Bundling a declared module produces a file whose stamped digest matches its content. Re-running the bundler with no upstream change is idempotent and rewrites nothing. Changing the Fleet Core source and not re-bundling causes validation to report a stale bundle naming the module. Hand-editing a bundled file causes validation to report a digest mismatch. Declaring a module that does not exist in the portable Fleet Core fails loudly rather than producing an empty bundle. A consumer declaring two modules receives exactly those two and no others.
+**Test scenarios:** Bundling a declared module produces a file whose generated-output digest matches its content with the stamp block excluded. Re-running in generate mode with no upstream change is idempotent and rewrites nothing. Changing the Fleet Core source without re-bundling makes check mode report a **stale source**, naming the module, and not a tampering error. Hand-editing a bundled file's body makes check mode report **tampering**, and not a staleness error — the two defects are distinguishable, which is the point of two domains. A declaration naming a module absent from the portable Fleet Core fails loudly rather than producing an empty bundle. A declaration violating the closed schema is rejected naming the offending field. A consumer declaring two modules receives exactly those two and no others. Check mode writes nothing, asserted by comparing the tree before and after.
 
-**Verification:** a fresh clone plus `python3 scripts/bundle_fleet_module.py` followed by `python3 scripts/check_repo.py` passes, and each seeded staleness or edit defect fails.
+**Verification:** a fresh clone plus generate mode followed by `python3 scripts/check_repo.py` passes; a seeded stale source and a seeded hand edit each fail with their own distinct signal.
 
 ### U4. Portable site-profile contract
 
@@ -280,17 +389,25 @@ Define what an operator site profile is, how it is found, and what the plugin ma
 
 **Goal:** A secret-free profile schema, a three-path first-setup contract, a remembered configured path with an environment-variable override, and a hard no-inference rule when no profile is present.
 
-**Requirements:** R10, R11, R12, R13, R14, R15.
+**Requirements:** R10, R11, R12, R13, R14, R15, R36, R37.
 
 **Dependencies:** U1.
 
-**Files:** `plugins/unifi/skills/unifi-network/references/site-profile.md`, `plugins/unifi/schemas/site-profile.schema.json`, `plugins/unifi/scripts/site_profile.py`, `tests/test_site_profile.py`.
+**Files:** `plugins/unifi/skills/unifi-network/references/site-profile.md`, `plugins/unifi/schemas/site-profile.schema.json`, `plugins/unifi/scripts/site_profile.py`, `plugins/unifi/scripts/site_profile_setup.py`, `tests/test_site_profile.py`, `tests/test_site_profile_setup.py`.
 
-**Approach:** The profile carries intended meaning the controller cannot report — trust roles, critical hosts, ownership, expected policies, operational constraints — and nothing else; credentials are excluded by schema, not by convention. Resolution order is the `UNIFI_SITE_PROFILE` environment variable, then the remembered configured path, then no profile at all, which is a valid and fully supported state rather than an error. The no-inference rule is enforced in code rather than described in prose: with no profile loaded, any request for a trust role, criticality, ownership, or intended policy returns an explicit unknown that callers must render as unknown.
+**Approach:** The profile carries intended meaning the controller cannot report — trust roles, critical hosts, ownership, expected policies, operational constraints — and nothing else; credentials are excluded by schema, not by convention.
+
+The format is JSON, parsed with the standard library, so a host with no third-party parser can still read a profile. That keeps the optional-profile promise true on a minimal runtime; an operator may author in a friendlier format and render JSON at deployment.
+
+Resolution order is the `UNIFI_SITE_PROFILE` environment variable, then the remembered configured path, then no profile at all, which is a valid and fully supported state rather than an error. The configured path is stored in a portable configuration file at `${XDG_CONFIG_HOME:-~/.config}/infiquetra/unifi/config.json`, and the deployed runtime profile default is `${XDG_CONFIG_HOME:-~/.config}/infiquetra/unifi/site-profile.json`.
+
+The setup entrypoint is a named module, not an implied behavior: `site_profile_setup.py` presents exactly the three paths and writes the operator's choice to the configuration file so it is not asked again. A contract nothing presents is not reachable by a user.
+
+The no-inference rule is enforced in code rather than described in prose: with no profile loaded, any request for a trust role, criticality, ownership, or intended policy returns an explicit unknown that callers must render as unknown.
 
 **Patterns to follow:** the environment-variable-then-default resolution already used for `UNIFI_HOST` in both clients, so the profile's precedence chain reads the same way to anyone who knows the existing code.
 
-**Test scenarios:** With no profile anywhere, loading succeeds and reports discovery-only mode rather than raising. With no profile, a trust-role query returns an explicit unknown and never a default or a guess. `UNIFI_SITE_PROFILE` pointing at a valid file overrides a different remembered configured path. `UNIFI_SITE_PROFILE` pointing at a nonexistent path fails loudly and does not silently fall back to the configured path. A profile containing a credential-shaped field is rejected by schema validation naming the offending field. A profile whose schema version is unrecognized is rejected rather than partially applied. First setup with no profile offers exactly three paths, and a test asserts the count is three so a fourth cannot be added silently.
+**Test scenarios:** With no profile anywhere, loading succeeds and reports discovery-only mode rather than raising. With no profile, a trust-role query returns an explicit unknown and never a default or a guess. `UNIFI_SITE_PROFILE` pointing at a valid file overrides a different remembered configured path. `UNIFI_SITE_PROFILE` pointing at a nonexistent path fails loudly and does not silently fall back to the configured path. A profile containing a credential-shaped field is rejected by schema validation naming the offending field. A profile whose schema version is unrecognized is rejected rather than partially applied. Loading a profile requires no third-party import, asserted by running the loader with third-party modules blocked from the import path. Setup offers exactly three paths, asserted by count so a fourth cannot be added silently. Choosing a path writes the configuration file, and a second setup invocation reads it back rather than asking again. A configuration file naming a path that no longer exists reports that clearly rather than silently reverting to discovery-only.
 
 **Verification:** the schema rejects every seeded invalid profile, the three-path count is asserted by test, and a no-profile run reports unknowns rather than inferences.
 
@@ -300,17 +417,17 @@ Let the plugin learn actual controller state safely, and compare it to intended 
 
 **Goal:** A credential-safe, read-only discovery capability covering networks, VLANs, devices, clients, and cameras; a proposed-profile generator for operator review; and a drift report over the merged actual-plus-intended view.
 
-**Requirements:** R11, R13, R26, R27.
+**Requirements:** R11, R13, R26, R27, R39.
 
 **Dependencies:** U4.
 
 **Files:** `plugins/unifi/scripts/discover.py`, `plugins/unifi/scripts/drift.py`, `tests/test_discover.py`, `tests/test_drift.py`.
 
-**Approach:** Discovery composes only operations classified read-only and never passes `--confirm`, so the clients' own dry-run gate remains a second line of defence beneath the classification. Because neither client filters or redacts a controller response, persistence is default-deny: discovery output is held in memory and written only to an operator-named path outside any repository, never to a default location inside one. The proposed profile is a review artifact, not an applied one, and generating it never writes the live profile.
+**Approach:** Discovery composes only operations classified read-only and never passes `--confirm`, so the clients' own dry-run gate remains a second line of defence beneath the classification. Because neither client filters or redacts a controller response, persistence is default-deny: discovery output is held in memory and written only to an operator-named path outside any repository, never to a default location inside one. The proposed profile is a review artifact, not an applied one, and generating it never writes the live profile. It contains observed fields plus explicit unknown intent: discovery can report that a host exists, never that the host is critical, trusted, or owned by anyone. Prefilling an intent field from observation would be exactly the inference the no-inference rule forbids, so the generator emits unknown for every intent field and a test enforces it.
 
 **Patterns to follow:** the read-only rows of the operation classification recorded in this plan's sources, and the existing clients' JSON-on-stdout output discipline.
 
-**Test scenarios:** Discovery against a mocked controller invokes only read-only endpoints, asserted by recording every method and URL and failing on any non-GET. Discovery never passes `--confirm`, asserted on the invocation record. Discovery with no output path given writes no file anywhere. Discovery with an output path inside the repository working tree is refused. A proposed profile is generated without writing the configured profile path. Drift with no profile present reports discovery-only and asserts no drift findings, because there is no intended state to differ from. Drift with a profile reports a host present on the controller but absent from the profile, and a policy expected by the profile but absent on the controller. A camera snapshot is never invoked by discovery, since it returns imagery rather than topology.
+**Test scenarios:** Discovery against a mocked controller invokes only read-only endpoints, asserted by recording every method and URL and failing on any non-GET. Discovery never passes `--confirm`, asserted on the invocation record. Discovery with no output path given writes no file anywhere. Discovery with an output path inside the repository working tree is refused. A proposed profile is generated without writing the configured profile path. Every intent field of a generated proposal is unknown, asserted field by field across trust role, criticality, ownership, and intended policy, so no observation can leak into an intent value. Drift with no profile present reports discovery-only and asserts no drift findings, because there is no intended state to differ from. Drift with a profile reports a host present on the controller but absent from the profile, and a policy expected by the profile but absent on the controller. A camera snapshot is never invoked by discovery, since it returns imagery rather than topology.
 
 **Verification:** the method-and-URL recorder shows zero non-GET calls across the whole discovery path, and no test run leaves a file inside the working tree.
 
@@ -320,19 +437,25 @@ Correct the authoritative source's documentation so the port has something true 
 
 **Goal:** In `infiquetra-claude-plugins`, bring every documentation surface into agreement with the shipped code, and stop short of releasing.
 
-**Requirements:** R5, R6, R7.
+**Requirements:** R5, R6, R7, R29, R45.
 
-**Dependencies:** none. Runs in a different repository from U1 through U5 and shares no file with them.
+**Dependencies:** none. Runs in Orchestrate Run B, a different repository from U1 through U5, and shares no file with them.
 
-**Files:** in `infiquetra-claude-plugins`: `plugins/unifi/skills/unifi-protect/SKILL.md`, `plugins/unifi/skills/unifi-protect/references/protect-api-endpoints.md`, `plugins/unifi/skills/unifi-network/SKILL.md`, `plugins/unifi/skills/unifi-network/references/udm-api-endpoints.md`, `plugins/unifi/README.md`, `plugins/unifi/commands/unifi.md`, `plugins/unifi/CHANGELOG.md`, `plugins/unifi/.claude-plugin/plugin.json`.
+**Files:** in `infiquetra-claude-plugins`: `plugins/unifi/skills/unifi-protect/SKILL.md`, `plugins/unifi/skills/unifi-protect/references/protect-api-endpoints.md`, `plugins/unifi/skills/unifi-network/SKILL.md`, `plugins/unifi/skills/unifi-network/references/udm-api-endpoints.md`, `plugins/unifi/README.md`, `plugins/unifi/commands/unifi.md`, `plugins/unifi/CHANGELOG.md`, `plugins/unifi/.claude-plugin/plugin.json`, and the test file this unit owns, `tests/test_unifi_docs_match_code.py`.
 
 **Approach:** Remove every reference to the four Protect capabilities the code does not implement, across all six affected files including the plugin manifest's own description. Rewrite the Protect endpoint reference against the integration API the client actually calls rather than the older cookie-authenticated path it currently documents. Correct the network reference on each endpoint where it disagrees with the code, and document the network capabilities that exist but are unmentioned. Re-derive both reference documents from the source rather than editing them in place, because both have drifted far enough that patching risks preserving errors nobody checked.
 
+This unit also removes the two disallowed skill frontmatter fields, `triggers` and `script`, moving their content into each skill's body. Doing it here rather than during synchronization is what keeps the portable skill files byte copies instead of transforms, and it keeps the repair-upstream-first decision consistent with the no-divergence rule.
+
+This unit owns one new upstream test file. Without it the unit's own verification would be impossible inside its declared file boundary, which is the defect this correction closes.
+
 **Patterns to follow:** the shipped client source is the only trustworthy description of current behavior; neither existing reference document may be used as an input.
 
-**Test scenarios:** A test asserts that every command shown in the Protect skill exists in the Protect client's parser, and fails if any documented command is absent. The mirrored test asserts the same for the network skill. A test asserts that every endpoint path named in each reference document appears in its client's source. A test asserts the plugin manifest description names no capability absent from either client.
+**Test scenarios:** Every command shown in the Protect skill exists in the Protect client's parser, failing if any documented command is absent; the mirrored assertion covers the network skill. Every endpoint path named in each reference document appears in its client's source. The plugin manifest description names no capability absent from either client. The plugin README names no absent capability, in either the Protect or the network section. The slash command document names no absent capability. The agent definition names no absent capability. The changelog's entries describe no absent capability. Each of the twelve network resource groups and each of the six Protect resource groups appears in its skill, closing the under-documentation gap rather than only the over-documentation one. Neither skill's frontmatter carries a field outside the open specification's six permitted fields.
 
-**Verification:** the upstream test suite passes, the documentation-versus-code assertions above pass, and no release is cut.
+**Surface-to-assertion map:** every surface named by R5 through R7 is covered above — Protect skill, network skill, both references, plugin manifest, README, slash command, agent definition, and changelog. No surface is left to a review gate, so none can drift silently.
+
+**Verification:** the upstream test suite passes, all assertions above pass, and no release is cut.
 
 ### U7. Upstream topology relocation and default removal, authored and unreleased
 
@@ -340,13 +463,13 @@ Remove one operator's addressing from the source without destroying the knowledg
 
 **Goal:** In `infiquetra-claude-plugins`, remove the hard-coded controller default from both clients and relocate the agent's embedded lab topology into the site-profile form, preserving every fact.
 
-**Requirements:** R8, R9, R15.
+**Requirements:** R8, R9, R15, R38.
 
-**Dependencies:** U4, U6.
+**Dependencies:** U4, U6. Waits on Run A's portable profile contract receipt.
 
-**Files:** in `infiquetra-claude-plugins`: `plugins/unifi/skills/unifi-network/scripts/unifi_network_client.py`, `plugins/unifi/skills/unifi-protect/scripts/unifi_protect_client.py`, `plugins/unifi/agents/unifi-network-ops.md`, `plugins/unifi/CHANGELOG.md`, and the upstream client test suites.
+**Files:** in `infiquetra-claude-plugins`: `plugins/unifi/skills/unifi-network/scripts/unifi_network_client.py`, `plugins/unifi/skills/unifi-protect/scripts/unifi_protect_client.py`, `plugins/unifi/agents/unifi-network-ops.md`, `plugins/unifi/skills/unifi-network/scripts/site_profile_loader.py`, `plugins/unifi/CHANGELOG.md`, and the upstream client test suites including `tests/test_unifi_site_profile_loader.py`.
 
-**Approach:** Make the controller host required with no baked-in fallback, failing loudly the way the missing-API-key check already does, rather than substituting a different address that would merely move the problem. Relocate the agent's topology section into the profile shape defined in U4 and have the agent read site context from the resolved profile instead of from its own text. Depends on U4 because there must be a defined place to relocate into before anything is relocated; depends on U6 because both units edit the changelog and the agent definition, and merging beats sequencing on a shared file.
+**Approach:** Make the controller host required with no baked-in fallback, failing loudly the way the missing-API-key check already does, rather than substituting a different address that would merely move the problem. Relocate the agent's topology section into the profile shape defined in U4 and have the agent read site context from the resolved profile instead of from its own text. The Claude repository gets its own loader implementing the U4 contract, because the portable loader lives only in the target repository and the upstream agent cannot depend on a file that is not there. The loader is small and reads the same JSON contract, pinned to the schema version named in Run A's receipt. Depends on U4 because there must be a defined place to relocate into before anything is relocated; depends on U6 because both units edit the changelog and the agent definition, and merging beats sequencing on a shared file.
 
 **Patterns to follow:** the existing missing-API-key failure at the top of both constructors, which prints a structured error and exits before any network call.
 
@@ -380,19 +503,27 @@ Prove the replacement context path works before switching anything on.
 
 **Goal:** Demonstrate that the Claude agent reads usable site context from the deployed profile, and only then activate the repaired upstream release.
 
-**Requirements:** R9, R3.
+**Requirements:** R9, R3, R40, R41, R42, R44.
 
-**Dependencies:** U7, U8.
+**Dependencies:** U7, U8. Waits on Run C's deployed-profile receipt.
 
-**Files:** in `infiquetra-claude-plugins`: release artifacts and `plugins/unifi/CHANGELOG.md`; in this repository: `docs/evidence/2026-08-21-unifi-transition-evidence.md`.
+**Files:** in `infiquetra-claude-plugins`, the three release surfaces the upstream tri-lock parity gate requires to agree — `plugins/unifi/.claude-plugin/plugin.json`, that plugin's entry in the root `.claude-plugin/marketplace.json`, and `plugins/unifi/CHANGELOG.md`; in this repository: `docs/evidence/2026-08-22-unifi-transition-evidence.md` and `schemas/public-evidence.schema.json`, with `tests/test_public_evidence_schema.py`.
 
-**Approach:** This unit exists solely to honor the no-capability-gap rule, so its evidence is the deliverable and the release is merely what the evidence unlocks. Capture, before activation, that the agent resolves the profile, reports the same site facts it previously carried inline, and degrades to explicit unknowns when the profile is absent. Activation is a deliberate, separate step after that evidence is recorded, and it is the point at which the corrected revision becomes available to pin.
+**Approach:** This unit exists solely to honor the no-capability-gap rule, so its evidence is the deliverable and the release is merely what the evidence unlocks.
+
+The upstream repository enforces a tri-lock: the plugin manifest version, the marketplace entry version, and the changelog's top dated heading must be equal, and the marketplace file is generated from the plugin manifest rather than hand-edited. Naming only "release artifacts" would leave an implementer to discover that gate by failing it, so all three surfaces are named and the version bump is one coordinated change.
+
+Evidence is captured in two stages. Before activation, the agent is loaded from a staged path rather than from the installed release, proving the replacement context path works against the corrected bytes. After activation, an installed-version and digest readback confirms the client is actually running those bytes, and a fresh client session re-proves all three profile states. Source-tree evidence alone cannot establish this, because a running client can hold a cached earlier version.
+
+The public evidence artifact follows the public evidence schema: compared field names, comparison counts, per-field pass or fail, digests of the private input and of the result, and commands with site-identifying arguments redacted. The private receipt carrying actual values stays outside this repository and is referenced only by digest.
 
 **Patterns to follow:** the repository's own rule that a component being deployed is not the same as a behavior being verified end to end.
 
-**Test scenarios:** With the profile deployed, the agent reports site context equivalent to what it previously embedded, compared fact by fact. With the profile absent, the agent reports explicit unknowns and makes no inference, confirming the U4 rule holds through the agent rather than only in the library. With the profile present but unreadable, the failure is loud rather than a silent fallback to no-profile mode.
+**Test scenarios:** Pre-activation, loaded from the staged path: with the profile deployed the agent reports site context equivalent to what it previously embedded, compared fact by fact; with the profile absent it reports explicit unknowns and makes no inference; with the profile present but unreadable it fails loudly rather than silently falling back to no-profile mode. Post-activation, in a **fresh** client session: the installed version and digest match the released bytes, and all three profile states re-prove. The tri-lock parity gate passes, with plugin manifest, marketplace entry, and changelog versions equal. The generated marketplace file matches its generator's output. The public evidence artifact validates against the public evidence schema. The public artifact contains no address, hostname, hardware address, or camera name, asserted by pattern search against inert example values.
 
-**Verification:** the evidence document records all three outcomes with their commands and results, and the release is activated only after it is written. The corrected revision's commit identifier is captured for U10 to pin.
+**Rollback:** the trigger is any post-activation fresh-session failure of the three profile states, or a tri-lock or readback mismatch. The action is releasing the prior version by the same coordinated three-surface bump, refreshing the marketplace, and repeating the fresh-session proof against the restored version. A rollback that is not re-proved has not been verified.
+
+**Verification:** the evidence document records the pre-activation and post-activation outcomes under the public schema, the release is activated only after the pre-activation evidence is written, the fresh-session readback passes, and the corrected revision's commit identifier is captured as Run B's receipt for U10 to pin.
 
 ### U10. Synchronize from the corrected revision
 
@@ -400,17 +531,23 @@ Produce the portable package as a derived artifact whose provenance a machine ca
 
 **Goal:** A synchronization script, a provenance manifest pinned to the corrected upstream revision, the assembled portable tree, and the Claude client extension directory.
 
-**Requirements:** R1, R2, R3, R4, R28, R29, R18.
+**Requirements:** R1, R2, R3, R4, R28, R29, R18, R31.
 
-**Dependencies:** U3, U5, U9.
+**Dependencies:** U3, U5, U9. Resumes Run A once Run B's corrected-revision receipt exists.
 
 **Files:** `scripts/sync_vendor_source.py`, `tests/test_sync_vendor_source.py`, `plugins/unifi/plugin.json`, `plugins/unifi/PROVENANCE.json`, `plugins/unifi/skills/**`, `plugins/unifi/com.infiquetra.claude/**`, `plugins/unifi/README.md`, `plugins/unifi/CHANGELOG.md`.
 
-**Approach:** The script takes a local Claude checkout and an explicit commit, copies the files assigned portable custody, places the Claude-custody files under the `com.infiquetra.claude/` client extension directory that the specification's section 8.2 defines, and writes the provenance manifest. Both `fleet_commons_shim.py` copies are dropped rather than copied, because the build-time bundle from U3 replaces them and retaining Claude-specific discovery is prohibited. The portable skill frontmatter is reduced to the six permitted fields, moving the current `triggers` and `script` values into the skill body where they inform without violating the schema.
+**Approach:** The script takes a local Claude checkout and an explicit commit, copies the files assigned portable custody, places the Claude-custody files under the `com.infiquetra.claude/` client extension directory that the specification's section 8.2 defines, and writes the provenance manifest with each path's classification.
+
+Synchronization is classification-aware. Byte copies are overwritten and must match their source digest exactly. The one transform, the relocated Claude manifest, records source digest, output digest, and transform version. Target-owned paths — the profile library, its schema and setup entrypoint, discovery and drift, the build declaration, and the generated bundle — are never overwritten and never removed, which is what stops a synchronizer from silently deleting the U4 and U5 work.
+
+The skill frontmatter needs no downstream edit, because U6 corrected it upstream. That is deliberate: it keeps the skill files byte copies and leaves the no-divergence rule intact.
+
+Both `fleet_commons_shim.py` copies are dropped rather than copied, because the build-time bundle from U3 replaces them and retaining Claude-specific discovery is prohibited.
 
 **Patterns to follow:** the digest conventions established in U1 and U3, so provenance manifests and bundle stamps remain one mechanism rather than two.
 
-**Test scenarios:** Synchronizing from a fixture checkout produces a tree whose every file digest matches the written manifest. Re-running against the same commit is idempotent and changes nothing. Synchronizing from a dirty checkout is refused, because provenance pinned to a commit that does not describe the bytes is worse than no provenance. Neither `fleet_commons_shim.py` appears anywhere in the output. The portable manifest carries the exact canonical schema identifier and a specification-conformant name. Each portable skill's frontmatter carries only permitted fields, and each skill's name matches its directory. The Claude manifest lands under the client extension directory and not at the plugin root, where it would collide with the portable manifest. A ported client's command surface equals the upstream client's, compared parser-to-parser rather than by reading documentation.
+**Test scenarios:** Synchronizing from a fixture checkout produces a tree whose every file digest matches the written manifest, and every path carries exactly one classification. Re-running against the same commit is idempotent and changes nothing. Synchronizing from a dirty checkout is refused, because provenance pinned to a commit that does not describe the bytes is worse than no provenance. Target-owned files created before synchronization still exist, unmodified, afterwards — the regression that would silently destroy the U4 and U5 work. A byte-copy path whose content differs from its source fails rather than being recorded as a transform. Neither `fleet_commons_shim.py` appears anywhere in the output. The portable manifest carries the exact canonical schema identifier and a specification-conformant name. Each portable skill's frontmatter carries only permitted fields, and each skill's name matches its directory. The Claude manifest lands under the client extension directory and not at the plugin root, where it would collide with the portable manifest. A ported client's command surface equals the upstream client's, compared parser-to-parser rather than by reading documentation.
 
 **Verification:** `python3 scripts/check_repo.py` and the full test suite pass on the assembled tree, and the parser-to-parser comparison reports zero differences across all 52 network and 21 Protect actions.
 
@@ -420,19 +557,25 @@ Assess every installed client the same way, and record what is true rather than 
 
 **Goal:** A completed matrix covering Claude Code, OpenAI Codex, Cursor Agent, Qwen, Grok, OpenCode, Gemini CLI, Muse, Agy, and Hermes, each recorded under one of four statuses with concrete evidence.
 
-**Requirements:** R22, R23, R24, R26, R27.
+**Requirements:** R22, R23, R24, R26, R27, R43, R44.
 
 **Dependencies:** U10.
 
-**Files:** `docs/evidence/2026-08-21-unifi-compatibility-matrix.md`.
+**Files:** `docs/evidence/2026-08-22-unifi-compatibility-matrix.md`, `schemas/compatibility-matrix.schema.json`, `scripts/check_compatibility_matrix.py`, `tests/test_check_compatibility_matrix.py`.
 
-**Approach:** Every client receives the identical bounded assessment: package installation or supported placement, discovery, loading, and the safest meaningful credential-free or read-only invocation. Status is one of works directly, works through an adapter, unsupported, or failed, and each carries the command run, the observed output, and the concrete reason. Coverage is mandatory and passing is not, so a client that cannot load the package is recorded and the assessment continues rather than halting.
+**Approach:** Every client receives the identical bounded assessment across four named stages: placement, discovery, load, and invocation. Each stage is recorded independently as executed, blocked, or not applicable, with its command and evidence, and only then does the client receive exactly one overall status of works directly, works through an adapter, unsupported, or failed.
+
+Recording per stage is what makes coverage real. A row that stops at the first failure and reports one status can otherwise be counted as covered while proving nothing about whether the package ever loaded, which is precisely the assessment the pilot exists to produce.
+
+Coverage is mandatory and passing is not. A client that cannot load the package is recorded as unsupported or failed with its reason, and the assessment continues to the next client rather than halting. No remediation begins here.
+
+Evidence follows the public evidence schema, so a recorded command carries no site-identifying argument and no raw controller response reaches this public repository.
 
 **Patterns to follow:** the shared `~/.agents/skills` path already present on this machine with eight skills and a lock file, which is the known-working mechanism for clients that discover loose skills.
 
-**Test scenarios:** Not a feature-bearing unit in the usual sense; its output is evidence rather than behavior. The assessment itself is constrained by test: a recorded invocation that includes `--confirm` fails the evidence check, and a recorded invocation of any operation classified mutating fails it. Every one of the ten clients has exactly one status recorded, asserted by count, so a silently skipped client cannot pass as covered. Every non-working status carries a non-empty reason.
+**Test scenarios:** The matrix validator enforces what prose cannot. A recorded invocation that includes `--confirm` fails the check, and a recorded invocation of any operation classified mutating fails it. All ten named clients are present, asserted by set equality against the client list rather than by count, so a substituted or renamed client cannot pass as covered. Every client carries all four stage results, and a row missing a stage fails even when it carries an overall status — the defect this correction closes. Every stage result is one of executed, blocked, or not applicable, and every non-executed stage carries a reason. Every executed stage carries a command and its evidence. Every client carries exactly one overall status drawn from the four permitted values. Unsupported and failed are accepted outcomes and never fail the check, preserving coverage-not-a-gate. The record validates against the public evidence schema, and a seeded address, hostname, or hardware address in any evidence field fails.
 
-**Verification:** ten rows, four permitted statuses, every row carrying evidence, and zero mutating or confirmed invocations anywhere in the record.
+**Verification:** ten clients, forty stage results, ten overall statuses, zero mutating or confirmed invocations, and a clean pass against both the matrix schema and the public evidence schema.
 
 ### U12. Documentation, journal, and the operator pause
 
@@ -456,14 +599,14 @@ Record what was decided and learned, then stop deliberately rather than drifting
 
 ## Ownership and repository map
 
-Four repositories are touched. Ownership matters because two of them are not this one, and this session has no authority over either.
+Three repositories are touched. Ownership matters because two of them are not this one, and this session has no authority over either.
 
 | Units | Repository | Visibility | Owner | Authority status |
 |---|---|---|---|---|
 | U1, U2, U3, U4, U5, U10, U11, U12 | `infiquetra-agent-plugins` | Public | Jeff Cox | This plan's target; changes proposed by pull request |
 | U6, U7, U9 | `infiquetra-claude-plugins` | Public | Jeff Cox | Authoritative source; not authorized by this session |
 | U8 | `home-lab` | Private | Jeff Cox | Custody home; not authorized by this session |
-| U9 evidence, U11 matrix | `infiquetra-agent-plugins` | Public | Jeff Cox | Evidence artifacts, site-identifying content excluded |
+| U9 evidence, U11 matrix | `infiquetra-agent-plugins` (the same repository as the first row) | Public | Jeff Cox | Evidence artifacts, produced under the public evidence schema |
 
 ## Validation and continuous integration
 
@@ -481,9 +624,9 @@ Every unit is reversible, and the two irreversible-feeling ones are not actually
 
 Units in this repository roll back by reverting the pull request; nothing is published, and no consumer depends on this repository yet. The portable package's existence changes nothing for any current user until a client is pointed at it.
 
-The upstream repair rolls back by reverting its own pull request in the Claude repository before release activation. After activation, rollback means releasing the prior version, which is why U9 gates activation on evidence rather than on completion.
+The upstream repair rolls back by reverting its own pull request in the Claude repository before release activation. After activation, rollback is a defined procedure rather than an intention: the trigger is any post-activation fresh-session failure of the three profile states, or a tri-lock or readback mismatch; the action is releasing the prior version through the same coordinated bump of plugin manifest, marketplace entry, and changelog; and the marketplace is refreshed and the fresh-session proof repeated against the restored version. A rollback that has not been re-proved has not been verified.
 
-The one change with a real blast radius is U7's removal of the controller default, because it changes behavior for anyone relying on the fallback. Its rollback is the same release-the-prior-version path, and its risk is bounded by U9 proving the replacement context path first.
+The one change with a real blast radius is U7's removal of the controller default, because it changes behavior for anyone relying on the fallback. Its rollback is that same procedure, and its risk is bounded by U9 proving the replacement context path before activation rather than after.
 
 The site profile in `home-lab` rolls back by reverting that repository and re-running the deployment, which is idempotent.
 
@@ -493,7 +636,7 @@ The site profile in `home-lab` rolls back by reverting that repository and re-ru
 
 Custody does not move. The Claude repository remains authoritative for `unifi` throughout this pilot, and nothing here transfers that authority.
 
-Full Fleet Core parity is not attempted or claimed. Sixteen modules totaling roughly 4,500 lines remain unported by design, and `DEFERRED.md` names each one.
+Full Fleet Core parity is not attempted or claimed. The deferred inventory is derived from the pinned source tree rather than from a handwritten number, and `DEFERRED.md` names every item.
 
 Remediating a failing client is not in scope. The matrix records status; it does not fix anything, and implementation scope is never automatically expanded to make a client pass.
 
@@ -527,17 +670,19 @@ Each risk carries the mitigation actually planned for it, not a general reassura
 
 ## Open Questions
 
-Two remain, and both are genuinely operator-owned rather than deferred out of laziness.
-
-The execution backend and routing destination for this plan are not yet chosen. Saga Plan asks these at its final phase, and they are recorded in the plan's frontmatter and saga tick once answered.
+One remains, and it is genuinely deferred rather than undecided.
 
 Whether the portable package should eventually generate the Claude marketplace entry, rather than that entry continuing to be maintained upstream by hand, is out of scope here but becomes answerable once this pilot proves the generation path.
+
+Execution ownership and routing are settled, not open. See [Execution ownership](#execution-ownership).
 
 ## Stop Conditions
 
 The pilot stops, and asks, at each of these. None of them is a failure; each is a point where continuing without a decision would exceed granted authority.
 
-Stop before any change to `infiquetra-claude-plugins`. Units U6, U7, and U9 are defined here but not authorized by this session.
+Stop before any change to `infiquetra-claude-plugins`. Units U6, U7, and U9 are defined here but not authorized by this session, and they belong to Orchestrate Run B rather than to the target-repository run.
+
+Stop when a cross-repository receipt is missing. Run B waits for Run A's portable profile contract receipt; Run B's activation waits for Run C's deployed-profile receipt; Run A resumes at U10 only on Run B's corrected-revision receipt. A missing receipt is a stop, never an invitation to reach into another repository.
 
 Stop before any change to `home-lab`. Unit U8 is defined here but not authorized.
 

--- a/docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md
+++ b/docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md
@@ -1,0 +1,566 @@
+---
+title: UniFi and portable Fleet Core portability pilot
+type: feat
+status: active
+date: 2026-08-21
+origin: docs/cross-vendor-plugin-architecture-brief.md
+backend: inline
+---
+
+# UniFi and portable Fleet Core portability pilot
+
+## Summary
+
+Port the Claude Code `unifi` plugin into a portable Agent Plugins 1.0 package in this repository, together with a new portable Fleet Core source carrying only the `retry_backoff` module the UniFi clients require. The Claude repository stays authoritative throughout: it is repaired first, released second, and synchronized from third. The pilot ends with a ten-client compatibility matrix and a deliberate operator pause, not with an automatic remediation sweep.
+
+## Problem Frame
+
+Infiquetra maintains overlapping plugin behavior across ten installed coding-agent clients, and the architecture brief proposes authoring vendor-neutral behavior once while keeping genuinely host-specific features in explicit adapters. That proposal has never been tested against a real plugin, so the repository's queued P1 item asks for a first pilot with a chosen plugin, a required client matrix, a source-custody rule, and semantic parity evidence.
+
+The `unifi` plugin was chosen because it is small enough to finish and real enough to matter: two skills with bundled Python clients that must become portable core, plus a slash command and an agent definition that must become explicit Claude adapters. Investigation then found three things the file listing alone could not show, and each of them changes the work.
+
+The plugin is not self-contained. Both clients reach into a second plugin at import time, through discovery paths that only exist under Claude Code. Its documentation describes four Protect capabilities the code removed five months ago, and both API reference documents disagree with the shipped code. And the clients hard-code one operator's controller address as a universal default, which cannot ship in a public portable package.
+
+## Requirements
+
+The reviewer's and the implementer's checklist. Requirements are grouped by concern; identifiers run continuously across groups and are never renumbered.
+
+### Source custody and synchronization
+
+R1. The portable copy is a derived artifact and never a second writable source. A committed synchronization script copies from a named `infiquetra-claude-plugins` commit and writes a provenance manifest recording source repository, source commit, and per-file SHA-256 digest.
+
+R2. Repository validation verifies the portable tree against its own provenance manifest with no network call, so continuous integration stays hermetic.
+
+R3. The authoritative Claude source repair is authored, verified, and released before any synchronization unit runs. The pinned source commit in the provenance manifest is the corrected revision, never 995a475.
+
+R4. No portable file diverges from its authoritative source by intent. Where the portable tree must differ, the difference is produced by the upstream repair first, not by editing the copy.
+
+### Upstream repair, authored and released before the port
+
+R5. The Protect skill's documentation, the plugin README, the slash command, the changelog, the agent definition, and the Protect API reference are corrected to describe only the six resources the client implements: cameras, liveviews, lights, sensors, chimes, and viewers.
+
+R6. The network API reference is corrected on every endpoint path where it disagrees with the shipped code: traffic routes, static DNS, DHCP leases, alarms, backup, VPN, and the device-locate command body.
+
+R7. The network skill documents its implemented but undocumented capabilities: the `wlans` and `vpn` resource groups, the `devices adopt` and `devices forget` actions, the `backup` group, and the `stats dpi` action.
+
+R8. The hard-coded controller address is removed as a default from both clients. The embedded lab topology is relocated into the operator site profile, never deleted.
+
+R9. The repaired upstream release is not activated until the replacement context path is verified end to end. The existing Claude agent never temporarily loses usable site context.
+
+### Portable site profile
+
+R10. The site profile is optional. The portable plugin is fully usable with no profile present, and no arrangement in it is treated as a universal assumption.
+
+R11. On first setup with no configured profile available, exactly three safe paths are offered: supply an existing profile path; run credential-safe read-only discovery and generate a proposed profile for operator review; or continue in discovery-only mode with explicit limits on unknown operator intent.
+
+R12. The chosen profile path is remembered through normal client configuration so it is not requested on every use. The `UNIFI_SITE_PROFILE` environment variable overrides the configured path.
+
+R13. Without a profile, the plugin and the agent report actual controller state and never infer trust roles, criticality, ownership, or intended policy. Absent intent is reported as absent.
+
+R14. Credentials never live in the profile. Raw discovered inventory and sensitive identifiers are never committed to this public repository.
+
+R15. The portable contract and the Infiquetra custody instance stay separable. This repository's normative documentation never presents the private home-lab plus Ansible arrangement as required.
+
+### Portable Fleet Core
+
+R16. Fleet Core becomes a first-class portable source and package with its own tests, releases, versioning, provenance, and compatibility contract.
+
+R17. Only the `retry_backoff` module and its applicable tests are ported. Every remaining Fleet Core module is inventoried as explicitly unported and deferred, and no document claims full Fleet Core parity.
+
+R18. Generated installable UniFi artifacts bundle the required Fleet Core module at build time. Users never separately install Fleet Core.
+
+R19. The bundled copy is generated and read-only, stamped with the Fleet Core version, content digest, and provenance. Continuous integration rejects a stale bundle or any manual edit to one.
+
+R20. No Agent Plugins dependency field is invented, `FLEET_COMMONS_ROOT` is not required, and no Claude-specific runtime discovery is retained in the portable package.
+
+R21. A later plugin port can add another Fleet Core module to the same authoritative portable source and bundle only the subset it needs, without changing this packaging model.
+
+### Compatibility coverage
+
+R22. All ten installed clients receive the same bounded smoke assessment: package installation or supported placement, discovery, loading, and the safest meaningful credential-free or read-only invocation.
+
+R23. Each client is recorded as exactly one of: works directly; works through an adapter; unsupported; or failed. Every record carries a concrete reason and its evidence.
+
+R24. Coverage is mandatory; passing is not. No single unsupported or failing client blocks completion of the pilot assessment.
+
+R25. The pilot pauses after the matrix for a separate operator decision per failing client. Implementation scope is never automatically expanded to repair a failing client.
+
+### Safety boundaries
+
+R26. Live invocation is limited to read-only operations. No test path ever passes `--confirm`, so the clients' own dry-run gate remains a second line of defence beneath the classification.
+
+R27. Raw read output is default-deny for persistence to any committable path, because neither client filters or redacts controller responses.
+
+### Packaging conformance
+
+R28. The portable manifest lives at the plugin root and carries the two fields Agent Plugins 1.0 requires: the exact canonical `$schema` identifier and `name`. Claude-specific files live under the `com.infiquetra.claude/` client extension directory.
+
+R29. Portable skill frontmatter conforms to the open Agent Skills specification's six permitted fields, and each skill's `name` matches its parent directory name.
+
+## Key Technical Decisions
+
+The load-bearing choices that constrain implementation. Each is a decision with the rationale that justifies it, including the alternative it rejects.
+
+**KTD1 — The portable copy is derived, verified by digest, never hand-maintained.** A synchronization script plus a per-file SHA-256 provenance manifest makes the derivation checkable by machine, and continuous integration verifies the tree against its own manifest with no network call so the check stays hermetic. Rejected: a hand-port with only a provenance header, because drift then becomes undetectable by machine; and a subtree or submodule of the vendor repository, because it drags an entire coding-agent-vendor repository into a portable catalog and makes the core-versus-adapter split impossible to express in the layout.
+
+**KTD2 — VOID. Preserved for audit only.** A parity baseline of "correct the ported documentation downstream" was recorded in error by the controlling client and was never an operator decision. Nothing downstream of it was ever approved, and downstream-only documentation correction and intentional target divergence are both explicitly unapproved. The entry is preserved rather than erased, and belongs in the archive under this repository's supersession convention.
+
+**KTD2-prime — Repair the authoritative source first; synchronize from the corrected revision.** The Claude repository stays authoritative, so a defect it carries is fixed there and released there before the port consumes it. Rejected: porting the defect verbatim, which would republish known-false capability claims into a second public repository; and an errata overlay beside the wrong text, which leaves the falsehood inside the very document an agent loads first.
+
+**KTD2-double-prime — Extract means relocate, not delete, and the release is gated on the replacement path.** The repair scope covers both the stale documentation and de-site-ification, and the relocated topology is preserved in the operator site profile. The repaired release is not activated until the replacement context path is verified, so the existing Claude agent never temporarily loses usable site context. This creates the plan's one hard sequencing constraint and is why the portable profile contract is a predecessor of the upstream release while the synchronization is its successor.
+
+**KTD3 — Site profile custody is private and versioned; the runtime contract is a path.** The profile is authored in the private `home-lab` repository, which already owns this address space, and is deployed to a documented machine-local runtime path that the portable core reads. The portable core reads a path and has no knowledge of `home-lab`. Rejected: reading directly from a repository checkout, which couples the runtime to one operator's clone layout; and an unversioned local-only file, which leaves a curated topology unreviewed and unbacked-up across several machines.
+
+**KTD4 — Fleet Core becomes a first-class portable source.** It gets its own tests, releases, versioning, provenance, and compatibility contract rather than being folded invisibly into its consumers. Rejected: inlining the retry logic into each client, which reverses the fleet-wide decision that adopted one shared primitive to stop per-plugin drift.
+
+**KTD4-A — Port one vertical slice; bundle it at build time.** Only `retry_backoff` and its tests are ported now, every other module is inventoried as deferred, and the generated installable artifact bundles the module so users never install Fleet Core separately. This dissolves rather than works around the fact that Agent Plugins 1.0 has no dependency mechanism: at install time there is no dependency to declare, because the artifact is already complete. The generated, read-only, digest-stamped discipline is what keeps that from degrading into an unmaintained copy-paste fork. Rejected: inventing a dependency field, requiring `FLEET_COMMONS_ROOT`, and retaining Claude-specific runtime discovery.
+
+**KTD5 — Compatibility coverage is mandatory; passing is not.** All ten installed clients are assessed identically and recorded under one of four statuses with evidence, and no single failure blocks the pilot. The matrix is a deliverable that ends in an operator pause, because deciding whether a given client warrants repair, an adapter, a different distribution path, or explicitly unsupported status is a scope decision that belongs to the operator rather than to the implementer.
+
+**KTD6 — Repository validation stays standard-library-only; ported plugin tests get their own job.** This repository's continuous integration currently runs `python3` with no dependency-install step and no project file, while the UniFi clients need `requests` and `urllib3` and their tests are written for pytest. Keeping `scripts/check_repo.py` and its unittest suite dependency-free preserves a fast hermetic baseline that cannot break on a dependency outage, and a second job installs dependencies and runs the ported plugin tests. Rejected: rewriting 134 existing pytest tests into unittest, which would discard proven upstream coverage for no behavioral gain.
+
+**KTD7 — The portable package targets Python 3.10 or newer.** Neither client carries a `__future__` annotations import, so the bare union annotation on both constructors is evaluated at definition time and requires Python 3.10. This is read off the code rather than chosen, and it is declared in the skills' `compatibility` frontmatter field so a consuming client can see it before running anything.
+
+## High-Level Technical Design
+
+Three things need shape that prose alone does not carry: which file belongs to which custody, what the portable package looks like when assembled, and why the unit order has one constraint that cannot be reordered.
+
+### File custody — portable core versus Claude adapter
+
+Every one of the thirteen tracked source files is assigned. Nothing is left implicit, and a file does not become portable merely by sitting beside portable files.
+
+| Source file, relative to `plugins/unifi/` in the Claude repository | Custody | Why |
+|---|---|---|
+| `skills/unifi-network/scripts/unifi_network_client.py` | Portable core | Vendor-neutral Python; the domain client, not a coding-agent integration |
+| `skills/unifi-protect/scripts/unifi_protect_client.py` | Portable core | Same |
+| `skills/unifi-network/SKILL.md` | Portable core | Procedural instruction, the Agent Skills unit of portability |
+| `skills/unifi-protect/SKILL.md` | Portable core | Same |
+| `skills/unifi-network/references/udm-api-endpoints.md` | Portable core | Reference material bundled with a skill |
+| `skills/unifi-protect/references/protect-api-endpoints.md` | Portable core | Same |
+| `README.md` | Portable core | Package documentation, rewritten site-neutral |
+| `CHANGELOG.md` | Portable core | Package version history |
+| `.claude-plugin/plugin.json` | Claude adapter | Claude Code manifest; its required location conflicts with the portable manifest's |
+| `commands/unifi.md` | Claude adapter | Commands are outside Agent Plugins 1.0 by name |
+| `agents/unifi-network-ops.md` | Claude adapter | Agent definitions are outside Agent Plugins 1.0 by name |
+| `skills/unifi-network/scripts/fleet_commons_shim.py` | Neither — removed | Replaced by the build-time bundle; its discovery is Claude-specific |
+| `skills/unifi-protect/scripts/fleet_commons_shim.py` | Neither — removed | Same |
+
+The marketplace entry in the Claude repository's `.claude-plugin/marketplace.json` is also a Claude adapter concern and stays in that repository.
+
+### Behavior-parity inventory
+
+Parity is asserted against the code, and the code is what the repaired upstream release will contain. The counts below are read from the source and are what the parity check must reproduce.
+
+| Surface | Implemented today | Parity obligation |
+|---|---|---|
+| Network client | 52 actions across 12 resource groups; 27 read-only, 25 mutating | Ported command surface equals the corrected upstream surface exactly |
+| Protect client | 21 actions across 6 resource groups; 13 read-only, 8 mutating | Same; the four documented-but-absent capabilities stay absent |
+| Network skill | Documents 9 of 12 resource groups | Upstream repair adds the missing four surfaces; portable copy matches |
+| Protect skill | Documents 4 capabilities that do not exist | Upstream repair removes them; portable copy matches |
+| Claude command | Names one absent Protect capability | Repaired upstream; stays a Claude adapter |
+| Claude agent | Names absent capabilities and embeds site topology | Repaired and de-site-ified upstream; stays a Claude adapter |
+
+### Assembled portable package
+
+```text
+plugins/unifi/
+├── plugin.json                      # Agent Plugins 1.0: $schema + name
+├── PROVENANCE.json                  # generated: source repo, commit, per-file sha256
+├── README.md
+├── CHANGELOG.md
+├── skills/
+│   ├── unifi-network/
+│   │   ├── SKILL.md                 # six permitted frontmatter fields only
+│   │   ├── references/udm-api-endpoints.md
+│   │   └── scripts/
+│   │       ├── unifi_network_client.py
+│   │       └── _bundled/retry_backoff.py    # generated, read-only, stamped
+│   └── unifi-protect/               # same shape
+└── com.infiquetra.claude/           # client extension directory, spec section 8.2
+    ├── plugin.json                  # Claude Code manifest
+    ├── commands/unifi.md
+    └── agents/unifi-network-ops.md
+
+plugins/fleet-core/
+├── plugin.json
+├── DEFERRED.md                      # every unported module, named
+└── scripts/fleet_commons/retry_backoff.py
+```
+
+### Unit order and its one hard constraint
+
+The graph below is the dependency order. The constraint that cannot be reordered is that the portable profile contract must exist and be verified before the upstream release is activated, while the synchronization must happen after it. Both edges are real and together they do not form a cycle.
+
+```mermaid
+graph TD
+    U1[U1 target repo groundwork] --> U2[U2 portable Fleet Core slice]
+    U1 --> U4[U4 portable site-profile contract]
+    U2 --> U3[U3 build-time bundling]
+    U4 --> U5[U5 read-only discovery and drift]
+    U4 --> U7[U7 upstream topology relocation]
+    U6[U6 upstream docs repair] --> U7
+    U4 --> U8[U8 Infiquetra profile custody]
+    U7 --> U8
+    U7 --> U9[U9 transition evidence, then release]
+    U8 --> U9
+    U9 --> U10[U10 synchronize from corrected revision]
+    U3 --> U10
+    U5 --> U10
+    U10 --> U11[U11 ten-client compatibility matrix]
+    U11 --> U12[U12 documentation, journal, operator pause]
+```
+
+## Implementation Units
+
+Twelve units, dependency-ordered. Units U6 through U9 change the `infiquetra-claude-plugins` repository or the private `home-lab` repository; every other unit changes this repository. No two units that can run concurrently declare the same file.
+
+### U1. Target repository groundwork and validation extension
+
+Prepare this repository to hold a plugin package at all, and extend its validator to enforce the guarantees the rest of the plan depends on.
+
+**Goal:** Close the local-state gap, and teach `scripts/check_repo.py` to verify provenance manifests, reject stale or hand-edited bundles, and check Agent Skills frontmatter conformance.
+
+**Requirements:** R2, R19, R28, R29, R14.
+
+**Dependencies:** none.
+
+**Files:** `.gitignore`, `scripts/check_repo.py`, `tests/test_check_repo.py`, `.github/workflows/ci.yml`.
+
+**Approach:** Add `.claude/` to the ignore list so Saga's machine-local state can never be committed, which the repository's own rule against committing agent runtime state already implies but the ignore file does not yet cover. Extend the validator with three checks that all run without network access: a provenance check that recomputes each listed file's digest and compares it to the manifest, a bundle check that rejects any file under a `_bundled/` directory whose digest does not match its stamp, and a frontmatter check that rejects a portable skill carrying any field outside the open specification's six and any skill whose `name` does not match its parent directory. Keep the existing stricter-than-specification requirement for `version` and `description` but record it as deliberate.
+
+**Patterns to follow:** the existing `check_plugin_manifests` function in `scripts/check_repo.py`, which already returns a list of error strings and is exercised by `tests/test_check_repo.py` against temporary directories rather than the live tree.
+
+**Test scenarios:** A manifest listing a file whose content has changed produces exactly one digest-mismatch error naming that file. A manifest listing a file that does not exist produces a missing-file error rather than raising. A bundled file whose stamped digest matches its content produces no error, and one whose stamp does not match produces a stale-bundle error. A skill whose frontmatter carries `triggers` produces a disallowed-field error naming `triggers`. A skill directory named `unifi-network` whose frontmatter `name` is `unifi_network` produces a name-mismatch error. A repository with no `plugins/` directory still passes, preserving today's behavior.
+
+**Verification:** `python3 scripts/check_repo.py` and `python3 -m unittest discover -s tests -v` both pass on a tree with no plugins, and the new checks fail loudly on each seeded defect above.
+
+### U2. Portable Fleet Core source with the retry_backoff slice
+
+Establish Fleet Core as a portable source carrying exactly one module, and name every module it does not carry.
+
+**Goal:** Create `plugins/fleet-core/` as a conformant Agent Plugins 1.0 package containing `retry_backoff` and its tests, with an explicit inventory of the sixteen modules deliberately left unported.
+
+**Requirements:** R16, R17, R21.
+
+**Dependencies:** U1.
+
+**Files:** `plugins/fleet-core/plugin.json`, `plugins/fleet-core/DEFERRED.md`, `plugins/fleet-core/README.md`, `plugins/fleet-core/scripts/fleet_commons/retry_backoff.py`, `tests/test_retry_backoff.py`.
+
+**Approach:** The slice is genuinely self-contained, so this is a copy plus a manifest rather than a refactor: `retry_backoff.py` imports only `random`, `time`, `collections.abc.Callable`, and `typing.Any`, and its single textual mention of the wider package is prose in a docstring. Port its 220-line, 10-test pytest suite alongside it. Write `DEFERRED.md` naming all sixteen unported modules with their line counts, so no reader can mistake a 177-line slice for the 5,548-line whole.
+
+**Patterns to follow:** the upstream module and test at `plugins/fleet-core/scripts/fleet_commons/retry_backoff.py` and `tests/test_retry_backoff.py` in the Claude repository.
+
+**Test scenarios:** All ten upstream tests pass unchanged against the ported module. A retryable failure followed by success returns the success value. A non-retryable failure propagates immediately without a second attempt. The attempt cap is honored exactly. Computed jitter stays within its documented bounds. A server-supplied retry hint overrides the computed backoff, and an excessive hint is clamped to the maximum delay. The manifest validates against the published Agent Plugins 1.0 schema.
+
+**Verification:** `plugins/fleet-core/plugin.json` passes the repository validator, the ported test suite passes, and `DEFERRED.md` names every module present upstream but absent here.
+
+### U3. Build-time bundling, provenance stamping, and staleness rejection
+
+Make the UniFi artifact complete at build time so no user ever installs Fleet Core separately.
+
+**Goal:** A build step that copies the required Fleet Core module into the consuming plugin as a generated, read-only, stamped artifact, and a validation path that rejects a stale or hand-edited bundle.
+
+**Requirements:** R18, R19, R20, R21.
+
+**Dependencies:** U2.
+
+**Files:** `scripts/bundle_fleet_module.py`, `tests/test_bundle_fleet_module.py`, `scripts/check_repo.py`.
+
+**Approach:** The bundler reads a declared module list from the consuming plugin, copies each named module from `plugins/fleet-core/`, and writes it under the consumer's `scripts/_bundled/` with a header stamping the Fleet Core version, the module's content digest, and its provenance. The stamp is what makes staleness detectable, so it is the load-bearing output rather than the copy itself. Bundling only the declared subset is what lets a later plugin port reuse this model unchanged.
+
+**Patterns to follow:** the provenance-manifest shape introduced in U1, so bundle stamps and sync manifests use one digest convention rather than two.
+
+**Test scenarios:** Bundling a declared module produces a file whose stamped digest matches its content. Re-running the bundler with no upstream change is idempotent and rewrites nothing. Changing the Fleet Core source and not re-bundling causes validation to report a stale bundle naming the module. Hand-editing a bundled file causes validation to report a digest mismatch. Declaring a module that does not exist in the portable Fleet Core fails loudly rather than producing an empty bundle. A consumer declaring two modules receives exactly those two and no others.
+
+**Verification:** a fresh clone plus `python3 scripts/bundle_fleet_module.py` followed by `python3 scripts/check_repo.py` passes, and each seeded staleness or edit defect fails.
+
+### U4. Portable site-profile contract
+
+Define what an operator site profile is, how it is found, and what the plugin may never infer without one.
+
+**Goal:** A secret-free profile schema, a three-path first-setup contract, a remembered configured path with an environment-variable override, and a hard no-inference rule when no profile is present.
+
+**Requirements:** R10, R11, R12, R13, R14, R15.
+
+**Dependencies:** U1.
+
+**Files:** `plugins/unifi/skills/unifi-network/references/site-profile.md`, `plugins/unifi/schemas/site-profile.schema.json`, `plugins/unifi/scripts/site_profile.py`, `tests/test_site_profile.py`.
+
+**Approach:** The profile carries intended meaning the controller cannot report — trust roles, critical hosts, ownership, expected policies, operational constraints — and nothing else; credentials are excluded by schema, not by convention. Resolution order is the `UNIFI_SITE_PROFILE` environment variable, then the remembered configured path, then no profile at all, which is a valid and fully supported state rather than an error. The no-inference rule is enforced in code rather than described in prose: with no profile loaded, any request for a trust role, criticality, ownership, or intended policy returns an explicit unknown that callers must render as unknown.
+
+**Patterns to follow:** the environment-variable-then-default resolution already used for `UNIFI_HOST` in both clients, so the profile's precedence chain reads the same way to anyone who knows the existing code.
+
+**Test scenarios:** With no profile anywhere, loading succeeds and reports discovery-only mode rather than raising. With no profile, a trust-role query returns an explicit unknown and never a default or a guess. `UNIFI_SITE_PROFILE` pointing at a valid file overrides a different remembered configured path. `UNIFI_SITE_PROFILE` pointing at a nonexistent path fails loudly and does not silently fall back to the configured path. A profile containing a credential-shaped field is rejected by schema validation naming the offending field. A profile whose schema version is unrecognized is rejected rather than partially applied. First setup with no profile offers exactly three paths, and a test asserts the count is three so a fourth cannot be added silently.
+
+**Verification:** the schema rejects every seeded invalid profile, the three-path count is asserted by test, and a no-profile run reports unknowns rather than inferences.
+
+### U5. Portable read-only discovery and drift reporting
+
+Let the plugin learn actual controller state safely, and compare it to intended state when a profile exists.
+
+**Goal:** A credential-safe, read-only discovery capability covering networks, VLANs, devices, clients, and cameras; a proposed-profile generator for operator review; and a drift report over the merged actual-plus-intended view.
+
+**Requirements:** R11, R13, R26, R27.
+
+**Dependencies:** U4.
+
+**Files:** `plugins/unifi/scripts/discover.py`, `plugins/unifi/scripts/drift.py`, `tests/test_discover.py`, `tests/test_drift.py`.
+
+**Approach:** Discovery composes only operations classified read-only and never passes `--confirm`, so the clients' own dry-run gate remains a second line of defence beneath the classification. Because neither client filters or redacts a controller response, persistence is default-deny: discovery output is held in memory and written only to an operator-named path outside any repository, never to a default location inside one. The proposed profile is a review artifact, not an applied one, and generating it never writes the live profile.
+
+**Patterns to follow:** the read-only rows of the operation classification recorded in this plan's sources, and the existing clients' JSON-on-stdout output discipline.
+
+**Test scenarios:** Discovery against a mocked controller invokes only read-only endpoints, asserted by recording every method and URL and failing on any non-GET. Discovery never passes `--confirm`, asserted on the invocation record. Discovery with no output path given writes no file anywhere. Discovery with an output path inside the repository working tree is refused. A proposed profile is generated without writing the configured profile path. Drift with no profile present reports discovery-only and asserts no drift findings, because there is no intended state to differ from. Drift with a profile reports a host present on the controller but absent from the profile, and a policy expected by the profile but absent on the controller. A camera snapshot is never invoked by discovery, since it returns imagery rather than topology.
+
+**Verification:** the method-and-URL recorder shows zero non-GET calls across the whole discovery path, and no test run leaves a file inside the working tree.
+
+### U6. Upstream documentation repair, authored and unreleased
+
+Correct the authoritative source's documentation so the port has something true to copy.
+
+**Goal:** In `infiquetra-claude-plugins`, bring every documentation surface into agreement with the shipped code, and stop short of releasing.
+
+**Requirements:** R5, R6, R7.
+
+**Dependencies:** none. Runs in a different repository from U1 through U5 and shares no file with them.
+
+**Files:** in `infiquetra-claude-plugins`: `plugins/unifi/skills/unifi-protect/SKILL.md`, `plugins/unifi/skills/unifi-protect/references/protect-api-endpoints.md`, `plugins/unifi/skills/unifi-network/SKILL.md`, `plugins/unifi/skills/unifi-network/references/udm-api-endpoints.md`, `plugins/unifi/README.md`, `plugins/unifi/commands/unifi.md`, `plugins/unifi/CHANGELOG.md`, `plugins/unifi/.claude-plugin/plugin.json`.
+
+**Approach:** Remove every reference to the four Protect capabilities the code does not implement, across all six affected files including the plugin manifest's own description. Rewrite the Protect endpoint reference against the integration API the client actually calls rather than the older cookie-authenticated path it currently documents. Correct the network reference on each endpoint where it disagrees with the code, and document the network capabilities that exist but are unmentioned. Re-derive both reference documents from the source rather than editing them in place, because both have drifted far enough that patching risks preserving errors nobody checked.
+
+**Patterns to follow:** the shipped client source is the only trustworthy description of current behavior; neither existing reference document may be used as an input.
+
+**Test scenarios:** A test asserts that every command shown in the Protect skill exists in the Protect client's parser, and fails if any documented command is absent. The mirrored test asserts the same for the network skill. A test asserts that every endpoint path named in each reference document appears in its client's source. A test asserts the plugin manifest description names no capability absent from either client.
+
+**Verification:** the upstream test suite passes, the documentation-versus-code assertions above pass, and no release is cut.
+
+### U7. Upstream topology relocation and default removal, authored and unreleased
+
+Remove one operator's addressing from the source without destroying the knowledge it encoded.
+
+**Goal:** In `infiquetra-claude-plugins`, remove the hard-coded controller default from both clients and relocate the agent's embedded lab topology into the site-profile form, preserving every fact.
+
+**Requirements:** R8, R9, R15.
+
+**Dependencies:** U4, U6.
+
+**Files:** in `infiquetra-claude-plugins`: `plugins/unifi/skills/unifi-network/scripts/unifi_network_client.py`, `plugins/unifi/skills/unifi-protect/scripts/unifi_protect_client.py`, `plugins/unifi/agents/unifi-network-ops.md`, `plugins/unifi/CHANGELOG.md`, and the upstream client test suites.
+
+**Approach:** Make the controller host required with no baked-in fallback, failing loudly the way the missing-API-key check already does, rather than substituting a different address that would merely move the problem. Relocate the agent's topology section into the profile shape defined in U4 and have the agent read site context from the resolved profile instead of from its own text. Depends on U4 because there must be a defined place to relocate into before anything is relocated; depends on U6 because both units edit the changelog and the agent definition, and merging beats sequencing on a shared file.
+
+**Patterns to follow:** the existing missing-API-key failure at the top of both constructors, which prints a structured error and exits before any network call.
+
+**Test scenarios:** With no host supplied by flag or environment, the client exits with a structured error naming the host variable and makes no network call. With the host supplied by flag, that value is used and the environment is not consulted. With the host supplied only by environment, that value is used. A present-but-empty host variable fails loudly rather than producing a malformed URL, closing a defect the current code has. The agent definition contains no address literal, asserted by pattern search. Every fact previously embedded in the agent appears in the relocated profile, asserted field by field so relocation cannot silently lose one.
+
+**Verification:** the upstream suite passes, a pattern search finds no controller address literal in the plugin, and the relocated profile is field-complete against the prior agent text. No release is cut.
+
+### U8. Infiquetra site profile custody and deployment
+
+Give the relocated topology a private, versioned home and a path the runtime can read.
+
+**Goal:** Author the Infiquetra profile in the private `home-lab` repository and deploy it to the documented machine-local runtime path.
+
+**Requirements:** R14, R15, R12.
+
+**Dependencies:** U4, U7.
+
+**Files:** in `home-lab`: `knowledge/unifi-site-profile.yaml` and an Ansible deployment task under `ansible/`.
+
+**Approach:** The profile content comes from U7's relocation, so this unit transports rather than invents. It lives in `home-lab` because that repository is private and already owns this address space in its cluster topology document and Ansible inventory. Nothing about this unit appears in the public repository as a requirement; it is the Infiquetra instance of a contract that deliberately does not name it.
+
+**Patterns to follow:** the existing `home-lab` Ansible inventory and `knowledge/` conventions, so this file is maintained the way its neighbors already are.
+
+**Test scenarios:** The authored profile validates against the U4 schema. The deployed file at the runtime path is byte-identical to the authored source. Deployment is idempotent, changing nothing on a second run. The profile contains no credential, asserted by the same schema rule that rejects credential-shaped fields. A test asserts the public repository contains no copy of this file.
+
+**Verification:** schema validation passes, the deployed and authored copies match, and the public repository contains no site-identifying content.
+
+### U9. Transition evidence, then upstream release activation
+
+Prove the replacement context path works before switching anything on.
+
+**Goal:** Demonstrate that the Claude agent reads usable site context from the deployed profile, and only then activate the repaired upstream release.
+
+**Requirements:** R9, R3.
+
+**Dependencies:** U7, U8.
+
+**Files:** in `infiquetra-claude-plugins`: release artifacts and `plugins/unifi/CHANGELOG.md`; in this repository: `docs/evidence/2026-08-21-unifi-transition-evidence.md`.
+
+**Approach:** This unit exists solely to honor the no-capability-gap rule, so its evidence is the deliverable and the release is merely what the evidence unlocks. Capture, before activation, that the agent resolves the profile, reports the same site facts it previously carried inline, and degrades to explicit unknowns when the profile is absent. Activation is a deliberate, separate step after that evidence is recorded, and it is the point at which the corrected revision becomes available to pin.
+
+**Patterns to follow:** the repository's own rule that a component being deployed is not the same as a behavior being verified end to end.
+
+**Test scenarios:** With the profile deployed, the agent reports site context equivalent to what it previously embedded, compared fact by fact. With the profile absent, the agent reports explicit unknowns and makes no inference, confirming the U4 rule holds through the agent rather than only in the library. With the profile present but unreadable, the failure is loud rather than a silent fallback to no-profile mode.
+
+**Verification:** the evidence document records all three outcomes with their commands and results, and the release is activated only after it is written. The corrected revision's commit identifier is captured for U10 to pin.
+
+### U10. Synchronize from the corrected revision
+
+Produce the portable package as a derived artifact whose provenance a machine can check.
+
+**Goal:** A synchronization script, a provenance manifest pinned to the corrected upstream revision, the assembled portable tree, and the Claude client extension directory.
+
+**Requirements:** R1, R2, R3, R4, R28, R29, R18.
+
+**Dependencies:** U3, U5, U9.
+
+**Files:** `scripts/sync_vendor_source.py`, `tests/test_sync_vendor_source.py`, `plugins/unifi/plugin.json`, `plugins/unifi/PROVENANCE.json`, `plugins/unifi/skills/**`, `plugins/unifi/com.infiquetra.claude/**`, `plugins/unifi/README.md`, `plugins/unifi/CHANGELOG.md`.
+
+**Approach:** The script takes a local Claude checkout and an explicit commit, copies the files assigned portable custody, places the Claude-custody files under the `com.infiquetra.claude/` client extension directory that the specification's section 8.2 defines, and writes the provenance manifest. Both `fleet_commons_shim.py` copies are dropped rather than copied, because the build-time bundle from U3 replaces them and retaining Claude-specific discovery is prohibited. The portable skill frontmatter is reduced to the six permitted fields, moving the current `triggers` and `script` values into the skill body where they inform without violating the schema.
+
+**Patterns to follow:** the digest conventions established in U1 and U3, so provenance manifests and bundle stamps remain one mechanism rather than two.
+
+**Test scenarios:** Synchronizing from a fixture checkout produces a tree whose every file digest matches the written manifest. Re-running against the same commit is idempotent and changes nothing. Synchronizing from a dirty checkout is refused, because provenance pinned to a commit that does not describe the bytes is worse than no provenance. Neither `fleet_commons_shim.py` appears anywhere in the output. The portable manifest carries the exact canonical schema identifier and a specification-conformant name. Each portable skill's frontmatter carries only permitted fields, and each skill's name matches its directory. The Claude manifest lands under the client extension directory and not at the plugin root, where it would collide with the portable manifest. A ported client's command surface equals the upstream client's, compared parser-to-parser rather than by reading documentation.
+
+**Verification:** `python3 scripts/check_repo.py` and the full test suite pass on the assembled tree, and the parser-to-parser comparison reports zero differences across all 52 network and 21 Protect actions.
+
+### U11. Ten-client compatibility matrix
+
+Assess every installed client the same way, and record what is true rather than what is hoped.
+
+**Goal:** A completed matrix covering Claude Code, OpenAI Codex, Cursor Agent, Qwen, Grok, OpenCode, Gemini CLI, Muse, Agy, and Hermes, each recorded under one of four statuses with concrete evidence.
+
+**Requirements:** R22, R23, R24, R26, R27.
+
+**Dependencies:** U10.
+
+**Files:** `docs/evidence/2026-08-21-unifi-compatibility-matrix.md`.
+
+**Approach:** Every client receives the identical bounded assessment: package installation or supported placement, discovery, loading, and the safest meaningful credential-free or read-only invocation. Status is one of works directly, works through an adapter, unsupported, or failed, and each carries the command run, the observed output, and the concrete reason. Coverage is mandatory and passing is not, so a client that cannot load the package is recorded and the assessment continues rather than halting.
+
+**Patterns to follow:** the shared `~/.agents/skills` path already present on this machine with eight skills and a lock file, which is the known-working mechanism for clients that discover loose skills.
+
+**Test scenarios:** Not a feature-bearing unit in the usual sense; its output is evidence rather than behavior. The assessment itself is constrained by test: a recorded invocation that includes `--confirm` fails the evidence check, and a recorded invocation of any operation classified mutating fails it. Every one of the ten clients has exactly one status recorded, asserted by count, so a silently skipped client cannot pass as covered. Every non-working status carries a non-empty reason.
+
+**Verification:** ten rows, four permitted statuses, every row carrying evidence, and zero mutating or confirmed invocations anywhere in the record.
+
+### U12. Documentation, journal, and the operator pause
+
+Record what was decided and learned, then stop deliberately rather than drifting into remediation.
+
+**Goal:** Update this repository's documentation and engineering journal, and present the matrix for the operator's per-client decision without acting on it.
+
+**Requirements:** R25, R15, R17.
+
+**Dependencies:** U11.
+
+**Files:** `README.md`, `docs/README.md`, `llms.txt`, `docs/engineering-journal/DECISIONS.md`, `docs/engineering-journal/LEARNINGS.md`, `docs/engineering-journal/QUEUED.md`, `docs/engineering-journal/ARCHIVE.md`.
+
+**Approach:** Record each key technical decision with its rationale and rejected alternatives, and preserve the void KTD2 in the archive with a link to its replacement rather than deleting it, following this repository's own supersession convention. Close the queued pilot item by moving it to the archive with its outcome. Add the durable learnings the investigation produced, since each was expensive to find and cheap to lose.
+
+**Patterns to follow:** the existing journal entries, which carry author, decision, rejected alternatives, rationale, revisit condition, and references.
+
+**Test scenarios:** No behavioral change. Test expectation: none — documentation and journal only. The repository validator's link check covers every added local link, so a broken reference fails continuous integration.
+
+**Verification:** `python3 scripts/check_repo.py` passes with all new links resolving, the queued pilot item appears in the archive with its outcome, and the void KTD2 is preserved in the archive with its replacement linked.
+
+## Ownership and repository map
+
+Four repositories are touched. Ownership matters because two of them are not this one, and this session has no authority over either.
+
+| Units | Repository | Visibility | Owner | Authority status |
+|---|---|---|---|---|
+| U1, U2, U3, U4, U5, U10, U11, U12 | `infiquetra-agent-plugins` | Public | Jeff Cox | This plan's target; changes proposed by pull request |
+| U6, U7, U9 | `infiquetra-claude-plugins` | Public | Jeff Cox | Authoritative source; not authorized by this session |
+| U8 | `home-lab` | Private | Jeff Cox | Custody home; not authorized by this session |
+| U9 evidence, U11 matrix | `infiquetra-agent-plugins` | Public | Jeff Cox | Evidence artifacts, site-identifying content excluded |
+
+## Validation and continuous integration
+
+The repository's hermetic baseline is preserved and a second job carries the dependency-bearing work.
+
+The existing job keeps running `python3 scripts/check_repo.py`, `python3 -m unittest discover -s tests -v`, and `git diff --check` with no dependency installation, so a dependency outage can never break the repository's own baseline. It gains the provenance, bundle-staleness, and frontmatter checks from U1, all of which are pure local computation.
+
+A second job installs Python 3.10 or newer plus `requests`, `urllib3`, and `pytest`, then runs the ported plugin tests. This job is where the Fleet Core slice tests, the site-profile tests, the discovery tests, and the parser-to-parser parity comparison run.
+
+Neither job ever contacts a UniFi controller. The compatibility matrix is produced by an operator-run assessment, not by continuous integration, because it requires ten installed clients that no hosted runner has.
+
+## Rollback
+
+Every unit is reversible, and the two irreversible-feeling ones are not actually irreversible.
+
+Units in this repository roll back by reverting the pull request; nothing is published, and no consumer depends on this repository yet. The portable package's existence changes nothing for any current user until a client is pointed at it.
+
+The upstream repair rolls back by reverting its own pull request in the Claude repository before release activation. After activation, rollback means releasing the prior version, which is why U9 gates activation on evidence rather than on completion.
+
+The one change with a real blast radius is U7's removal of the controller default, because it changes behavior for anyone relying on the fallback. Its rollback is the same release-the-prior-version path, and its risk is bounded by U9 proving the replacement context path first.
+
+The site profile in `home-lab` rolls back by reverting that repository and re-running the deployment, which is idempotent.
+
+## Scope Boundaries
+
+### Explicit non-goals
+
+Custody does not move. The Claude repository remains authoritative for `unifi` throughout this pilot, and nothing here transfers that authority.
+
+Full Fleet Core parity is not attempted or claimed. Sixteen modules totaling roughly 4,500 lines remain unported by design, and `DEFERRED.md` names each one.
+
+Remediating a failing client is not in scope. The matrix records status; it does not fix anything, and implementation scope is never automatically expanded to make a client pass.
+
+No marketplace publication, no release of the portable package, and no retirement of any existing vendor marketplace.
+
+Saga, Team Execution, and the remaining eleven Claude plugins are untouched. So is the untracked `.serena` directory.
+
+### Deferred to follow-up work
+
+Porting further Fleet Core modules, each bundling only the subset its consumer requires, under the packaging model this pilot establishes.
+
+A custody-transfer decision for `unifi`, which becomes answerable only once this pilot's evidence exists.
+
+The per-client remediation decisions that follow the operator pause in U12.
+
+Generating the Claude marketplace entry from this repository rather than maintaining it upstream.
+
+## Risks and Dependencies
+
+Each risk carries the mitigation actually planned for it, not a general reassurance.
+
+| Risk | Mitigation |
+|---|---|
+| The upstream repair spans two repositories and two review cycles, so the pilot can stall waiting on work this session cannot perform | U1 through U5 have no dependency on the upstream repair and can complete in parallel with it; only U10 onward blocks |
+| Removing the controller default changes behavior for existing users | U9 gates release activation on evidence that the replacement context path works, and the failure mode is a loud error rather than a wrong controller |
+| A bundled Fleet Core module silently drifts from its source | The stamp carries version, digest, and provenance, and continuous integration rejects both staleness and hand edits; the bundle is generated and read-only |
+| Discovery output contains unredactable operator inventory | Persistence is default-deny, the working tree is refused as an output location, and neither client filters responses so no field allowlist is trusted |
+| A client's Agent Plugins 1.0 support is assumed rather than verified | No claim enters the matrix without a recorded command and its output; unverified is not a permitted status, so the four statuses force a determination |
+| The specification could move under the port | Agent Plugins 1.0.0 is Published and current; 1.1.0 exists as a Working Draft in the same repository and is explicitly not targeted |
+| Two units editing one file lose a write | U6 and U7 share the changelog and agent definition and are therefore sequenced, not parallelized |
+
+## Open Questions
+
+Two remain, and both are genuinely operator-owned rather than deferred out of laziness.
+
+The execution backend and routing destination for this plan are not yet chosen. Saga Plan asks these at its final phase, and they are recorded in the plan's frontmatter and saga tick once answered.
+
+Whether the portable package should eventually generate the Claude marketplace entry, rather than that entry continuing to be maintained upstream by hand, is out of scope here but becomes answerable once this pilot proves the generation path.
+
+## Stop Conditions
+
+The pilot stops, and asks, at each of these. None of them is a failure; each is a point where continuing without a decision would exceed granted authority.
+
+Stop before any change to `infiquetra-claude-plugins`. Units U6, U7, and U9 are defined here but not authorized by this session.
+
+Stop before any change to `home-lab`. Unit U8 is defined here but not authorized.
+
+Stop before activating the repaired upstream release, until U9's transition evidence is written and reviewed.
+
+Stop if the corrected upstream revision cannot be pinned, because synchronizing from an unpinned or dirty source produces provenance that claims more than it can prove.
+
+Stop after the ten-client matrix is complete, for the operator's per-client decision. Do not begin remediating any failing client.
+
+Stop before merging this plan's pull request. Stop before any publication, release, or marketplace change.
+
+Stop if a live invocation would require `--confirm`, a mutating operation, or a credential this plan did not scope.
+
+## Sources and Research
+
+Primary evidence gathered during planning, with the identifiers a later reader needs.
+
+The authoritative source was read at commit 995a475 in `infiquetra-claude-plugins`. The Protect capability removal is commit 8a14ad49, dated 2026-03-17, whose message states that the older path requires cookie-based authentication and returns 401 with an API key.
+
+Agent Plugins 1.0.0 is Published; its required manifest fields are `$schema` and `name`, and section 5.2 states clients must not retrieve the schema while loading a plugin. Client extension directories are defined in section 8.2 as top-level directories named for a reverse-domain namespace, which makes `com.infiquetra.claude/` conformant rather than invented. Sections 6 and the design-decisions appendix confirm that commands, hooks, agents, rules, and Language Server Protocol servers are outside the version 1 format by name.
+
+The Agent Skills specification requires a skill's frontmatter `name` to match its parent directory name and permits six frontmatter fields: `name`, `description`, `license`, `compatibility`, `metadata`, and `allowed-tools`.
+
+This repository's validator already pins the exact canonical schema identifier at `scripts/check_repo.py:44`, and that identifier matches the specification's mandated literal.
+
+Local client baseline, probed directly: Claude Code 2.1.239, Codex 0.149.0, Cursor Agent 2026.08.11-e8db854, Qwen 0.21.15, Grok 1.0.5, OpenCode 1.18.18, Gemini CLI 0.44.1, Muse 0.2.1, plus Agy and Hermes on the executable path. The shared `~/.agents/skills` directory already exists with eight skills and a lock file.

--- a/docs/reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review-disposition.md
+++ b/docs/reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review-disposition.md
@@ -1,0 +1,85 @@
+# Disposition — document review of the UniFi and portable Fleet Core pilot plan
+
+This records the independent validation and repair of every finding in the
+[incoming review](2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review.md). The review
+artifact is preserved unmodified as incoming evidence; nothing in it was rewritten, softened, or
+deleted.
+
+## Provenance of the incoming review
+
+| field | value |
+|---|---|
+| artifact | `docs/reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review.md` |
+| SHA-256 as delivered | `3d50ae5ae128d3f15fcf4750c43a747d3c8dee123369997a4584e62eb24f01e5` |
+| length | 228 lines |
+| verdict | NOT READY / BLOCKED — ten priority-1 findings, two priority-2 findings |
+| reviewed revision | pull request #2 head `43b4cc833381cd6da3593de7808cc2ab7dcb43bc` |
+
+## Validation method
+
+Each finding was checked against primary evidence rather than accepted on the reviewer's authority:
+the exact plan text at the reviewed revision, the authoritative source repository at commit
+`995a475`, the installed Orchestrate contract, the published Agent Plugins 1.0.0 specification, and
+this repository's own standing rules. Repository validation being green was not treated as evidence
+against any finding, because the findings concern decisions and gates rather than document syntax.
+
+## Outcome
+
+**Twelve findings raised, twelve confirmed, none refuted and none narrowed.** No repair required a
+new operator decision; each was either a correction of the document to match an already-settled
+ruling, or an application of a standing repository rule.
+
+| finding | verdict | independently verified against | repair |
+|---|---|---|---|
+| D1 | CONFIRMED | Plan carries `backend: inline` in frontmatter while Open Questions declared the backend unchosen. Orchestrate's own contract states "orchestrate is always inline, and the plan carries `backend: inline` so every `/work` unit is told rather than asked." | Stale open question removed; an Execution ownership section names Orchestrate-through-Herdr as outer controller and `inline` as the per-dispatched-unit backend; KTD8 records the two-layer model. |
+| D2 | CONFIRMED | Orchestrate's README describes one run record over one repository's branches and worktrees. The plan spanned three repositories with no handoff topology. | A run-topology table defines Run A, B, and C, one per repository, joined by three named receipts; KTD9 records the rule; stop conditions gained a missing-receipt stop. |
+| D3 | CONFIRMED | R4 forbade intentional divergence while U10 reduced skill frontmatter downstream, and U4 and U5 authored target-owned files under `plugins/unifi/` with no classification. | R4 rewritten to classify every path as byte copy, versioned transform, or target-owned source; frontmatter repair moved upstream into U6 so skill files stay byte copies; U10 made classification-aware and forbidden from overwriting target-owned paths. |
+| D4 | CONFIRMED | R16 promised versioning, provenance, and releases; U2's file list carried none, and this repository's standing rule keeps vendor repositories authoritative absent a recorded custody decision. | R32 and R33 added; KTD10 records that custody does not move and the slice derives under the same rule as UniFi; U2 gained a provenance manifest, a changelog, and a named release surface. |
+| D5 | CONFIRMED | U3 named a declared module list but no declaration file, and Agent Plugins 1.0 has a closed manifest schema that forbids assigning semantics to unknown top-level fields. The digest was self-referential. | R34 and R35 added; a separate `fleet-bundle.json` with a closed schema; KTD11 defines two digest domains, with the generated-output digest excluding its own stamp block; generate and check modes separated. |
+| D6 | CONFIRMED | U8 named a YAML profile while the dependency-bearing job installed no parser; no component owned the three-path setup; U7 required the upstream agent to consume a loader that existed only in this repository. | R36 through R39 added; KTD12 pins JSON parsed by the standard library; U4 gained a named setup entrypoint and explicit configuration and runtime paths; U7 gained a Claude-side loader; U5 must emit unknown for every intent field. |
+| D7 | CONFIRMED | U9 named only "release artifacts" and the changelog, while the upstream repository enforces a tri-lock requiring plugin manifest, marketplace entry, and changelog versions to be equal, plus a generator check. Rollback was undefined. | R40 through R42 added; U9 names all three release surfaces, a staged pre-activation load, a post-activation installed-version and digest readback, and a fresh-session proof of all three profile states; the Rollback section gained a trigger, a version strategy, and a re-proof requirement. |
+| D8 | CONFIRMED | U11's tests asserted row count and permitted statuses only, and its file list owned no validator, so a row could be counted as covered after one early failure. | R43 added; every client now carries four stage results — placement, discovery, load, invocation — each executed, blocked, or not applicable with command and evidence, then exactly one overall status; a schema and validator were added; unsupported and failed remain accepted outcomes. |
+| D9 | CONFIRMED | U9 wrote fact-by-fact equivalence evidence into this public repository with no schema, allowlist, or check enforcing the stated exclusion. | R44 added; a public evidence schema records field names, counts, per-field results, digests, and redacted commands, and forbids raw topology or controller responses; the private receipt stays outside this repository and is linked by digest. |
+| D10 | CONFIRMED | The upstream `fleet_commons` package holds 18 files — 15 Python modules and 3 data files — plus `fleet_commons_shim.py` beside it. No counting basis yields sixteen remaining after porting one module. | The handwritten count was removed everywhere; the deferred inventory is generated from the pinned source tree by set difference, with its counting basis stated in the file, so an upstream addition fails the check until regenerated. |
+| D11 | CONFIRMED | The plan said four repositories while its ownership table named three distinct ones and repeated the target repository in a fourth row; the pull request body repeated the count. | Corrected to three in the plan and in the pull request body; the repeated row is labelled as the same repository. |
+| D12 | CONFIRMED | U6's file list contained no test path although its scenarios required new assertions, and its stated checks omitted the README, slash command, agent definition, and changelog that R5 also covers. | R45 added; U6 owns a named upstream test file; assertions now cover all eight surfaces named by R5 through R7, with a surface-to-assertion map so none is left to an unrecorded review gate. |
+
+## Refutations and narrowings
+
+None. Every finding survived independent validation on primary evidence.
+
+The reviewer's two priority-2 findings were factual arithmetic and count errors in the plan, and both
+were reproduced exactly. The reviewer's own alternative count for D10 was also checked and is
+correct.
+
+## Operator rulings preserved through the repair
+
+Each was re-checked against the repaired document rather than assumed to have survived.
+
+Orchestrate through Herdr is the outer controller, and `backend: inline` is the per-dispatched-unit
+Saga backend. Fleet Core is a first-class portable source, but only `retry_backoff` is ported now and
+every other item is inventoried as deferred. All ten clients must be assessed and none must pass. No
+client-specific remediation begins before the operator pause. The authoritative Claude source is
+repaired and released before the port synchronizes from it, and extract means relocate rather than
+delete.
+
+## What changed in the plan
+
+Requirements grew from 29 to 45; no existing requirement identifier was renumbered. Decisions grew
+from 8 to 15, retaining the void decision preserved for audit. Implementation units remain U1 through
+U12 with no renumbering, as the identifier stability rule requires. Four design sections were added:
+execution ownership, run topology, path classification, and the public evidence schema.
+
+## Checks
+
+| check | result |
+|---|---|
+| `python3 scripts/check_repo.py` | passed |
+| `python3 -m unittest discover -s tests -v` | passed, 4 tests |
+| `git diff --check` | passed |
+
+These confirm document syntax, required paths, and local link integrity. As the incoming review
+correctly noted, they cannot resolve decision-level findings; the validation above did that.
+
+No implementation, installation, publication, release, credential access, UniFi controller call, or
+change to any other repository was performed.

--- a/docs/reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review.md
+++ b/docs/reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review.md
@@ -1,0 +1,228 @@
+# Saga document review — UniFi and portable Fleet Core portability pilot
+
+This review covers the implementation plan on pull request (PR) #2 in `infiquetra-agent-plugins`, where readiness matters because the plan would coordinate source, release, deployment, and compatibility work across three repositories.
+
+## Applied fixes
+
+No fixes were applied. The operator required the plan, source code, external systems, other repositories, and Saga state to remain read-only; this review artifact is the only created file.
+
+## Readiness summary
+
+**Verdict: NOT READY — implementation is blocked by ten Saga priority P1 findings.** Saga priority P1 means a core decision, mapping, default, or gate is missing or wrong, so an implementer would have to invent behavior or exceed an authority boundary. Saga priority P2 means the document can probably drive work but would create meaningful rework, ambiguity, or review risk.
+
+The plan correctly preserves the central operator decisions about repairing the authoritative Claude source before synchronization, porting only the `retry_backoff` Fleet Core module, generating the consumer bundle, keeping the site profile optional, assessing all ten installed clients without requiring ten passes, and pausing before any client-specific remediation. Those decisions are not enough to approve the document because their source-custody, execution, profile, release, and evidence mechanics contradict one another or remain incomplete.
+
+## Review-result contract
+
+The review is tied to the exact PR head and the installed Saga contract used for this pass.
+
+| field | value |
+|---|---|
+| target path | `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md` |
+| classification | Plan document; Saga readiness-skeptic pass |
+| reviewed revision | PR #2 head `43b4cc833381cd6da3593de7808cc2ab7dcb43bc`; base `9a2c6d7e2497d7bbdfb801cf63ef83edb4176ea8` |
+| PR | [infiquetra-agent-plugins PR #2](https://github.com/infiquetra/infiquetra-agent-plugins/pull/2) |
+| Saga preflight | `saga` version `0.83.0+codex.20260811103502` is installed and enabled; its document-review skill and formatting contract match the current marketplace checkout and upstream commit `e85d4150aad9e7e17bce03a3387b2588ea8fd9fa` |
+| blocked | yes |
+| findings | 10 open P1 findings; 2 open P2 findings; no P0 or P3 findings |
+| applied fixes | none |
+| override rationale | none |
+| review artifact path | `docs/reviews/2026-08-22-unifi-fleet-core-portability-pilot-plan-doc-review.md` |
+| linked plan state | The ignored `.claude/saga/` state was read for consistency and not changed |
+
+## Remaining findings by priority
+
+The blocking findings concern decisions and gates, not prose polish.
+
+| finding | priority | status | plain-language finding |
+|---|---|---|---|
+| D1 | P1 | open | The plan records the per-unit Saga backend as `inline` and later says the backend is undecided; it also omits the settled outer-controller ownership by Orchestrate through Herdr. |
+| D2 | P1 | open | The dependency graph spans three repositories, but the current Orchestrate run model owns one repository and has no per-unit repository field; the plan does not define the required multi-run handoffs. |
+| D3 | P1 | open | The UniFi copy is declared fully derived with no intentional divergence, while the plan adds target-owned files and rewrites skill frontmatter only after synchronization. |
+| D4 | P1 | open | The plan makes Fleet Core a first-class portable source without deciding custody of `retry_backoff` or specifying the promised version, provenance, release, and compatibility surfaces. |
+| D5 | P1 | open | The generated bundle has no declared-module manifest or closed digest contract, so the build and stale-bundle validator require invention. |
+| D6 | P1 | open | The optional site-profile and discovery design lacks an executable storage, format, dependency, setup-entrypoint, and no-inference contract across the target and Claude repositories. |
+| D7 | P1 | open | The upstream activation unit cannot yet prove the no-capability-gap claim because its release surfaces, pre-activation staging path, fresh-session readback, and rollback trigger are unspecified. |
+| D8 | P1 | open | The ten-client gate can pass with ten status rows even when the four mandatory smoke stages were not each attempted or explicitly blocked with evidence. |
+| D9 | P1 | open | The public transition evidence can capture private topology or controller output because the plan states exclusion but defines no sanitization or evidence schema. |
+| D12 | P1 | open | The upstream documentation-repair unit promises new regression assertions but owns no test file and leaves several corrected surfaces outside its stated checks. |
+| D10 | P2 | open | The plan's count of sixteen unported Fleet Core modules does not match the authoritative source tree. |
+| D11 | P2 | open | The plan and PR body say four repositories are touched, but the ownership map names only three distinct repositories. |
+
+### D1 — P1 — The execution backend is settled, but the plan says it is open
+
+The intended ownership has two layers: Orchestrate is the outer controller and uses Herdr to dispatch and monitor work, while `backend: inline` is the Saga backend inside every dispatched unit so no unit starts nested orchestration.
+
+| aspect | evidence |
+|---|---|
+| contradiction | The plan records `backend: inline` at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:1-8`, then says the execution backend and routing destination are unchosen at `:528-534`. |
+| source truth | The architecture assigns session execution to Herdr at `docs/cross-vendor-plugin-architecture-brief.md:61-69` and says Orchestrate delegates execution to Herdr at `:106-113`. The authoritative Orchestrate contract says the plan always carries `backend: inline` because a dispatched unit must not nest another workflow at [`plugins/orchestrate/commands/orchestrate.md:119-123`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/orchestrate/commands/orchestrate.md#L119-L123), and the run model repeats that rule at [`orchestrate.py:435-447`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/orchestrate/skills/orchestrate/scripts/orchestrate.py#L435-L447). |
+| required correction | Remove the stale open question and add an execution-ownership section naming Orchestrate-through-Herdr as the outer controller and `inline` as the per-dispatched-unit Saga backend. Clarify that `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:502` means Saga and Team Execution source are unchanged, not that the approved controller is unused. |
+
+This is material because a literal worker can otherwise stop for an already-answered question, run everything in the main session, or create the nested orchestration the settled backend avoids.
+
+### D2 — P1 — One Orchestrate run cannot encode this three-repository graph
+
+The plan needs an explicit multi-run or handoff topology before Orchestrate can own its dependency graph.
+
+| aspect | evidence |
+|---|---|
+| plan shape | The plan declares twelve units across `infiquetra-agent-plugins`, `infiquetra-claude-plugins`, and `home-lab`, with evidence returning to the target repository at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:190-215` and `:457-466`. |
+| controller limit | Current Orchestrate describes one driven repository and one worktree per unit at [`plugins/orchestrate/README.md:1-18`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/orchestrate/README.md#L1-L18). Unit ownership paths are repository-relative at [`orchestrate.py:369-373`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/orchestrate/skills/orchestrate/scripts/orchestrate.py#L369-L373), and the controller resolves one repository root from its current checkout at [`orchestrate.py:1078-1091`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/orchestrate/skills/orchestrate/scripts/orchestrate.py#L1078-L1091). |
+| required correction | Define the approved outer topology: which repository owns each Orchestrate run, which receipt releases each cross-repository dependency, where the controller pauses for authority, and how the target-repository run resumes at implementation unit U10 after the Claude and home-lab work lands. |
+
+This is material because placing an outside-repository unit in the current run would either launch it in the wrong worktree or require ambient writes beyond that unit's declared authority.
+
+### D3 — P1 — The UniFi derivation rule conflicts with the planned output
+
+The plan does not distinguish byte-derived upstream files, deterministic transformations, and new portable files owned only by this repository.
+
+| aspect | evidence |
+|---|---|
+| no-divergence rule | Requirements R1 through R4 say the portable copy is derived, digest-verified, and never intentionally different from the authoritative source at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:28-36`; Key Technical Decisions (KTDs) 1 and 2-prime repeat that rule at `:104-110`. |
+| contradictory output | Implementation units U4 and U5 author new files directly under `plugins/unifi/` at `:277-315`. Implementation unit U10 then copies `plugins/unifi/skills/**` and removes `triggers` and `script` from frontmatter downstream at `:397-415`, even though the authoritative skill files still carry those fields at [`unifi-network/SKILL.md:1-17`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/unifi/skills/unifi-network/SKILL.md#L1-L17) and [`unifi-protect/SKILL.md:1-16`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/unifi/skills/unifi-protect/SKILL.md#L1-L16). |
+| required correction | Classify every target path as an upstream byte copy, a versioned deterministic transform, or target-owned portable source. Either repair the frontmatter upstream before synchronization or define transform provenance with source digest, output digest, and transform version; also define how synchronization preserves target-owned U4 and U5 files instead of overwriting or silently omitting them. |
+
+This is material because two reasonable synchronizers can both follow the prose and produce different trees, while only one can preserve the site-profile work and the no-divergence decision.
+
+### D4 — P1 — Fleet Core custody and lifecycle are not decided
+
+Calling Fleet Core a first-class portable source changes authority, but the plan never says whether authority for `retry_backoff` moves or remains in the Claude repository.
+
+| aspect | evidence |
+|---|---|
+| promised lifecycle | Requirement R16 promises Fleet Core its own tests, releases, versioning, provenance, and compatibility contract at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:64-76`. Implementation unit U2 lists only `plugin.json`, `DEFERRED.md`, `README.md`, the module, and its test at `:237-255`; the assembled tree likewise has no provenance or changelog at `:184-188`. |
+| current authority | This repository says existing vendor repositories remain authoritative until a pilot and later custody decision prove otherwise at `README.md:11-15` and `docs/engineering-journal/DECISIONS.md:53-70`. The source Fleet Core manifest is version `0.25.0` at [`plugins/fleet-core/.claude-plugin/plugin.json:1-4`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/fleet-core/.claude-plugin/plugin.json#L1-L4), and the module documents its Fleet Core compatibility promise at [`retry_backoff.py:1-18`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/plugins/fleet-core/scripts/fleet_commons/retry_backoff.py#L1-L18). |
+| required correction | Record who owns future `retry_backoff` edits, what initial portable version and provenance are derived from Fleet Core `0.25.0`, which files form its release surface, and how fixes flow to the existing Claude Fleet Core consumer. If custody moves for only this module, name that bounded transfer explicitly; if it does not, give Fleet Core the same synchronization rule as UniFi. |
+
+This is material because the first post-pilot retry fix would otherwise create two writable sources despite the repository's central custody rule.
+
+### D5 — P1 — The generated-bundle contract is incomplete
+
+The build-time bundling decision is sound, but the plan does not identify the input declaration or define exactly what each digest covers.
+
+| aspect | evidence |
+|---|---|
+| missing declaration | Implementation unit U3 says the bundler reads a declared module list from the consumer, but its file list names only the bundler, its test, and the repository validator at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:257-275`. No unit names a declaration file or schema. |
+| manifest limit | Agent Plugins 1.0 has a closed root manifest and forbids assigning semantics to unknown top-level fields at [`spec/1.0.0.md:141-147`](https://github.com/agentplugins/agent-plugins-spec/blob/main/spec/1.0.0.md#L141-L147), while requirement R20 correctly forbids inventing a dependency field at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:70-76`. |
+| digest ambiguity | The plan alternates among a module content digest, a stamp embedded in the generated file, and a digest of the generated file at `:261-273`. It does not define whether the stamp is excluded from hashing, how source staleness differs from bundle tampering, or where the Fleet Core version comes from. |
+| required correction | Name a separate portable build-declaration path and closed schema, define the generation and check-only commands, identify the version source, and define both the source-payload and generated-output digest domains so stale source and hand-edited output fail for different, deterministic reasons. |
+
+This is material because the declared model cannot be implemented inside the closed plugin manifest, and a digest embedded in the bytes it hashes is otherwise self-referential.
+
+### D6 — P1 — The optional site-profile path is not executable end to end
+
+The plan preserves optional operation and the no-inference rule, but it leaves the storage and integration decisions needed to make those guarantees real.
+
+| aspect | evidence |
+|---|---|
+| unresolved storage and format | Requirements R10 through R15 require a remembered configured path and environment override at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:50-62`. Implementation unit U8 names a YAML profile but no deployed runtime path at `:357-375`, while the dependency-bearing CI job lists `requests`, `urllib3`, and `pytest` but no YAML or JavaScript Object Notation (JSON) Schema runtime at `:468-476`. |
+| missing user path | Implementation unit U4 says first setup offers exactly three choices, but its files contain a library, schema, test, and reference only at `:277-295`; no skill, command, adapter, or other entrypoint owns presenting or remembering that choice. |
+| unsafe proposal ambiguity | Implementation unit U4 says the profile carries intended meaning and nothing else and forbids inferred intent at `:287-295`, while implementation unit U5 generates a proposed profile from actual controller discovery at `:297-315`. The plan does not say which fields may be prefilled or require a test that all trust, ownership, criticality, and policy fields remain unknown. |
+| cross-repository gap | Implementation unit U7 requires the upstream Claude agent to consume the U4 profile contract, but its Claude-repository file list contains no profile loader or adapter at `:337-355`; the only loader named by U4 lives in this target repository. |
+| required correction | Choose the profile serialization and validator dependency, the shared configured-path store, the exact machine-local deployment path, the setup entrypoint, and the cross-repository adapter. Define proposed-profile output as observed fields plus explicit unknown intent, or as an empty intent template, and test that it never infers operator meaning. |
+
+This is material because the current text can produce a YAML file a dependency-free runtime cannot parse, an optional profile that no client can select, or a discovery proposal that violates the no-inference requirement.
+
+### D7 — P1 — Release activation does not yet prove no capability gap
+
+Pre-activation evidence is necessary, but it cannot by itself prove that the activated marketplace bytes and a fresh Claude session use the replacement context path.
+
+| aspect | evidence |
+|---|---|
+| incomplete activation unit | Implementation unit U9 names only unspecified “release artifacts,” the UniFi changelog, and a public evidence file at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:377-395`. It does not name the UniFi plugin manifest, the root marketplace manifest, a staged pre-activation loading command, or a post-activation installed-version readback. |
+| authoritative release gate | The Claude repository requires generated marketplace parity and version equality across the plugin manifest, marketplace entry, and changelog at [`.github/workflows/ci.yml:132-152`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/.github/workflows/ci.yml#L132-L152) and [`scripts/check_release_surface_parity.py:1-6`](https://github.com/infiquetra/infiquetra-claude-plugins/blob/995a475/scripts/check_release_surface_parity.py#L1-L6). |
+| rollback gap | The plan says rollback after activation means “releasing the prior version” at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:478-488`, but it does not define a reachable rollback version, marketplace refresh, client downgrade or replacement version, fresh-session confirmation, or the failure that triggers rollback. |
+| required correction | Name every release surface and the exact staged pre-activation path, then require marketplace refresh, installed-version and digest readback, and a fresh Claude session that proves the profile-present, profile-absent, and unreadable-profile cases after activation. Define a tested rollback command and version strategy that restores prior behavior and repeats the fresh-session proof. |
+
+This is material because source-tree evidence can pass while the active client remains cached, loads the wrong version, or loses its site context after the irreversible-feeling step.
+
+### D8 — P1 — Ten rows do not prove ten complete smoke assessments
+
+The plan correctly says every client must be assessed and that not every client must pass, but its acceptance check proves row count rather than stage coverage.
+
+| aspect | evidence |
+|---|---|
+| promised coverage | Requirements R22 through R25 require installation or supported placement, discovery, loading, and the safest meaningful credential-free or read-only invocation for all ten clients at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:78-86`. |
+| weak gate | Implementation unit U11 requires one overall status, evidence, a reason, and no mutating invocation, but its tests and verification only assert ten rows and permitted overall statuses at `:417-435`. Its file list owns only the matrix document, not a validator or test, and a row can satisfy the prose checks after one early failure without recording what happened at every remaining stage. |
+| required correction | Give every client four stage results—placement, discovery, load, and invocation—each marked executed, blocked, or not applicable with command and evidence, followed by exactly one overall status. Keep all ten rows mandatory, keep unsupported and failed as acceptable assessment outcomes, and retain the operator pause before any remediation. |
+
+This is material because the current count gate can call a client “covered” without proving package loading or any meaningful invocation.
+
+### D9 — P1 — Public evidence has no sanitization contract
+
+The plan says site-identifying content is excluded, but the evidence-producing units do not define how that exclusion is enforced.
+
+| aspect | evidence |
+|---|---|
+| sensitive inputs | Requirement R14 forbids committing raw discovered inventory and sensitive identifiers at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:58-62`, and requirement R27 makes raw controller output default-deny for persistence at `:88-93`. |
+| public output risk | Implementation unit U9 writes commands and results proving fact-by-fact equivalence into this public repository at `:377-395`; the ownership table says site-identifying content is excluded at `:457-466`, but no schema, field allowlist, redaction rule, or automated check makes that true. |
+| repository rule | Public guidance forbids credentials and local environment material at `docs/public-safe-summary.md:5-14`, and the repository instructions require generated validation fixtures to use inert examples. |
+| required correction | Define a public evidence schema that records field names, counts, pass/fail comparisons, source and result digests, and redacted commands without raw topology or controller responses. Keep the sensitive receipt private, link it only by non-sensitive digest or identifier, and test the public artifact against inert example values. |
+
+This is material because the evidence step is specifically designed to compare private topology and would otherwise make publication safety depend on reviewer memory.
+
+### D12 — P1 — The upstream documentation repair has no complete test owner
+
+The plan promises regression assertions for the known documentation drift, but the implementation unit that needs them cannot create or update a test under its declared file boundary.
+
+| aspect | evidence |
+|---|---|
+| required repair | Requirements R5 through R7 cover the Protect skill, plugin README, slash command, changelog, agent definition, both API references, and missing Network capabilities at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:38-48`. |
+| missing ownership | Implementation unit U6 lists only documentation and manifest files at `:317-335`; it names no test file even though its test scenarios require new parser-to-document and endpoint assertions. |
+| incomplete stated assertions | The U6 scenarios check commands named in the two skills, paths named in the two references, and the plugin manifest description. They do not check the README, slash command, agent definition, or changelog that requirement R5 also requires to stop promising the four removed Protect capabilities. |
+| required correction | Add the exact upstream test paths to implementation unit U6 and map every R5 through R7 surface to an assertion or an explicit review gate. If implementation unit U7 owns the shared test files instead, move the tests and U6 completion gate there deliberately rather than leaving U6's verification impossible within its file list. |
+
+This is material because the pilot was created after false capability claims survived across multiple documents; leaving half those surfaces outside the regression gate permits the same failure to survive the repair.
+
+### D10 — P2 — The deferred Fleet Core count is stale
+
+The bounded slice is still correct, but the prose count cannot be used as an inventory assertion.
+
+| aspect | evidence |
+|---|---|
+| stale plan text | Implementation unit U2 and the scope boundary say sixteen modules remain unported at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:237-255` and `:490-500`. |
+| source count | At source commit `995a475ba78757f2f62df2bbd6e0078d8523eaf4`, `plugins/fleet-core/scripts/fleet_commons/` contains fifteen Python modules total, so fourteen Python modules remain after `retry_backoff.py` is ported. The same directory also contains three JSON data files, and `plugins/fleet-core/scripts/fleet_commons_shim.py` is another unported Python module; no consistent “module” definition produces sixteen remaining modules. |
+| required correction | Define whether the deferred inventory counts Python modules, data files, or all runtime support files, correct the prose count, and make `DEFERRED.md` completeness derive from the pinned source tree rather than from a handwritten number. |
+
+This is P2 rather than P1 because implementation unit U2 already requires the generated inventory to name every upstream item; deriving it from source can prevent omission even though the plan's current count is wrong.
+
+### D11 — P2 — The repository count is internally inconsistent
+
+The unit map is understandable, but its stated count is wrong unless a fourth repository is missing from the plan.
+
+| aspect | evidence |
+|---|---|
+| stale plan text | The plan says four repositories are touched at `docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md:457-466`, and the PR #2 body repeats that count. |
+| actual map | The ownership table names only `infiquetra-agent-plugins`, `infiquetra-claude-plugins`, and `home-lab`; its fourth row repeats `infiquetra-agent-plugins` for two evidence artifacts. Implementation-unit ownership at `:213-215` also describes only those three repositories. |
+| required correction | Change the count to three everywhere, or name the omitted fourth repository and assign its units, authority, dependencies, files, tests, and stop condition. |
+
+This is P2 because the existing rows still identify where every currently defined unit belongs, but the mismatch undermines the cross-repository authority summary and the PR reviewer note.
+
+## What the plan gets right
+
+The core operator choices are present and should survive remediation.
+
+| reviewed concern | result |
+|---|---|
+| settled operator decisions | The authoritative-source-first correction, void decision audit trail, relocation rather than deletion, optional profile, no-inference rule, bounded Fleet Core module, generated bundling, ten-client coverage, non-all-pass outcome, and operator pause are all present. |
+| bounded Fleet Core slice | The source module is self-contained apart from Python standard-library imports, and its authoritative test file contains ten deterministic tests; the plan does not broaden the port to the rest of Fleet Core. |
+| optional site profile | Requirements R10 through R15 make absence valid and require explicit unknowns rather than inferred intent. Finding D6 concerns the missing executable contract, not the optionality decision. |
+| ten-client policy | The plan names Claude Code, OpenAI Codex, Cursor Agent, Qwen, Grok, OpenCode, Gemini CLI, Muse, Agy, and Hermes, and explicitly allows unsupported or failed outcomes. Finding D8 preserves that policy while requiring stage-complete evidence. |
+| operator pause | Requirement R25, KTD5, implementation unit U12, the non-goals, deferred work, and the stop conditions all prohibit automatic client remediation. |
+| authority stops | The plan states that the current session cannot change `infiquetra-claude-plugins` or `home-lab`, and it stops before both repositories and before release activation. Finding D2 requires the outer controller to carry those stops across actual runs. |
+| read-only live behavior | The plan prohibits `--confirm`, mutating operations, and raw controller-output persistence. No live controller operation was run during this review. |
+
+## Checks and evidence limits
+
+The verdict is based on the exact PR head, current repository files, source commit `995a475ba78757f2f62df2bbd6e0078d8523eaf4` in `infiquetra-claude-plugins`, the clean current `home-lab` checkout, the published Agent Plugins 1.0.0 and Agent Skills specifications, and the current installed Saga and Orchestrate contracts.
+
+Repository validation is relevant only to document syntax and links; it cannot resolve the P1 findings above. No implementation tests, client smoke tests, release, installation, credential access, UniFi controller call, Saga-state mutation, or external-system mutation was performed.
+
+| check | result |
+|---|---|
+| `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_repo.py` | passed |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v` | passed; 4 tests |
+| `git diff --check` | passed |
+
+The Claude-repository test collection was not used as approval evidence because its configured coverage plugin attempted to write `.coverage` in the read-only checkout and the sandbox refused the write. Source inspection independently confirmed the ten `retry_backoff` test functions and the release-surface gates needed for this plan review.


### PR DESCRIPTION
## Summary

Records the decision-complete plan for the first portability pilot. It ports the Claude `unifi` plugin into a portable Agent Plugins 1.0 package in this repository, alongside a new portable Fleet Core source carrying only the `retry_backoff` module the UniFi clients require.

This is documentation only. No implementation, copying, publication, release, client installation, credential access, or UniFi controller call is performed or authorized by this change.

Three problems surfaced during investigation that the tracked file list could not show, and each reshaped the plan:

- The plugin is not self-contained. Both clients reach into a separate plugin at module import time through discovery paths that only exist under Claude Code, and the manifest declares no dependency.
- The Protect documentation promises four capabilities the code removed five months ago, and both API reference documents disagree with the shipped code.
- One operator's controller address is hard-coded as a universal default in both clients, which cannot ship in a public portable package.

## Document review and repair

A Saga document review returned **NOT READY / BLOCKED** with twelve findings — ten priority-1 and two priority-2. Every finding was independently validated against primary evidence rather than accepted on the reviewer's authority: the plan text at the reviewed revision, the source repository at `995a475`, the installed Orchestrate contract, and the published Agent Plugins 1.0.0 specification.

**All twelve confirmed. None refuted, none narrowed.** No repair required a new operator decision; each was either a correction of the document to match an already-settled ruling, or an application of a standing repository rule.

The failures clustered in four places: a self-contradiction about execution ownership, a dependency graph that no single controller run could carry, contracts promised in requirements but owned by no file or test, and evidence gates that proved counts rather than coverage.

Requirements grew from 29 to 45 and decisions from 8 to 15, with no identifier renumbered. Four design sections were added: execution ownership, run topology across three repositories, path classification, and the public evidence schema.

The delivered review artifact is preserved **byte-identical** as incoming evidence, SHA-256 `3d50ae5ae128d3f15fcf4750c43a747d3c8dee123369997a4584e62eb24f01e5`, alongside a finding-by-finding disposition record and an audit entry registering both under the journal convention.

## Portability and custody

- **Portable core, vendor adapter, documentation, or tooling:** Documentation and planning only. The plan assigns all thirteen tracked source files to portable core or Claude adapter, drops two, and classifies every portable path as a byte copy, a versioned transform, or target-owned source.
- **Current source of truth before this change:** `infiquetra-claude-plugins` remains authoritative for both `unifi` and the Fleet Core slice. This change does not move custody, and the plan explicitly keeps it there — the source is repaired, verified, and released first, and the port then synchronizes from the corrected revision by a digest-verified derivation.
- **Compatibility or migration impact:** None from this change. The plan defines mandatory compatibility coverage across all ten installed clients, each recorded with four stage results and one overall status. Coverage is mandatory; passing is not, and the matrix ends in an operator pause rather than automatic remediation.

## Validation

- [x] `python3 scripts/check_repo.py`
- [x] `python3 -m unittest discover -s tests -v`
- [x] `git diff --check`
- [x] Changed plugin behavior has focused compatibility evidence, or the pull request explains why none is applicable — **not applicable**: no plugin behavior changes here. The plan defines the compatibility evidence the pilot must produce.

## Repository hygiene

- [x] The change is scoped and follows existing patterns.
- [x] The engineering journal was updated when durable knowledge changed — one decision entry, two learnings, the queued pilot item updated, a superseded parity baseline preserved in the archive with its replacement linked, and an audit entry for the document review.
- [x] No credentials, private policy, installed plugin copies, or local runtime state are included.

## Reviewer notes

The plan carries 45 requirements, 15 decisions, and 12 dependency-ordered units across **three** repositories: this one, `infiquetra-claude-plugins`, and the private `home-lab`. Two of those are outside this session's authority, and the plan says so per unit and per Orchestrate run.

One decision is recorded as **void**. It was mis-entered by the controlling client and was never an operator decision; it is preserved in the archive rather than erased, because an audit trail that hides a mis-entry teaches nothing about how it happened.

The unit graph has one constraint that cannot be reordered: the portable site-profile contract must be verified before the repaired upstream release is activated, while synchronization must happen after it. Both edges are real and together they do not form a cycle. Across repositories, that constraint is carried by three named receipts rather than by ambient access.