### PR TITLE
docs(retro): mission-control migration retrospective and runbook v1.1.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,11 @@
   is the approved run plan for the mission-control package port. It has been
   executed and completed across all implementation units under porting runbook
   v1.0.0.
+- [Mission Control migration retrospective](retros/issue-9-2026-08-25.md)
+  is the evidence-based retrospective of that run: what made the unattended
+  execution work, every deviation with its mechanism, the lessons folded into
+  runbook v1.1.0, and the upstream filing dispositions including the one
+  declined proposal.
 - [PR #6 independent code reviews](code-reviews/2026-08-24-pr-6-code-review-index.md)
   indexes the five review rounds that preceded the porting tools being merged,
   each preserved byte-for-byte with the revision it reviewed and its digest.

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -2,6 +2,48 @@
 
 ## 2026-08-25
 
+### Async worker watchers trigger on branch commits and runner liveness, never agent status
+
+**Author.** Jeff Cox and Claude (mission-control migration retrospective,
+[#9](https://github.com/infiquetra/infiquetra-agent-plugins/issues/9))
+
+**Decision.** A watcher over a dispatched CLI-agent unit wakes on durable side
+effects — a commit appearing on the unit's branch, or its runner process dying —
+with agent status used only as a long-threshold stall signal that the agent's
+own heartbeat resets. Status alone never triggers action.
+
+**Rationale.** Antigravity reports `done` at its async turn boundary while a
+background runner keeps executing; the mcport-9-resume1 run burned three watcher
+redesigns on this (a 5-minute idle alarm fired mid-work twice) before the
+commit-triggered design held for the rest of the run.
+
+**Rejected alternatives.** Status-polling watchers (false alarms by
+construction); short idle thresholds without heartbeat reset (fire during any
+long grind, such as a 47-minute mutation-anchor run).
+
+**Revisit when.** A driven CLI exposes a first-class completion signal distinct
+from its conversational turn state.
+
+### Record-only orchestration branches are marked merge=false at creation
+
+**Author.** Jeff Cox and Claude (mission-control migration retrospective, #9)
+
+**Decision.** Any orchestrate unit whose branch exists to be read rather than
+landed — a review controller, a doc-review unit, a unit that stopped on a
+blocked marker — carries `merge=false` in the run state, set the moment its
+nature is known.
+
+**Rationale.** `land` merges every done unit with commits and applies no review
+or content gating in selection. When the first U8 evidence unit stopped by
+committing `.orchestrate-unit-blocked.md`, only an immediate `merge=false` edit
+kept the blocked marker off the integration lane.
+
+**Rejected alternatives.** Land-time vigilance (one missed `land` ships the
+marker); deleting the blocked branch immediately (destroys the record before its
+content is durably quoted into the child issue).
+
+**Revisit when.** Orchestrate grows a first-class record-only unit type.
+
 ### Portable mission-control package port executed under runbook v1.0.0 (U9)
 
 **Author.** Jeff Cox and Antigravity (orchestrated unit U9, issue #19)

--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -2,6 +2,30 @@
 
 ## 2026-08-25
 
+### An async CLI agent's "done" status is a turn boundary, not completion
+
+**Author.** Jeff Cox and Claude (mission-control migration retrospective,
+[#9](https://github.com/infiquetra/infiquetra-agent-plugins/issues/9))
+
+**Context.** Driving five Antigravity units unattended through Herdr during the
+mcport-9-resume1 run.
+
+**Evidence.** The U8 evidence unit showed `done` 75 seconds after launch while
+its background runner was executing the ten-client assessment; the cycle-16 unit
+ground 68 mutation anchors for ~47 minutes of `done` status punctuated by a
+4-minute self-scheduled heartbeat; after each turn a CLI-feedback dialog
+occupied the composer and could swallow a follow-up prompt
+([retro §2.5](../retros/issue-9-2026-08-25.md)).
+
+**Mechanism.** The CLI ends its interactive turn and self-schedules background
+work; the session multiplexer reads turn state, so "done" means "not currently
+conversing," and anything sent to the composer before the dialog is cleared is
+captured by the dialog, not the agent.
+
+**Generalizable rule.** Judge an async worker by durable side effects — commits,
+artifacts, live processes — never by its conversational state, and clear its
+composer before prompting into an existing session.
+
 ### Package-internal asset paths must avoid assuming fixed ancestor repository depth
 
 **Author.** Jeff Cox and Antigravity

--- a/docs/engineering-journal/QUEUED.md
+++ b/docs/engineering-journal/QUEUED.md
@@ -1,5 +1,21 @@
 # Queued work - infiquetra-agent-plugins
 
+## Consume the eight open upstream mission-control filings via a deliberate repin + resync
+
+The #9 migration filed eight defects/enhancements against
+`infiquetra/infiquetra-claude-plugins`, all open as of 2026-08-25: #818–#822
+(during the run: stale 2.1.0 paths, `/issue` self-alias, README `flow`
+omission, `beads-config.json` help text, `sync_template_docs.py` `parents[3]`)
+and #828–#830 (at the retrospective: module-scope `yaml` import deferral, the
+two tests' `parents[3]` assumptions, an upstream card-validator
+verdict-agreement test). When upstream lands any of them, the fix reaches this
+repository only through the resync policy — repin, `sync_vendor_source.py
+--check`, re-run the suites, and re-run exactly the fingerprint-bound evidence
+whose binding moved — never an in-place edit. One related proposal was
+deliberately **declined**, not deferred (restructuring
+`test_prompt_alignment.py`'s repository-structural premises); the
+[retrospective](../retros/issue-9-2026-08-25.md) records all dispositions.
+
 ## The link checker validates against the filesystem, not against the repository
 
 `check_repo.py` resolves each local markdown link with `(document.parent /

--- a/docs/retros/issue-9-2026-08-25.md
+++ b/docs/retros/issue-9-2026-08-25.md
@@ -1,0 +1,121 @@
+# Retrospective — mission-control migration (#9, run `mcport-9-resume1`)
+
+**Date.** 2026-08-25 · **Scope.** Thread-scoped retro on parent #9 and children #10–#19 ·
+**Evidence base.** The eleven issues, PRs #20/#21/#23/#24 (verified merged as squashes
+`8e2b47b`/`3948525`/`d23cb91`/`ef04797`), the 16 run-window `review_result.v1` artifacts under
+[`docs/code-reviews/`](../code-reviews/), the orchestrate run state, and repository truth at
+`origin/main` = `ef04797`. Every load-bearing claim below was re-verified against those sources at
+retro time; nothing is reconstructed from session memory alone. No saga exists for this thread (it
+ran under orchestrate), so the saga-telemetry passes report no data by construction, not by omission.
+
+**Diff vs last retro.** This is the repository's first `docs/retros/` document. The nearest prior
+artifact is the [pilot retrospective](../engineering-journal/narratives/2026-08-23-unifi-portability-pilot-retrospective.md);
+where the pilot's lessons were tested by this run, the outcome is noted inline.
+
+**Outcome in one line.** Ten child cards, fourteen Saga Code Review processes (Grok 4.6 xhigh) with
+fourteen acceptances — thirteen at cycle 1, one (U9) at cycle 2 after a one-line repair — four
+serialized main merges, one governed stop-and-repair train, roughly 7½ hours from wave-1 dispatch to
+the final merge, fully unattended.
+
+---
+
+## 1. What made the unattended run work
+
+1. **Decision-complete task texts.** Every dispatch carried deliverables, constraints, verification
+   commands, commit shape, and stop conditions, plus "never stop on a question — take the most
+   defensible option and record it." Zero of 14 worker dispatches stalled on a question.
+2. **One review process per frozen revision, serialized landing.** Every lens result carries
+   `revision_binding`; no review examined a moving target; nothing landed unreviewed.
+3. **Orchestrator verification before every submission.** Every gate re-run first-hand; evidence
+   claims probed, not relayed (U7's defective probe records were caught and reproduced-corrected
+   before submission).
+4. **The judgment-item pattern.** Every deviation or ambiguity went to the reviewer explicitly in
+   the submission, so acceptance was informed rather than surprised. 13/14 processes closed at
+   cycle 1 with zero findings.
+5. **Stop conditions workers obeyed, plus precedented repair machinery.** The U8 evidence unit hit a
+   real blocker, committed its blocked report (`080b535`), and finished. The U3/U5→cycle-15
+   precedent was reused as U8a + U8b (cycle-16), turning a hard stop into a ~2-hour governed repair.
+6. **Content-addressed evidence binding.** The matrix binds `$.package.{file_count,tree_sha256}`,
+   the mutation proof binds file digests — never commit ids. This survived docs-only freeze commits
+   and the squash-merge policy surprise; the matrix checker passed unchanged on main.
+7. **Watchers keyed on durable signals** — branch commits and runner liveness, never agent status —
+   plus a short launch-verification timer on every dispatch.
+8. **One idempotent board path + per-child SHA-chain comments.** Closeout board readback was a
+   single query: 10/10 Done, Objective `improve-agent-plugins` ×10, `attempts: 1` on every write.
+9. **Prospective-only operator amendment.** The mid-run pool change (sixth pass) touched forward
+   text only; five Antigravity units then executed with the model readback verified at each launch.
+10. **`merge=false` on record-only branches** (review controller, doc reviews, the blocked unit), so
+    `land` could never drag a non-deliverable into the lane.
+
+## 2. Deviations, failures, and mechanisms
+
+1. **The U8 stop — harness seam.** `assess_clients.py` hard-raised for skill-scoped clients on any
+   entrypoint outside a skill unit; the pilot's geometry (skill-resident entrypoints) was baked into
+   a graded tool as a global refusal, and mission-control is the first package-root-entrypoint
+   package. Fixed in U8a: invocation recorded **blocked-in-advance** per client; unifi behavior
+   byte-identical. Cost ≈ 2 hours.
+2. **The run's only review finding: a hand-transcribed identity cell.** U9's Packages table pinned
+   UniFi at `ed72f439` (a fleet-core lineage revision) where `plugins/unifi/PROVENANCE.json` records
+   `818fd684`/2.0.6. Mechanism: a hand-authored catalog row with no derivation and no pin test.
+   Caught by the review's shipped-behavior-parity dimension; repaired in one line.
+3. **Squash-only merge policy discovered at merge time.** The integration submission and PR #23 body
+   stated a merge-commit landing; the repository rejects merge commits. No material impact
+   (content-addressed bindings held; nothing rewritten; per-unit SHAs stay resolvable via permanent
+   PR refs). Disclosed on #18.
+4. **Worker probe evidence was reconstructed, not captured.** Two of U7's committed probe records
+   could not have run as written (invalid syntax; a tautology). Substance was real and was
+   reproduced first-hand; the committed record was wrong as written.
+5. **Antigravity session mechanics** cost three watcher redesigns: `done` is an async turn boundary,
+   the CLI-feedback dialog occupies the composer between turns, and self-scheduled heartbeats flip
+   status. Final design: commit-triggered, with a long idle threshold the heartbeat resets.
+6. **Codex rejects task text beginning with `/`** (namespace collision); one unit re-dispatched.
+7. **Orchestrator-side friction**: an output-filtering shell proxy garbled verification output three
+   times (resolved via plumbing commands); a cwd-relative state file failed the same way twice;
+   `land` under a checked-out run branch needs a reset-before-use discipline.
+8. **Card-vs-pin drift caught at filing time.** #19 enumerated an extra stale-path site (the agent
+   file); the pin shows it clean; the filing (#818) records only the six verified sites.
+
+## 3. Lessons applied (R1–R6 → runbook v1.1.0)
+
+Applied to [`docs/runbooks/portable-plugin-port.md`](../runbooks/portable-plugin-port.md) in the
+same change as this document:
+
+- **R1** Merge-policy preflight before any text states a merge form (entry criteria).
+- **R2** Evidence binds to content — tree hashes and file digests, never commit ids (Phase 3).
+- **R3** Hand-authored identity rows are derived from their authority or pinned by a test in the
+  same commit (completion evidence).
+- **R4** Capable-of-failing probes are captured transcripts, pasted verbatim (Phase 2).
+- **R5** A fleet harness records one client's true variance as that row's blocked outcome, never a
+  global refusal (anti-patterns).
+- **R6** The orchestrated per-unit loop: verify first-hand → settle → submit with judgment items →
+  land → persist typed artifacts → close with the SHA chain (new section).
+
+Operator-consumed separately (not in this repository): the client/ops quirks D1–D5 (Antigravity
+turn-boundary and dialog mechanics, the Codex leading-slash rule, cwd-sensitive tooling, proxy-
+garbled verification output, re-verify-at-the-pin filing discipline) go to Agent Operations daily
+history directly.
+
+## 4. Upstream dispositions (infiquetra-claude-plugins)
+
+Filed during the run, all open: **#818** (stale 2.1.0 paths), **#819** (`/issue` self-alias),
+**#820** (README skills table omits `flow`), **#821** (`rollout update` names removed
+`beads-config.json`), **#822** (`sync_template_docs.py` `parents[3]` depth assumption).
+
+Filed at this retrospective per operator approval:
+
+- **#828** — defer the module-scope `import yaml` in `sdlc_manager.py:83` so PyYAML-free commands
+  and `--help` work (enhancement; downstream had to add PyYAML to CI and the assessment venv).
+- **#829** — remove the fixed `parents[3]` repository-depth assumptions from
+  `test_issue_contract_parity.py:35` and `test_prompt_alignment.py:8` (defect; sibling of #822,
+  which scoped its fix to the script only).
+- **#830** — add an upstream verdict-agreement test for the two card-validator implementations, on
+  the proven 37-case pattern with a loud explicit skip when the home-lab authority checkout is
+  unavailable (enhancement).
+
+**Declined (recorded, not filed):** the proposal to restructure `test_prompt_alignment.py`'s six
+repository-structural premises (marketplace root, `plugins/saga` sibling, and kin) for portability.
+Upstream is unaffected in place; downstream custody already handles it as dropped-from-source; the
+operator declined the filing at this retrospective.
+
+All eight open filings reach this repository only through a later deliberate repin + resync (see
+`QUEUED.md`); nothing is repaired downstream in place.

--- a/docs/runbooks/portable-plugin-port.md
+++ b/docs/runbooks/portable-plugin-port.md
@@ -1,6 +1,7 @@
 # Runbook: porting a Claude plugin into the portable catalog
 
-**Version 1.0.0** · Adopted 2026-08-23 · Derived from the UniFi pilot
+**Version 1.1.0** · Adopted 2026-08-23 · Amended 2026-08-25 from the
+[mission-control retrospective](../retros/issue-9-2026-08-25.md) · Derived from the UniFi pilot
 
 Record the version you followed in the port's plan and its saga tick. Change the
 minor version when a step is added or reordered; the major when the phase
@@ -22,6 +23,7 @@ Do not begin porting until every line is true.
 - [ ] The client roster and assessment method are scripted in `scripts/assess_clients.py`, not to be re-derived. Print the plan with `python3 scripts/assess_clients.py --package <package>` before running it.
 - [ ] The Python floor is decided and a matching interpreter exists.
 - [ ] Non-goals are written down.
+- [ ] The repository's allowed merge methods are read (`gh repo view --json squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed`) before any plan, review contract, or PR text states a merge form.
 
 ---
 
@@ -49,6 +51,7 @@ For each validation rule, in this order:
 - [ ] Name the **authority** for it, and **derive it at test time** rather than restating it. A test that rebuilds the rule's premise from its authority fails when the premise moves; a copied constant does not.
 - [ ] Write the **class corpus** — every member of the input class, in every vulnerable shape — *before* the rule ships.
 - [ ] Where a rule exists in more than one copy, assert agreement on **verdicts**, not on constants, patterns, or helper outputs.
+- [ ] Record every capable-of-failing probe as a **captured transcript** — the exact command and its output pasted verbatim, never reconstructed after the fact.
 
 ## Phase 3 — Freeze and gather evidence (serial)
 
@@ -57,6 +60,7 @@ For each validation rule, in this order:
 - [ ] Freeze the candidate: exact commit recorded, working tree clean.
 - [ ] **One** client matrix run and **one** readback, bound to the shipped fingerprint.
 - [ ] Mutation proof per rule copy, bound by test to the committed blobs.
+- [ ] Every evidence binding names **content** — the package tree hash or file digests, never a commit id. A freeze record pins the package tree hash, not its own commit.
 
 ## Phase 4 — Review (2 reviewers in parallel, **maximum 3 rounds**)
 
@@ -90,8 +94,19 @@ All required, on the exact frozen commit.
 - [ ] One fingerprint-bound matrix and readback.
 - [ ] Mutation proof per rule copy, bound by test to committed blobs.
 - [ ] Provenance digests equal across every copy of a byte-copied path.
+- [ ] Every hand-authored catalog or identity row (a version, a pin, a count) is derived from its authority file or pinned by a test in the same commit.
 
 ---
+
+## Unit loop (when the port runs as orchestrated units)
+
+Per dispatched unit, in order. The mission-control port ran this loop fourteen
+times for fourteen review acceptances.
+
+- [ ] Verify the unit's claims first-hand in its worktree — re-run every gate; probe evidence claims, never relay them.
+- [ ] Settle the unit, then submit the frozen revision for review with every deviation or ambiguity stated as an explicit judgment item.
+- [ ] On acceptance: land, persist the typed review artifacts, and close the child with its base → frozen → merged SHA chain.
+- [ ] Keep record-only branches (review controllers, doc reviews, blocked units) `merge=false` so landing can never pick them up.
 
 ## Reusable assets
 
@@ -184,3 +199,4 @@ satisfied one.
 - Deriving a fix from the failing example rather than from the rule's predicate.
 - Adding a guard scoped to the instance just repaired.
 - Editing evidence to match a moved tree. Re-run it, and preserve the superseded record with its reason.
+- A fleet harness that refuses globally on one client's true variance. Record it as that row's blocked outcome with the reason named; a hard raise on an unanticipated package shape makes the whole assessment unrunnable.


### PR DESCRIPTION
Documentation-only closeout of the #9 mission-control migration, per the approved retrospective:

- **`docs/retros/issue-9-2026-08-25.md`** — the evidence-based retrospective (first document in `docs/retros/`): what made the unattended run work, deviations with mechanisms, lessons, and upstream dispositions — including the three issues filed at the retrospective (infiquetra-claude-plugins #828/#829/#830, boarded on Operations with Objective `improve-claude-plugins`) and the one **declined** proposal, recorded not filed.
- **Runbook v1.0.0 → v1.1.0** (`docs/runbooks/portable-plugin-port.md`): six checklist additions from the run — merge-policy preflight, captured probe transcripts, content-addressed evidence bindings, derived-or-pinned identity rows, the per-unit orchestration loop, and the global-refusal harness anti-pattern.
- **Journal**: two DECISIONS (watcher signals; `merge=false` record-only branches), one LEARNINGS (async turn-boundary mechanism), one QUEUED (repin+resync consumption of the eight open upstream filings).
- **`docs/README.md`**: the retrospective indexed.

No product code changes. Gate, 741 hermetic tests, 266 package tests, and whitespace all green on the branch.

https://claude.ai/code/session_01Jzy2G2V1P3beoLRTcTgvqi