### PR TITLE
docs(journal): portability pilot retrospective and reusable porting runbook

### DIFF
--- a/docs/engineering-journal/ARCHIVE.md
+++ b/docs/engineering-journal/ARCHIVE.md
@@ -1,5 +1,103 @@
 # Archive - shipped, rejected, and superseded items
 
+## 2026-08-23
+
+### SUPERSEDED - A completion watcher that can never fire looks exactly like work that never finished
+
+**Resolution.** Superseded by [A verification step that reports success for an
+unrelated reason is worth less than none](LEARNINGS.md), which generalises this
+instance together with five others from the same pilot. The mechanism recorded
+here is accurate and is cited by the successor as one of its six cases; what it
+lacked was the observation that the same defect was simultaneously live in the
+product, in the mutation harness, and in the repository gate. Archived rather
+than deleted, per this journal's convention.
+
+### A completion watcher that can never fire looks exactly like work that never finished
+
+**Author.** Jeff Cox and Claude
+
+**Context.** The cycle-7 review panel finished and wrote both artifacts. The coordinator's
+background watcher never reported them, so the coordinator sat idle while two complete,
+schema-valid reports sat on disk. The operator noticed and reconciled from the artifacts
+directly.
+
+**Evidence.** Background task `bo084hhi2` (PID 97405), the watcher loop in this session. Its
+completion test was:
+
+```bash
+mo=$( [ -f "$OX" ] && grep -c APPEND_HERE "$OX" || echo 1 )
+[ "$so" -gt 3000 ] && [ "$mo" -eq 0 ] && ...
+```
+
+**Mechanism.** `grep -c` prints the count *and* exits non-zero when the count is zero. Zero
+matches is the success condition being waited for, so on exactly that condition the command
+printed `0`, exited 1, and the `|| echo 1` branch fired too. `mo` became the two-line string
+`"0\n1"`, and `[ "0\n1" -eq 0 ]` is never true. The watcher was structurally incapable of
+reporting success: the closer the artifacts got to done, the more certainly it stayed silent.
+
+Two things made this worse than a stuck loop. It failed *only* in the success case, so every
+partial-progress poll behaved correctly and the bug was invisible until it mattered. And its
+silence was indistinguishable from the condition it was built to detect — a reviewer stalled
+mid-delivery with the marker still present — which is the failure this same session had already
+hit three times, so the silence read as expected rather than anomalous.
+
+**Generalizable rule.** Never let a predicate's success path depend on a command whose exit
+status disagrees with its output. For `grep -c`, capture the count with `$(grep -c X f || true)`,
+or test the file directly with `! grep -q X f`. More generally: a watcher must be able to fail
+*loudly*, so give it a bounded timeout that prints the observed state rather than one that
+prints nothing, and prefer checking the artifact and the reviewer's real foreground process over
+a derived boolean. When a watcher goes quiet on work that should be finishing, read the artifact
+before believing the watcher.
+
+### SUPERSEDED - A negative test that passed for the wrong reason reported coverage that did not exist
+
+**Resolution.** Superseded by the same successor entry, which cites this as its
+first case. The remedy recorded here — break the code on purpose and require the
+new assertions to fail — became the general habit rather than a credential-rule
+habit, and the successor states it for every kind of check rather than for
+must-not-fire tests alone. Archived rather than deleted, per this journal's
+convention.
+
+### A negative test that passed for the wrong reason reported coverage that did not exist
+
+**Author.** Jeff Cox and Claude
+
+**Context.** The credential-value rule was repaired once for grading the wrong span, and the
+repair broke in both directions: it cleared a real credential hidden behind a placeholder, and
+it rejected ordinary operational prose. Two independent reviewers found both on the next
+cycle. The repair had shipped with a must-not-fire test written specifically to catch the
+second class.
+
+**Evidence.** The cycle-4 negative set used `auth: see the runbook for the rotation
+procedure`. It passed. The cycle-5 reviewers used `token: rotation happens quarterly`, which
+failed. Both are the same shape — a credential-shaped key assigned English prose — and the
+difference is only that the first sentence begins with `see`, three characters, which falls
+under the rule's six-character length floor before any grading happens.
+
+**Mechanism.** The test exercised the length floor, not the rule it was written for. Its
+subject never reached the code under test, so it could not have failed no matter how wrong
+that code was. It looked like coverage of the false-positive category and was coverage of
+nothing.
+
+**Fix.** The replacement set is chosen so each case would fail for the *right* reason if the
+rule were wrong: first tokens that are long English words (`rotation`, `managed`,
+`internationalization`), capitalized forms, and a ticket number that carries a digit. Twenty
+eight assertions fail against the defective rule.
+
+**What surprised.** Reviewing my own test set would not have caught this. Reading it, the
+example plainly belongs to the category; only running it against deliberately broken code
+shows that it never touches the rule. Mutation is the only cheap check that distinguishes a
+test from a test-shaped statement.
+
+**Generalizable rule.** For any test that exists to prove a guard does *not* fire, verify it
+would fire if the guard were wrong. A negative case that is filtered out by a precondition
+before reaching the logic is worse than no test, because it is counted as coverage. Cheapest
+implementation: break the code on purpose and require the new assertions to fail. Every repair
+in this pilot now ships with that count recorded, which is how this one was caught.
+
+**Refs.** the upstream repository `infiquetra-claude-plugins`,
+cycle-5 reviews in [`docs/reviews/`](../reviews/).
+
 ## 2026-08-22
 
 ### SHIPPED - Emit the declared Fleet Core bundle so the package has a working entrypoint

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -1,5 +1,57 @@
 # Decisions - infiquetra-agent-plugins
 
+## 2026-08-23
+
+### Review rounds are bounded at three, and a round's repairs ship as one release
+
+**Author.** Jeff Cox and Claude
+
+**Decision.** A port under independent review gets at most three review rounds
+against a frozen candidate. Every confirmed finding from a round is batched into a
+single repair and a single release, and the fingerprint-bound evidence is re-run
+once per round rather than once per defect. If the third round still returns
+`repairs_requested`, work stops and the residual findings go to the operator with
+their evidence, rather than a fourth round beginning on the coordinator's own
+authority.
+
+**Rationale.** The UniFi pilot ran nine rounds and shipped one defect per release.
+Because the compatibility matrix and the post-activation readback are bound to the
+package fingerprint by test, each release invalidated both: nine ten-client matrix
+runs and eight readback captures for one port. Batching cycles 4 through 8 into
+one repair per round would have produced roughly two of those runs instead of six.
+
+The round bound is a separate lever from the batching and addresses a different
+failure. Rounds four through nine were all one rule, and the coordinator kept
+authorising its own next attempt because each round produced a real finding. A
+real finding is not evidence that another unattended round is the right response;
+after three, the operator is better placed to judge whether the rule needs a
+different approach than another repair.
+
+**Rejected alternatives.**
+
+- *Leave both unbounded, as the pilot ran.* This is the status quo that produced
+  the numbers above. Its one merit — every defect found is fixed immediately — is
+  preserved by batching, which fixes them all, just together.
+- *Bound the rounds but keep per-defect releases.* Keeps the evidence multiplier,
+  which is where the mechanical time actually went.
+- *Weaken the fingerprint binding so evidence survives a byte change.* Rejected
+  outright. That binding caught stale evidence repeatedly across the pilot and is
+  the reason the final record can be trusted. The cost is real and the answer is
+  fewer releases, not weaker evidence.
+- *Batch across rounds as well, reviewing only once at the end.* Discards the
+  independent check on each repair, which is what caught the two class-level
+  defects.
+
+**Exception.** A confirmed fail-open in a security rule is repaired and re-reviewed
+on its own, not batched. Holding a known-exploitable gap to fill a batch trades
+the wrong thing.
+
+**Revisit when.** A port hits the three-round bound twice, or a round's batch grows
+large enough that a reviewer cannot attribute a regression to a specific repair. The
+first says the bound is too tight for the work; the second says the batch is too
+coarse, and the batch should split before the bound moves.
+
+
 ## 2026-08-22
 
 ### Compatibility evidence is captured on the floor interpreter, by explicit path

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -2,85 +2,71 @@
 
 ## 2026-08-23
 
-### A completion watcher that can never fire looks exactly like work that never finished
+### A verification step that reports success for an unrelated reason is worth less than none
 
 **Author.** Jeff Cox and Claude
 
-**Context.** The cycle-7 review panel finished and wrote both artifacts. The coordinator's
-background watcher never reported them, so the coordinator sat idle while two complete,
-schema-valid reports sat on disk. The operator noticed and reconciled from the artifacts
-directly.
+**Context.** The UniFi portability pilot ran nine review cycles. Across them the
+same defect appeared six times, three times in the product and three times in the
+coordinator's own verification tooling, and it was never recognised as one defect
+until the retrospective. Each instance was fixed on its own terms and the class
+went on producing new ones.
 
-**Evidence.** Background task `bo084hhi2` (PID 97405), the watcher loop in this session. Its
-completion test was:
+**Evidence.** Six instances, all from this pilot:
 
-```bash
-mo=$( [ -f "$OX" ] && grep -c APPEND_HERE "$OX" || echo 1 )
-[ "$so" -gt 3000 ] && [ "$mo" -eq 0 ] && ...
-```
+| Instance | Reported | Actually |
+|---|---|---|
+| A must-not-fire test whose subject was three characters long | the false-positive class is covered | filtered by a length floor before reaching the rule |
+| A completion watcher testing `grep -c ... \|\| echo 1` | reviewers still working | the predicate could never be true, and only in the success case |
+| A mutation run whose anchors held real characters, in a file storing them escaped | six guards proved | nothing was replaced; the runs were of unmutated code |
+| A mutation run started from an already-failing baseline | eleven guards proved | every result unreadable against the noise |
+| A "survived" detector matching the restored run's `OK` | one mutation survived | it had matched the wrong section |
+| The repository gate's link check | repository links resolve | one resolved only via a sibling checkout on one machine |
 
-**Mechanism.** `grep -c` prints the count *and* exits non-zero when the count is zero. Zero
-matches is the success condition being waited for, so on exactly that condition the command
-printed `0`, exited 1, and the `|| echo 1` branch fired too. `mo` became the two-line string
-`"0\n1"`, and `[ "0\n1" -eq 0 ]` is never true. The watcher was structurally incapable of
-reporting success: the closer the artifacts got to done, the more certainly it stayed silent.
+**Mechanism.** Each is a check whose passing condition is satisfied by something
+other than the property it claims to establish — a precondition, an exit status
+that disagrees with its own output, an unmutated file, a noisy baseline, an
+adjacent line of output, a neighbouring directory on disk. Reading the check does
+not reveal this; every one of them reads correctly. Only running it against a
+world where the claimed property is false does.
 
-Two things made this worse than a stuck loop. It failed *only* in the success case, so every
-partial-progress poll behaved correctly and the bug was invisible until it mattered. And its
-silence was indistinguishable from the condition it was built to detect — a reviewer stalled
-mid-delivery with the marker still present — which is the failure this same session had already
-hit three times, so the silence read as expected rather than anomalous.
+Two of them share a sharper property worth naming on its own: they failed *only*
+in the success case. The watcher's predicate broke exactly when the artifacts
+completed, and the link check passed exactly on the machine where the link was
+wrong. A check that degrades gracefully announces itself; a check that fails only
+when it matters is silent precisely when it is needed.
 
-**Generalizable rule.** Never let a predicate's success path depend on a command whose exit
-status disagrees with its output. For `grep -c`, capture the count with `$(grep -c X f || true)`,
-or test the file directly with `! grep -q X f`. More generally: a watcher must be able to fail
-*loudly*, so give it a bounded timeout that prints the observed state rather than one that
-prints nothing, and prefer checking the artifact and the reviewer's real foreground process over
-a derived boolean. When a watcher goes quiet on work that should be finishing, read the artifact
-before believing the watcher.
+**Fix.** Three habits, each cheap:
 
+1. **Make every check fail on demand.** Break the property on purpose and require
+   the check to fail. For tests this is mutation; for a gate, feed it a violation;
+   for a watcher, hand it the state it is waiting for and confirm it fires.
+2. **Never let a success path depend on a command whose exit status disagrees with
+   its output.** `grep -c` prints a count and exits non-zero on zero matches, so
+   `$(grep -c X f || echo 1)` yields two lines on the success condition. Use
+   `$(grep -c X f || true)`, or test the file with `! grep -q X f`.
+3. **Require a green baseline before any differential run**, and assert on a
+   missing mutation anchor rather than proceeding. Both failures above were
+   invisible without these.
+
+**What surprised.** The product bug and the tooling bugs are the same bug. Nine
+review cycles hunted the first with increasing rigour while the harness doing the
+hunting carried three instances of it. Reviewers scored the code; nothing scored
+the scorer.
+
+**Generalizable rule.** For every check — test, gate, watcher, proof — state the
+property it establishes and the input that would make that property false, then
+confirm the check fails on that input. If it cannot be made to fail, it is not
+evidence, and counting it as coverage is worse than having none, because the gap
+is now believed closed.
+
+**Refs.** [The UniFi portability pilot retrospective](narratives/2026-08-23-unifi-portability-pilot-retrospective.md).
+Two entries superseded by this one and preserved in
+[`ARCHIVE.md`](ARCHIVE.md): the negative test that could not fail, and the
+completion watcher that could not fire.
 
 ## 2026-08-22
 
-### A negative test that passed for the wrong reason reported coverage that did not exist
-
-**Author.** Jeff Cox and Claude
-
-**Context.** The credential-value rule was repaired once for grading the wrong span, and the
-repair broke in both directions: it cleared a real credential hidden behind a placeholder, and
-it rejected ordinary operational prose. Two independent reviewers found both on the next
-cycle. The repair had shipped with a must-not-fire test written specifically to catch the
-second class.
-
-**Evidence.** The cycle-4 negative set used `auth: see the runbook for the rotation
-procedure`. It passed. The cycle-5 reviewers used `token: rotation happens quarterly`, which
-failed. Both are the same shape — a credential-shaped key assigned English prose — and the
-difference is only that the first sentence begins with `see`, three characters, which falls
-under the rule's six-character length floor before any grading happens.
-
-**Mechanism.** The test exercised the length floor, not the rule it was written for. Its
-subject never reached the code under test, so it could not have failed no matter how wrong
-that code was. It looked like coverage of the false-positive category and was coverage of
-nothing.
-
-**Fix.** The replacement set is chosen so each case would fail for the *right* reason if the
-rule were wrong: first tokens that are long English words (`rotation`, `managed`,
-`internationalization`), capitalized forms, and a ticket number that carries a digit. Twenty
-eight assertions fail against the defective rule.
-
-**What surprised.** Reviewing my own test set would not have caught this. Reading it, the
-example plainly belongs to the category; only running it against deliberately broken code
-shows that it never touches the rule. Mutation is the only cheap check that distinguishes a
-test from a test-shaped statement.
-
-**Generalizable rule.** For any test that exists to prove a guard does *not* fire, verify it
-would fire if the guard were wrong. A negative case that is filtered out by a precondition
-before reaching the logic is worse than no test, because it is counted as coverage. Cheapest
-implementation: break the code on purpose and require the new assertions to fail. Every repair
-in this pilot now ships with that count recorded, which is how this one was caught.
-
-**Refs.** the upstream repository `infiquetra-claude-plugins`,
-cycle-5 reviews in [`docs/reviews/`](../reviews/).
 
 ### The credential detector read the wrong span, so `Bearer` cleared the token behind it
 

--- a/docs/engineering-journal/narratives/2026-08-23-unifi-portability-pilot-retrospective.md
+++ b/docs/engineering-journal/narratives/2026-08-23-unifi-portability-pilot-retrospective.md
@@ -1,0 +1,164 @@
+# The UniFi portability pilot, and where its twenty-eight hours went
+
+Date: 2026-08-23
+Author: Jeff Cox and Claude
+Related entries:
+
+- [A verification step that reports success for an unrelated reason](../LEARNINGS.md) — the generalizable rule this pilot produced.
+- [Bound review rounds, and batch a round's repairs into one release](../DECISIONS.md) — the convention adopted because of it.
+- [Portable plugin port runbook](../../runbooks/portable-plugin-port.md) — the checklist that replaces re-deriving this.
+- [The repository gate's link checker resolves against the filesystem](../QUEUED.md) — the one gap left open.
+
+## Context
+
+The pilot ported the Claude Code `unifi` plugin into a portable Agent Plugins 1.0
+package. It merged as `558564cb` with both independent reviewers accepting. The
+next port of a Claude plugin into this catalog starts from what this pilot built,
+so the question worth answering is not whether it succeeded but which of its
+twenty-eight hours the next one has to spend again.
+
+The figures below come from commit timestamps, pull-request records, and the
+preserved evidence. They are *elapsed* times spanning unattended agent runs and
+operator-away periods, so they measure calendar cost, not effort.
+
+## Narrative
+
+### Where the time went
+
+The repository spans `2026-08-22T02:29Z` to `2026-08-23T06:12Z` — 27 hours and 43
+minutes, four pull requests, forty-six commits.
+
+| Phase | Elapsed | Share | What happened |
+|---|---|---|---|
+| Plan and document review (PR #1–2) | ~2h | 7% | A 723-line plan with explicit non-goals, reviewed |
+| Build and first assessment (PR #3) | ~11.5h | 41% | The port, the tooling, the first ten-client matrix, cycle-1 review |
+| Review and repair (PR #4, 40 commits) | ~13.3h | 48% | Cycles 2 through 9 |
+
+Nearly half the pilot was review and repair, and the dominant cost inside it was
+a single validation rule. The credential-value rule first appears at `18:41Z` on
+22 August and its last repair lands at `06:11Z` on 23 August: **eleven and a half
+hours, 41% of the entire pilot, on one rule in one file.** Six of nine review
+cycles and five of seven upstream releases were that rule.
+
+A second figure explains why each repair cost so much. The compatibility matrix
+and the post-activation readback are bound to the package fingerprint by test, so
+any byte change invalidates both. The pilot produced **nine ten-client matrix runs
+and eight readback captures**. That binding is correct — it caught stale evidence
+repeatedly, which is exactly what it exists for — but repairs shipped one defect
+per release, so the multiplier applied six times over.
+
+### The one rule
+
+The contract is a sentence: a site profile states intent and points at where a
+secret lives; it never carries one. Implementing that sentence took five upstream
+releases.
+
+| Release | What the rule did | What it was |
+|---|---|---|
+| 2.0.2 | Credential-shaped key plus high-entropy value | Value grading |
+| 2.0.3 | Window widened, then replaced by a walk with a digit-or-24 discriminator | Value grading, twice |
+| **2.0.4** | **The key decides; the value is not graded** | **Class-level** |
+| 2.0.5 | Assignment scoped to `\n` | Instance |
+| **2.0.6** | **The line-break set named, derived from `splitlines()`** | **Class-level** |
+
+Two insights ended two runs of defects, and both arrived only after several
+instance repairs had failed. Everything between them was chasing the input that
+had just broken.
+
+The entropy phase deserves recording because it could not have worked. Separating
+a credential from prose by properties of the literal string is not decidable, and
+the heuristics were measurably anti-correlated with the target: every false
+positive sat at 2.585 bits of entropy per character, every missed password
+between 2.500 and 3.116. The rule fired on the lower-entropy inputs and passed the
+higher-entropy ones. Changing the question — grade the key, not the value — made
+the problem decidable in one move.
+
+### Why instance fixes kept replacing class rules
+
+Five causes, and they compound.
+
+**The failing example was treated as the specification.** Each repair was derived
+from the input that had just failed rather than from the predicate the contract
+requires. *`oauth2` was refused* became *make `oauth2` pass*. *`\n` was swallowed*
+became *handle `\n`*. The question that ended each run — what decision does this
+rule have to make, and what is the authority for it? — was never asked until
+cycles 6 and 8, and both times asking it closed the line of defects immediately.
+
+**Each guard inherited the fix's scope.** The corpus added in cycle 7 was built
+specifically to catch divergence between the three copies of the rule. It pinned
+`\n` and nothing else, so it certified the very repair it existed to interrogate.
+A guard scoped to the instance cannot detect the class.
+
+**The brief propagated the narrowness to the reviewers.** The review briefs said,
+in effect, *here is what I just fixed, verify it*. The reviewers verified it.
+Cycle 8's brief was the first to say "probe them, do not reason about them" and to
+enumerate candidate inputs, and it produced the class-level finding on the first
+attempt. The reviewers were exactly as good as the question they were asked.
+
+**Agreement was asserted where it was easy to observe, not where it mattered.**
+Three copies of one rule, with drift tests comparing constants, compiled patterns
+and helper outputs. Every part matched while the verdicts differed.
+
+### Verification steps that reported success for unrelated reasons
+
+The pilot's unifying defect appeared in the product and in the coordinator's own
+tooling in the same form six times.
+
+| Incident | Why it reported wrongly |
+|---|---|
+| Completion watcher never fired | `grep -c` prints `0` *and* exits non-zero, so the success branch and the `\|\| echo 1` fallback both fired. It failed only in the success case. |
+| Mutation run invalid, twice over | Anchors written with real characters where the file stores them escaped, so nothing was replaced; and a baseline that was already failing. |
+| Mutation "survived" detector | Matched the *restored* run's `OK` rather than the mutant's. |
+| Repository gate green locally | A journal link resolved only because a sibling checkout exists on one machine. CI caught it. |
+| Cursor recorded as failing | An isolated `HOME` stripped real authentication; the operator corrected a false result in the deliverable. |
+| Grok and Agy recorded nothing | Auto-trust wrappers resolve the real binary through `$HOME`, which an isolated home does not contain. |
+
+The last two share a cause with the third-from-last: **the test environment
+differed from the environment the claim was about.** An isolated client home is
+not the operator's client; one developer's disk is not CI's disk.
+
+### What went right, and should not be re-litigated
+
+Scope held. The plan carried explicit non-goals and they survived contact with
+nine review cycles: the negative `Retry-After` defect was filed as
+`infiquetra-claude-plugins#770` in the repository that owns it rather than fixed
+in the pilot, the marketplace manifest stayed deferred, and three standing
+advisories stayed advisory. The one drift risk was the coordinator's — closing an
+advisory that had not been authorized — and it was stopped and raised instead.
+
+Custody discipline held too. Every repair to a byte-copied or transformed path
+went upstream first and came back through a resync, across seven upstream
+releases. Not once did a repair get made in the derived copy for convenience.
+
+And the fingerprint binding, which cost the most mechanical time, is the reason
+the evidence is trustworthy. It is not a candidate for weakening.
+
+## Outcome
+
+The pilot's real deliverable is not the UniFi package. It is a porting platform:
+a custody model, a sync engine, a repository gate, fingerprint-bound evidence, a
+ten-client assessment method, and a review protocol. Roughly 2,400 of about 3,270
+lines of tooling are already package-agnostic.
+
+What this retrospective changes:
+
+- One generalizable rule enters `LEARNINGS.md`, absorbing two entries that were
+  instances of it. Recorded there, not repeated here.
+- One convention enters `DECISIONS.md`: bounded review rounds, and a round's
+  repairs batched into a single release.
+- A versioned runbook at `docs/runbooks/portable-plugin-port.md` replaces
+  re-deriving the method. It carries the checklist; this narrative carries the
+  reasons.
+
+A projection, offered as a projection rather than a measurement: a comparable
+plugin should take six to nine hours on that path, because the tooling exists,
+one matrix run replaces nine, and one or two review rounds replace nine.
+
+## References
+
+- Merge commit `558564cb`; pull requests `infiquetra-agent-plugins#1` through `#4`.
+- Upstream releases `infiquetra-claude-plugins#765`, `#766`, `#767`, `#768`, `#769`, `#771`, `#774`, `#775`.
+- [`docs/reviews/`](../../reviews/) — twenty-eight review artifacts across nine cycles, including each cycle's reconciliation.
+- [`docs/evidence/2026-08-22-unifi-compatibility-matrix.md`](../../evidence/2026-08-22-unifi-compatibility-matrix.md) and its eight superseded predecessors.
+- [`docs/evidence/2026-08-23-cycle9-mutation-proof-portable-copies.txt`](../../evidence/2026-08-23-cycle9-mutation-proof-portable-copies.txt) and the upstream loader proof beside it.
+- [`docs/plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md`](../../plans/2026-08-21-unifi-fleet-core-portability-pilot-plan.md) — the plan whose non-goals held.

--- a/docs/runbooks/portable-plugin-port.md
+++ b/docs/runbooks/portable-plugin-port.md
@@ -1,0 +1,138 @@
+# Runbook: porting a Claude plugin into the portable catalog
+
+**Version 1.0.0** · Adopted 2026-08-23 · Derived from the UniFi pilot
+
+Record the version you followed in the port's plan and its saga tick. Change the
+minor version when a step is added or reordered; the major when the phase
+structure changes.
+
+This runbook is the checklist. It carries no narrative and no rationale — those
+live in [the pilot retrospective](../engineering-journal/narratives/2026-08-23-unifi-portability-pilot-retrospective.md)
+and in [`DECISIONS.md`](../engineering-journal/DECISIONS.md).
+
+---
+
+## Entry criteria
+
+Do not begin porting until every line is true.
+
+- [ ] Upstream plugin sits at a pinned commit; its own suite is green there.
+- [ ] Target tooling is parameterized for the new package (see [Reusable assets](#reusable-assets)) and `scripts/check_repo.py` passes on the empty port.
+- [ ] Every validation rule the plugin carries is inventoried, each with a named **predicate** and a named **authority** (a standard-library function, a specification, a schema — not a description).
+- [ ] The client roster and assessment method are scripted, not to be re-derived.
+- [ ] The Python floor is decided and a matching interpreter exists.
+- [ ] Non-goals are written down.
+
+---
+
+## Phase 0 — Prepare (serial, ~1h)
+
+- [ ] Set the package identity in the two package-specific tools.
+- [ ] Classify **every** path as `upstream-byte-copy`, `deterministic-transform`, or `target-owned`, and record it in `PROVENANCE.json`.
+- [ ] Confirm the floor interpreter by explicit path, never as `python3`.
+
+## Phase 1 — Port (parallel, concurrency cap 3)
+
+Three lanes that share no files. Cap is 3 because the fleet runs above Haiku.
+
+- [ ] **Lane A** — byte copies, provenance manifest, sync script wiring.
+- [ ] **Lane B** — target-owned surface: README, entrypoints, package manifest.
+- [ ] **Lane C** — bundling and deferred inventory, if the plugin has dependencies.
+
+Sequence, never parallelize, any two units that touch one file.
+
+## Phase 2 — Rule audit (serial) — *do not skip*
+
+For each validation rule, in this order:
+
+- [ ] State the **predicate**: the decision the rule must make.
+- [ ] Name the **authority** for it, and **derive it at test time** rather than restating it. A test that rebuilds the rule's premise from its authority fails when the premise moves; a copied constant does not.
+- [ ] Write the **class corpus** — every member of the input class, in every vulnerable shape — *before* the rule ships.
+- [ ] Where a rule exists in more than one copy, assert agreement on **verdicts**, not on constants, patterns, or helper outputs.
+
+## Phase 3 — Freeze and gather evidence (serial)
+
+- [ ] Repository gate and full suite green.
+- [ ] Floor verified from **staged bytes**, not the source tree; every entrypoint runs credential-free.
+- [ ] Freeze the candidate: exact commit recorded, working tree clean.
+- [ ] **One** client matrix run and **one** readback, bound to the shipped fingerprint.
+- [ ] Mutation proof per rule copy, bound by test to the committed blobs.
+
+## Phase 4 — Review (2 reviewers in parallel, **maximum 3 rounds**)
+
+- [ ] Both reviewers independent, models confirmed by live readback before briefing.
+- [ ] Brief on the **class**: require reviewers to enumerate a rule's input space and probe it, and to state the rule's authority. Do not brief only on what was just repaired.
+- [ ] Reviewers verify the commit id and a clean tree before scoring.
+- [ ] Reports delivered incrementally behind a completion marker; verify the artifact and the real process, never a status badge.
+- [ ] Each round batches **all** confirmed findings into one repair and one release. See [the decision](../engineering-journal/DECISIONS.md) on round bounds.
+
+---
+
+## Stop conditions
+
+Stop and report rather than continuing when any of these hold.
+
+| Condition | Action |
+|---|---|
+| A confirmed fail-open in a security rule | Stop immediately. Do not batch it with anything. |
+| Reviewers split on **fact** | Decide empirically; the reproduction is the arbiter, not the reviewer's rank. |
+| Reviewers split on **severity** | Operator decides. |
+| Three rounds exhausted | Stop with residuals listed and evidence preserved. |
+| Any verification harness found unsound | Discard that round's evidence and re-run. A harness that cannot fail proves nothing. |
+
+## Completion evidence
+
+All required, on the exact frozen commit.
+
+- [ ] Typed `review_result.v1` **accepted** from both reviewers.
+- [ ] Repository gate, full suite, and upstream suite green.
+- [ ] Floor verified from staged bytes.
+- [ ] One fingerprint-bound matrix and readback.
+- [ ] Mutation proof per rule copy, bound by test to committed blobs.
+- [ ] Provenance digests equal across every copy of a byte-copied path.
+
+---
+
+## Reusable assets
+
+Do not rebuild these.
+
+| Asset | State | Action for a new package |
+|---|---|---|
+| `scripts/check_repo.py` | Package-agnostic | Use as-is |
+| `scripts/bundle_fleet_module.py` | Package-agnostic | Use as-is |
+| `scripts/check_compatibility_matrix.py` | Near-generic | Set `PACKAGE_ROOT` |
+| `scripts/sync_vendor_source.py` | Near-generic | Set `SOURCE_PACKAGE_PATH`, `TARGET_PACKAGE`, and the copied-path table |
+| `PROVENANCE.json` three-way custody schema | Generic | Reuse the schema |
+| `MutationProofBindingTest` pattern | Generic | Reuse; it fails when a graded file changes without its proof |
+| The credential value rule and its corpus | Stable at unifi 2.0.6 | Reuse for any profile-like contract rather than re-deriving |
+| Review brief template | Evolved through nine cycles | Start from the cycle-9 brief |
+| Python 3.12.13 virtualenv | Built | Reuse |
+
+## Client assessment
+
+Ten clients, four stages each: placement, discovery, load, invocation. Every quirk
+below was learned the expensive way.
+
+| Client | Quirk |
+|---|---|
+| Cursor | Must run against the **real authenticated** `HOME`. An isolated home strips authentication and produces a false failure. |
+| Grok | Needs `GROK_AUTO_TRUST_REAL_BIN` under an isolated home. `plugin details` takes the plugin **name**, not the install id. |
+| Agy | Needs `AGY_AUTO_TRUST_REAL_BIN` under an isolated home. |
+| Qwen | Installer prompts for confirmation on stdin; with no answer it lists and exits without installing. Adds one metadata file to the extension directory. |
+| Gemini | `skills link` prompts on stdin and hangs rather than declining when stdin is closed. |
+| Muse | `--force` is required on the JSON install to report a digest once placement has installed the unit. |
+| Hermes | Run in an isolated home only. Confirm the live skills directory is unchanged before and after. |
+| Codex | Refuses the package root with an actionable message; load and invocation stay blocked. |
+
+Unset `UNIFI_*`-equivalent environment variables for every invocation. A client
+that needs credentials before it will report state gets a **blocked** stage with
+the requirement named, never a satisfied one.
+
+## Anti-patterns
+
+- Repairing a byte copy or a transform in place. Repairs go upstream and come back through a resync.
+- Weakening the fingerprint binding to avoid re-running evidence. Batch the repairs instead.
+- Deriving a fix from the failing example rather than from the rule's predicate.
+- Adding a guard scoped to the instance just repaired.
+- Editing evidence to match a moved tree. Re-run it, and preserve the superseded record with its reason.


### PR DESCRIPTION
Four durable artifacts from the UniFi portability pilot, split so no lesson appears in more than one place.

## What each owns

**`narratives/2026-08-23-unifi-portability-pilot-retrospective.md`** — the story, told once. The 27h43m timeline, the one validation rule that consumed 41% of the pilot, the five-release progression separating instance fixes from class fixes, the six verification-integrity incidents, and what scope and custody discipline got right.

**`LEARNINGS.md`** — one entry replacing two. *A verification step that reports success for an unrelated reason is worth less than none.* Six instances, three in the product and three in the coordinator's own tooling. The two entries it generalises move to `ARCHIVE.md` with supersession notes, per this journal's convention.

**`DECISIONS.md`** — one entry. Review rounds bounded at three; a round's repairs ship as one release. Four rejected alternatives, including weakening the fingerprint binding, refused outright.

**`docs/runbooks/portable-plugin-port.md` v1.0.0** — new directory. Checklist only: entry criteria, five phases, concurrency cap, stop conditions, completion evidence, reusable-asset table with exact parameterization deltas, and the ten-client quirk table.

## Why the split

The pilot's most expensive habit was fixing an instance and calling the class closed. Putting the same lesson in three files is that habit applied to documentation. Each artifact here has one job and cites the others rather than restating them — verified: the generalizable rule appears only in LEARNINGS, the timeline figures only in the narrative, the round-cap rationale only in DECISIONS.

## Reusable, so the next port doesn't rebuild it

Roughly 2,400 of ~3,270 lines of tooling are already package-agnostic. `check_repo.py` and `bundle_fleet_module.py` are usable as-is; `check_compatibility_matrix.py` and `sync_vendor_source.py` need a package-identity constant each. The runbook records exactly which.

## Verification

- `scripts/check_repo.py` green — including its link check, which now covers these files
- 437 tests green
- `git diff --check` clean
- No broken internal links; every relative path stays inside the repository

Documentation only. No code, tooling, or evidence changed.

https://claude.ai/code/session_01HmDe8GFuZWx5U68iASA1ge