### PR TITLE
docs(shaping): resolve both voice runtime providers for version one

### DIFF
--- a/docs/sdlc-issue-drafts/2026-08-25-build-the-portable-voice-plugin-unattended-orche-2.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-build-the-portable-voice-plugin-unattended-orche-2.md
@@ -52,8 +52,8 @@ non-overlapping: all 33 requirements appear once, and no requirement appears twi
 | --- | --- | --- | --- | --- | --- | --- |
 | U1 | #28 | Package foundation, provider declaration contract, retention posture, subprocess discipline. **Implements R30.** | G1 | — | R20, R21, R23, R24, R28, R29, R30, R31, R32 | `plugins/voice/{plugin.json,README.md}`, `plugins/voice/scripts/{providers,settings,process}.py` |
 | U2 | #29 | Claude client extension: `Stop` hook, binding store, single-speaker guard | G2 | U1 | R1, R2, R3 | `plugins/voice/com.infiquetra.claude/**`, `plugins/voice/scripts/binding.py` |
-| U3 | #30 | Speak path: Markdown cleanup, code-block omission, synthesis invocation | G2 | U1 | R5, R6, R7 | `plugins/voice/scripts/{text_cleanup,speak}.py` |
-| U4 | #31 | Listen path: toggle recording, hosted transcription, ephemeral retention | G2 | U1 | R10, R12, R25, R26, R27 | `plugins/voice/scripts/{record,transcribe}.py` |
+| U3 | #30 | Speak path: Markdown cleanup, code-block omission, Voice Forge synthesis | G2 | U1 | R5, R6, R7 | `plugins/voice/scripts/{text_cleanup,speak}.py` |
+| U4 | #31 | Listen path: toggle recording, Hermes relay transcription, ephemeral retention | G2 | U1 | R10, R12, R25, R26, R27 | `plugins/voice/scripts/{record,transcribe}.py` |
 | U5 | #32 | Deliver path: unsubmitted `herdr pane send-text`, bound-only target, **audible** blocked refusal, transient retention | G3 | U1, U2, **U3**, U4 | R16, R17, R18, R19 | `plugins/voice/scripts/deliver.py` |
 | U6 | #33 | Agent Skill entrypoint, Voice pane controls, provider and keybinding preflight | G3 | U1, U2, U3, U4 | R4, R8, R9, R11, R13, R14, R15, R22 | `plugins/voice/skills/voice/SKILL.md`, `plugins/voice/scripts/{voice_cli,pane,preflight}.py` |
 | U7 | #34 | Acceptance evidence, README **verification**, journal closeout | G4 | U1–U6 | R33 | `docs/evidence/voice/**`, `plugins/voice/README.md` (finalize only), `docs/engineering-journal/**` |
@@ -277,6 +277,8 @@ proof** — do not repair a launcher or redesign the run during preflight.
 | P5 | `herdr pane send-text <pane_id> "<text>"` delivers literal text **without** Enter | Send text to a live pane and confirm it sits unsubmitted and editable | R16 is unmet and the loop cannot close; stop |
 | P6 | Terminal microphone permission is granted (decision D3) | Capture a short sample with `/opt/homebrew/bin/ffmpeg` via AVFoundation | U4 parks; recording cannot be exercised |
 | P7 | Every launch template in the per-run vendor table dry-runs cleanly | `agents --dry-run …` for each row | Stop; the affected role has no validated launcher |
+| P8 | **Voice Forge text-to-speech is reachable and can actually synthesize** (decision D1) | Resolve `VOICE_FORGE_BASE_URL` from the Home Lab deployment receipt; `GET /health` and require a **usable backend**, not merely a healthy process; `GET /v1/audio/voices` and require the configured `VOICE_FORGE_VOICE_ID` to be present; then `POST /v1/audio/speech` with a short real phrase and verify the response is non-empty, playable audio | **Stop. Do not substitute another text-to-speech provider.** A healthy process with no available backend fails this gate |
+| P9 | **Hermes relay speech-to-text resolves xAI and actually transcribes** (decision D2) | `GET {VOICE_HERMES_BASE_URL}/api/health` and require healthy; prove the configured `VOICE_HERMES_PROFILE` exists and resolves `stt.provider: xai` **without displaying any credential**; `POST /api/audio/transcribe?profile=mimir-engineer` with a short real audio sample and require `provider` = `xai` plus a non-empty expected transcript; confirm `voice` never read `auth.json` and stored no bearer | **Stop. Do not substitute another speech-to-text provider.** |
 
 Preflight is run once, immediately before dispatch, even though this contract already
 records earlier receipts. Record the results in the opening run comment on this issue.
@@ -286,7 +288,13 @@ records earlier receipts. Record the results in the opening run comment on this 
 The run halts and asks the operator when any of these occurs:
 
 - A unit concludes it must edit `.github/workflows/ci.yml`.
-- A unit needs a provider credential, a billing decision, or a paid endpoint.
+- A unit needs a provider credential, a billing decision, or a paid endpoint. `voice`
+  holds no credential of its own: Hermes owns the xAI OAuth token, and any unit that
+  finds itself reading `auth.json`, copying a bearer, or wanting `XAI_API_KEY` has hit
+  this condition.
+- Voice Forge preflight (P8) or Hermes speech-to-text preflight (P9) fails. Stop rather
+  than substituting a different provider — R23 forbids silent substitution, and these
+  two are decided.
 - A unit proposes writing Herdr configuration, which R15 forbids outright.
 - Microphone permission cannot be granted to the terminal non-interactively.
 - A Saga Code Review is still below the consensus threshold after three cycles.
@@ -307,6 +315,9 @@ The run halts and asks the operator when any of these occurs:
 - [ ] The multi-session silence check passes per AE1, recorded in the same acceptance evidence.
 - [ ] The README states the absent provenance manifest and port descriptor plainly per R30, implemented by U1 and verified by U7: `grep -iE "provenance|port descriptor" plugins/voice/README.md` returns a match.
 - [ ] The portable Agent Skill entrypoint exists and no MCP server was added: `test -f plugins/voice/skills/voice/SKILL.md && ! grep -riq "mcpServers" plugins/voice/` exits 0.
+- [ ] No credential is read or stored by the package: `grep -riE "auth\.json|XAI_API_KEY|Bearer " plugins/voice/scripts/` returns no output.
+- [ ] No Hermes internals are imported and no HTTP dependency was added: `grep -riE "^import hermes|from hermes|import requests|import httpx" plugins/voice/scripts/` returns no output.
+- [ ] No provider endpoint is hard-coded to an IP address: `grep -rE "https?://[0-9]{1,3}(\.[0-9]{1,3}){3}" plugins/voice/scripts/` returns no output.
 
 ### Verification
 
@@ -332,22 +343,32 @@ durable; and any pool that never ran disclosed as unexercised.
 
 ### Operator decision table
 
-Five of the six decisions are settled by operator ruling and are **closed**. Exactly
-one remains genuinely open. The run continues unattended through the closed ones and
-pauses only for D2 or a genuine stop condition outside its authority.
+**All six decisions are settled. There is no remaining provider decision gate.** The
+run continues unattended and pauses only for a genuine stop condition outside its
+authority.
 
 | # | Decision | Status | Ruling |
 | --- | --- | --- | --- |
-| D1 | Text-to-speech provider and egress class | **RESOLVED** | `/usr/bin/say`, egress class `on-device`, for the first text-to-speech acceptance proof. Declared like any other provider — `voice` still ships no implementation and still refuses by name rather than substituting |
-| D2 | Hosted speech-to-text provider, its credential variable name, and its external egress declaration | **PENDING — the only open decision** | Not decided. Do not infer, default, or select one. U4 builds against the U1 declaration contract and parks rather than choosing |
+| D1 | Text-to-speech provider and egress class | **RESOLVED** | **Voice Forge on the Mac mini**, reached over the local network. Egress class **`local-network`** — not `on-device`. Configured through non-secret `VOICE_FORGE_BASE_URL` (from the Home Lab deployment receipt) and `VOICE_FORGE_VOICE_ID` (a registered Voice Forge voice). No IP address is hard-coded. Synthesis uses `POST /v1/audio/speech` with Voice Forge's OpenAI-compatible request shape |
+| D2 | Speech-to-text provider, credential owner, and egress declaration | **RESOLVED** | **xAI Grok speech-to-text through the local Hermes relay.** `voice` calls `POST {VOICE_HERMES_BASE_URL}/api/audio/transcribe?profile={VOICE_HERMES_PROFILE}`, acceptance values `http://127.0.0.1:8765` and `mimir-engineer`. **Credential variable in `voice`: none.** Credential owner: Hermes xAI OAuth. **Effective audio egress: `external`**, because Hermes forwards the audio to xAI |
 | D3 | Audio capture tool and microphone permission | **RESOLVED** | `/opt/homebrew/bin/ffmpeg` using the macOS AVFoundation input device. Terminal microphone permission is confirmed during preflight (gate P6), not assumed at run time |
 | D4 | The Herdr-wide `voice stop` keybinding | **RESOLVED — yes** | The operator adds the documented keybinding. `voice` only preflights and reports its presence (R14) and never writes Herdr configuration (R15) |
-| D5 | Retention posture | **RESOLVED — ephemeral** | Temporary audio deleted after both success and failure; no `voice` transcript log; no telemetry. Planning chooses the smallest clear setting *name*; the behaviour is settled and is written down rather than defaulted (R28) |
+| D5 | Retention posture | **RESOLVED — ephemeral** | Temporary audio deleted after both success and failure; no `voice` transcript log; no telemetry. Planning chooses the smallest clear setting *name*; the behaviour is settled and written down rather than defaulted (R28) |
 
-**How D2 parks.** U4 preserves its work in a draft pull request linked with
-`Relates to`, the coordinator marks the unit parked and moves its board card, and
-independent lanes continue. The operator's ruling is recorded as a durable comment and
-the same unit resumes — no replacement unit is created for completed work.
+**Provider boundary — what stays outside `voice`.** Provider installation, OAuth
+refresh, service management, billing, and credentials all remain outside the plugin
+(R24). Hermes owns the xAI OAuth token and the xAI request; `voice` must never read
+`auth.json`, copy a bearer, import Hermes internals, or require an `XAI_API_KEY`. The
+Home Lab System Update session owns upgrading the Mac mini Voice Forge installation and
+making it reachable; this run neither modifies Home Lab nor waits on that session.
+
+Both providers are reached over plain HTTP behind the U1 declaration contract, so the
+provider boundary stays replaceable. `voice` depends on no Hermes Python module and no
+Hermes repository code.
+
+**Runtime proofs are not yet run.** D1 and D2 are *decided*, not *proven*. Gates P8 and
+P9 above are the proofs, and they belong to the fresh preflight after Home Lab finishes
+the Mac mini deployment.
 
 
 ### Authority
@@ -365,9 +386,9 @@ elsewhere. Pre-existing artifacts and unrelated sessions are never touched.
 **This becomes an unattended run only after the operator approves this contract and a
 fresh preflight passes green.** Both conditions are required; neither is assumed.
 
-Once running, it continues without routine supervision. It pauses for exactly two
-things: the pending D2 provider ruling, and a genuine stop condition outside its
-authority. It does not pause to confirm work it is already authorized to do, and it
+Once running, it continues without routine supervision. **Every operator decision gate
+is now resolved**, so it pauses for exactly one thing: a genuine stop condition outside
+its authority. It does not pause to confirm work it is already authorized to do, and it
 never answers an operator decision gate on the operator's behalf.
 
 **The coordinator is the sole Operations-board writer**, and keeps parent and child

--- a/docs/sdlc-issue-drafts/2026-08-25-voice-u1.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-voice-u1.md
@@ -50,6 +50,26 @@ with vendor-neutral `scripts/` and `skills/`, and the Claude client extension co
 to `plugins/voice/com.infiquetra.claude/` (U2 owns that directory). Hooks live in the
 client extension, never in portable core (R29), per `AGENTS.md:52-53`.
 
+**Both runtime providers are resolved, and their non-secret settings live here.** U1
+owns the settings surface that U3 and U4 consume:
+
+| Setting | Purpose | Version-one acceptance value |
+| --- | --- | --- |
+| `VOICE_FORGE_BASE_URL` | Voice Forge text-to-speech base URL on the Mac mini | From the Home Lab deployment receipt. **Never a hard-coded IP address** |
+| `VOICE_FORGE_VOICE_ID` | Selects a registered Voice Forge voice | Runtime configuration, not an operator gate |
+| `VOICE_HERMES_BASE_URL` | Local Hermes relay base URL | `http://127.0.0.1:8765` |
+| `VOICE_HERMES_PROFILE` | Hermes profile scoping the transcription | `mimir-engineer` |
+
+All four are **non-secret**. `voice` holds no credential of its own: Hermes owns the
+xAI OAuth token and the xAI request. The declaration contract's credential-variable-name
+field is therefore **empty** for both providers — which the contract must permit, since
+R20 requires the field to record a name rather than a value, and here there is no name
+to record.
+
+Egress classes differ and must both be stated (R21): Voice Forge is `local-network`;
+the Hermes relay route is **`external`**, because Hermes forwards the audio on to xAI.
+The relay being on loopback does not make the audio local.
+
 Retention posture is settled by operator decision D5 and is not open in planning:
 temporary audio is deleted after both success and failure, `voice` keeps no transcript
 log of its own, and it emits no telemetry. Planning chooses the smallest clear setting
@@ -105,7 +125,8 @@ parent contract rather than editing across the boundary.
   an unknown egress class is rejected; an unavailable provider raises a named refusal
   rather than falling back.
 - `plugins/voice/tests/test_settings.py` — the ephemeral retention posture is stated,
-  not defaulted; an absent value is not silently treated as empty.
+  not defaulted; an absent value is not silently treated as empty; the four non-secret
+  provider settings resolve, and no setting carries a secret.
 - `plugins/voice/tests/test_process.py` — every spawned subprocess has standard input
   closed and a deadline attached.
 
@@ -121,6 +142,8 @@ parent contract rather than editing across the boundary.
 
 - [ ] The portable provider contract imports cleanly: `python3 -c "import sys; sys.path.insert(0,'plugins/voice/scripts'); import providers"` → exits 0.
 - [ ] Egress class is a closed set of exactly the four stated values: `grep -cE "on-device|local-network|named-remote-service|unofficial-remote-endpoint" plugins/voice/scripts/providers.py` → returns at least 4.
+- [ ] The four non-secret provider settings are defined: `grep -cE "VOICE_FORGE_BASE_URL|VOICE_FORGE_VOICE_ID|VOICE_HERMES_BASE_URL|VOICE_HERMES_PROFILE" plugins/voice/scripts/settings.py` → returns at least 4.
+- [ ] A declaration with no credential variable is valid, and no credential is read: `grep -riE "auth\.json|XAI_API_KEY" plugins/voice/scripts/` → returns no output.
 - [ ] The README states the absent manifest and descriptor plainly (R30): `grep -iE "provenance|port descriptor" plugins/voice/README.md` → returns a match.
 - [ ] Portable core contains no Claude hook (R29): `find plugins/voice/scripts -name '*hook*'` → returns no output.
 - [ ] Repository validation passes with the new package present: `python3 scripts/check_repo.py` → prints `Repository validation passed.`.

--- a/docs/sdlc-issue-drafts/2026-08-25-voice-u3.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-voice-u3.md
@@ -40,10 +40,25 @@ Basic Markdown cleaning keeps formatting syntax from being read aloud (R6), and 
 contents of fenced code blocks are omitted entirely rather than summarised or spoken
 (R7).
 
-Synthesis runs through the provider the operator declared in U1. Operator decision D1
-is settled: the first text-to-speech acceptance proof uses `/usr/bin/say` with egress
-class `on-device`. It is a declared provider like any other — `voice` still ships no
-implementation and still refuses by name rather than substituting.
+Synthesis runs through the provider the operator declared in U1. **Operator decision D1
+is settled: Voice Forge on the Mac mini, reached over the local network, egress class
+`local-network`.**
+
+Voice Forge exposes an OpenAI-compatible contract. Synthesis calls
+`POST {VOICE_FORGE_BASE_URL}/v1/audio/speech` with the OpenAI-compatible request shape,
+selecting the voice named by `VOICE_FORGE_VOICE_ID`. The companion endpoints
+`GET /v1/audio/voices` and `GET /health` exist and are used by U6's preflight, not here.
+
+**Standard library only (R31).** Make the call with `urllib.request` from the standard
+library. Do **not** add `requests`, `httpx`, or any other HTTP client dependency merely
+for this call. The base URL comes from settings; never hard-code an IP address.
+
+The Home Lab System Update session owns upgrading the Mac mini Voice Forge installation
+and making it reachable. This unit neither modifies Home Lab nor waits on that session;
+it builds against the endpoint contract and lets preflight gate P8 prove reachability.
+
+It remains a declared provider like any other — `voice` ships no implementation and
+refuses by name rather than substituting (R23).
 
 Playback must expose a stop handle so U6 can interrupt it immediately, and a speak
 entry point U5 can call for the audible refusal. This unit provides both mechanisms;
@@ -88,7 +103,9 @@ parent contract rather than editing across the boundary.
   list syntax are not spoken; fenced code-block contents are omitted entirely; a long
   input is returned whole, proving no length gate is applied.
 - `plugins/voice/tests/test_speak.py` — the declared provider is invoked with the
-  cleaned text verbatim; an absent provider raises a named refusal; the stop handle
+  cleaned text verbatim; the request targets `POST /v1/audio/speech` at the configured
+  base URL with the configured voice id, built on `urllib.request`; an unreachable or
+  unhealthy Voice Forge raises a named refusal rather than substituting; the stop handle
   interrupts playback; the refusal entry point U5 calls speaks its message.
 
 ### Context library links
@@ -104,6 +121,8 @@ parent contract rather than editing across the boundary.
 - [ ] Fenced code-block contents never reach speech (R7): `python3 -m pytest plugins/voice/tests/test_text_cleanup.py -q` → no failures.
 - [ ] No length gate, ceiling, or truncation exists in the speak path (R5): `grep -icE "truncat|max_len|ceiling|summaris|summariz" plugins/voice/scripts/speak.py` → returns 0.
 - [ ] Synthesis invokes the declared provider and refuses by name when absent: `python3 -m pytest plugins/voice/tests/test_speak.py -q` → no failures.
+- [ ] Synthesis targets the Voice Forge speech endpoint: `grep -c "/v1/audio/speech" plugins/voice/scripts/speak.py` → returns at least 1.
+- [ ] No HTTP client dependency was added and no IP is hard-coded: `grep -riE "import requests|import httpx|https?://[0-9]{1,3}(\.[0-9]{1,3}){3}" plugins/voice/scripts/speak.py` → returns no output.
 - [ ] A speak entry point exists for U5's audible refusal (R18 support): `grep -cE "def speak" plugins/voice/scripts/speak.py` → returns at least 1.
 - [ ] Repository validation passes: `python3 scripts/check_repo.py` → prints `Repository validation passed.`.
 

--- a/docs/sdlc-issue-drafts/2026-08-25-voice-u4.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-voice-u4.md
@@ -45,11 +45,31 @@ audio is deleted immediately after transcription, including when transcription f
 bound agent's own conversation history after delivery (R26) — and it emits no telemetry
 (R27).
 
-**Operator decision D2 remains genuinely pending and is the only open provider
-choice.** The exact hosted speech-to-text provider, its credential *variable name*, and
-its external egress declaration are not decided. Do not infer, default, or select one.
-Build against the U1 declaration contract so any hosted provider drops in, and park the
-unit rather than choosing.
+**Operator decision D2 is resolved: xAI Grok speech-to-text through the local Hermes
+relay.** Nothing about the provider is open any more.
+
+`voice` sends the recorded audio to
+`POST {VOICE_HERMES_BASE_URL}/api/audio/transcribe?profile={VOICE_HERMES_PROFILE}`
+using the documented `AudioTranscriptionRequest` shape — a base64 audio **data URL**
+plus the profile query parameter — and consumes the returned transcript. The relay
+scopes the transcription to that profile, deletes its own temporary upload, and returns
+the transcript together with the resolving provider. Version-one acceptance values are
+`http://127.0.0.1:8765` and `mimir-engineer`.
+
+**The credential boundary is absolute.** `voice` holds no credential: its
+credential-variable field for this provider is empty, and Hermes owns the xAI OAuth
+token and the xAI request. This unit must never read `auth.json`, copy a bearer, import
+any Hermes Python module, depend on Hermes repository code, or require `XAI_API_KEY`.
+The boundary is plain HTTP, which keeps the provider replaceable.
+
+**Egress is `external`, not local.** The relay listens on loopback, but Hermes forwards
+the audio to xAI, so the effective audio egress leaves the machine and R21 requires that
+be stated plainly. A loopback address must not be mistaken for a local egress class.
+
+**Standard library only (R31).** Build the request with `urllib.request`; do not add an
+HTTP client dependency for this call.
+
+Runtime proof belongs to preflight gate P9, not to this unit.
 
 **Proportionality.** `voice` is a private, single-user developer plugin — not a
 Pentagon system. Prefer the smallest compatible implementation. Standard-library
@@ -67,7 +87,11 @@ outcome, and the coordinator moves the card.
 
 ### Out-of-scope / non-goals
 
-- Choosing the hosted speech-to-text provider; that is pending decision D2.
+- Managing xAI credentials, OAuth refresh, or Hermes service lifecycle. Hermes owns all
+  of it. Reading `auth.json`, copying a bearer, or requiring `XAI_API_KEY` is a stop
+  condition, not an implementation choice.
+- Importing Hermes Python modules or depending on Hermes repository code; the boundary
+  is plain HTTP so the provider stays replaceable.
 - Delivering the transcript to the agent — U5 owns delivery and the blocked-state refusal.
 - The recording indicator and barge-in behaviour — U6 owns pane presentation.
 - Bundling a speech-to-text implementation or managing credentials.
@@ -89,9 +113,12 @@ parent contract rather than editing across the boundary.
 - `plugins/voice/tests/test_record.py` — one press starts and a second stops; an
   abandoned recording issues no transcription request; the audio file is gone after a
   successful run and after a deliberately failed one.
-- `plugins/voice/tests/test_transcribe.py` — the declared hosted provider is invoked
-  per its declaration; no transcript file is written anywhere; no telemetry call is
-  made.
+- `plugins/voice/tests/test_transcribe.py` — the request posts a base64 audio data URL
+  to `/api/audio/transcribe` with the configured profile query parameter, built on
+  `urllib.request`; the returned transcript and provider are consumed; an unreachable
+  relay raises a named refusal rather than substituting; no credential is read and no
+  Hermes module is imported; no transcript file is written anywhere; no telemetry call
+  is made.
 
 ### Context library links
 
@@ -107,7 +134,9 @@ parent contract rather than editing across the boundary.
 - [ ] Audio is deleted after success and after failure (R25, D5): `python3 -m pytest plugins/voice/tests/test_record.py -q -k retention` → no failures.
 - [ ] No transcript log is written by the package (R26, D5): `grep -icE "transcript_log|write_transcript|history_file" plugins/voice/scripts/transcribe.py` → returns 0.
 - [ ] No telemetry is emitted (R27, D5): `grep -ricE "telemetry|analytics|posthog" plugins/voice/scripts/` → returns 0.
-- [ ] No hosted provider is hard-coded while D2 is pending: `grep -icE "deepgram|assemblyai|whisper\.api|openai\.com/v1/audio" plugins/voice/scripts/transcribe.py` → returns 0.
+- [ ] Transcription targets the Hermes relay endpoint with the profile parameter: `grep -cE "/api/audio/transcribe" plugins/voice/scripts/transcribe.py` → returns at least 1.
+- [ ] No credential is read, stored, or required: `grep -riE "auth\.json|XAI_API_KEY|Bearer " plugins/voice/scripts/transcribe.py` → returns no output.
+- [ ] No Hermes internals are imported and no HTTP dependency added: `grep -riE "^import hermes|from hermes|import requests|import httpx" plugins/voice/scripts/transcribe.py` → returns no output.
 
 ### Verification
 

--- a/docs/sdlc-issue-drafts/2026-08-25-voice-u6.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-voice-u6.md
@@ -54,7 +54,27 @@ and reports its absence (R14) but never writes Herdr configuration (R15).
 
 Provider preflight checks a declared endpoint and its stated capabilities before use
 and reports a missing or misconfigured prerequisite *by name* rather than failing at
-first use (R22). It never substitutes one provider for another.
+first use (R22). It never substitutes one provider for another (R23).
+
+Both runtime providers are resolved, and preflight proves each one end to end:
+
+**Voice Forge text-to-speech (decision D1).** Resolve `VOICE_FORGE_BASE_URL`; call
+`GET /health` and require a **usable backend**, because a healthy process with no
+available backend is insufficient; call `GET /v1/audio/voices` and require the
+configured `VOICE_FORGE_VOICE_ID` to be present; then `POST /v1/audio/speech` with a
+short real phrase and verify the response is non-empty, playable audio. On failure,
+report by name and **stop — never substitute another text-to-speech provider.**
+
+**Hermes relay speech-to-text (decision D2).** Call
+`GET {VOICE_HERMES_BASE_URL}/api/health` and require healthy; prove the configured
+`VOICE_HERMES_PROFILE` exists and resolves `stt.provider: xai` **without displaying any
+credential**; then `POST /api/audio/transcribe?profile=mimir-engineer` with a short real
+audio sample and require the response `provider` to be `xai` with a non-empty expected
+transcript. Confirm `voice` never read `auth.json` and stored no bearer. On failure,
+report by name and **stop — never substitute another speech-to-text provider.**
+
+Preflight reports; it never installs, provisions, or manages a service. Use
+`urllib.request` from the standard library for both probes (R31).
 
 This is the largest unit by requirement count. If it proves too large in planning,
 split preflight from the pane rather than dropping scope.
@@ -103,8 +123,11 @@ parent contract rather than editing across the boundary.
   displayed; the stop key interrupts playback immediately rather than at the end of an
   utterance; starting a recording stops playback first.
 - `plugins/voice/tests/test_preflight.py` — a missing provider is reported by name and
-  never substituted; an absent Herdr `voice stop` keybinding is reported rather than
-  installed; no Herdr configuration file is ever written.
+  never substituted; a Voice Forge process that is healthy but has **no usable backend**
+  fails preflight; a missing `VOICE_FORGE_VOICE_ID` in the voices list fails by name; a
+  Hermes profile that does not resolve `stt.provider: xai` fails by name; no credential
+  value is ever read or printed; an absent Herdr `voice stop` keybinding is reported
+  rather than installed; no Herdr configuration file is ever written.
 
 ### Context library links
 
@@ -120,6 +143,8 @@ parent contract rather than editing across the boundary.
 - [ ] The skill has a bundled CLI that starts the pane: `test -f plugins/voice/scripts/voice_cli.py` → exits 0.
 - [ ] No Model Context Protocol server is declared anywhere in the package: `grep -ricE "mcpServers|mcp_server|modelcontextprotocol" plugins/voice/` → returns 0.
 - [ ] A missing prerequisite is named, never substituted (R22, R23): `python3 -m pytest plugins/voice/tests/test_preflight.py -q` → no failures.
+- [ ] Preflight probes both provider contracts: `grep -cE "/health|/v1/audio/voices|/v1/audio/speech|/api/health|/api/audio/transcribe" plugins/voice/scripts/preflight.py` → returns at least 5.
+- [ ] Preflight reads no credential and prints none: `grep -riE "auth\.json|XAI_API_KEY|Bearer " plugins/voice/scripts/preflight.py` → returns no output.
 - [ ] Herdr configuration is never written (R15): `grep -ricE "herdr.*config.*write|write.*herdr.*config" plugins/voice/scripts/` → returns 0.
 
 ### Verification


### PR DESCRIPTION
Documentation only. Resolves both runtime voice providers in the `voice` orchestration
contract and its synchronized shaping records. **D1 and D2 are now both resolved and no
provider decision gate remains.**

No code, no plugin, no board state change, and **neither runtime proof has been run** —
both belong to the fresh preflight after the Home Lab session finishes the Mac mini
Voice Forge deployment.

## Final provider table

| | Text-to-speech (D1) | Speech-to-text (D2) |
|---|---|---|
| Provider | **Voice Forge** on the Mac mini | **xAI Grok** via the local Hermes relay |
| Endpoint | `POST {VOICE_FORGE_BASE_URL}/v1/audio/speech` | `POST {VOICE_HERMES_BASE_URL}/api/audio/transcribe?profile={VOICE_HERMES_PROFILE}` |
| Settings | `VOICE_FORGE_BASE_URL`, `VOICE_FORGE_VOICE_ID` | `VOICE_HERMES_BASE_URL`, `VOICE_HERMES_PROFILE` |
| Acceptance values | From the Home Lab deployment receipt; no hard-coded IP | `http://127.0.0.1:8765`, `mimir-engineer` |
| Credential in `voice` | none | **none** — Hermes owns the xAI OAuth token |
| Egress class | `local-network` | **`external`** — Hermes forwards the audio to xAI |

The relay listening on loopback does not make the audio local; R21 requires the external
egress be stated plainly.

## What changed

- **D1** replaces `/usr/bin/say`. Egress corrected from `on-device` to `local-network`.
- **D2** resolved to xAI Grok through the Hermes relay, using the documented
  `AudioTranscriptionRequest` base64 data-url shape.
- **Credential boundary made absolute**: `voice` never reads `auth.json`, copies a
  bearer, imports Hermes modules, or requires `XAI_API_KEY`. The boundary is plain HTTP,
  so the provider stays replaceable.
- **Standard library only** — both calls use `urllib.request`; no HTTP client dependency
  is added, honoring R31.
- **Preflight gates P8 and P9 added.** P8 requires a *usable backend*, not merely a
  healthy Voice Forge process, plus the configured voice in the voices list and a real
  synthesis returning non-empty playable audio. P9 requires Hermes healthy, the profile
  resolving `stt.provider: xai` without displaying credentials, and a real transcription
  returning `provider: xai`. **Both stop rather than substitute another provider.**
- Provider lifecycle, OAuth refresh, service management, and credentials stay outside
  `voice`. Home Lab is neither modified nor waited on here.

## Issues amended

`#27` parent contract · `#28` U1 settings ownership · `#30` U3 Voice Forge synthesis ·
`#31` U4 Hermes transcription · `#33` U6 preflight.

`#29` U2, `#32` U5, and `#34` U7 carry no statement this change made false and were left
untouched.

## Validation

- Exact-once ownership re-verified on the live parent: **33 owned, no duplicates, none missing**
- All 8 cards pass `card_validator`
- `python3 scripts/check_repo.py` — Repository validation passed
- `python3 -m unittest discover -s tests` — 741 tests, OK
- `git diff --check` — clean

https://claude.ai/code/session_01FUnNmNAUKEjwDMe8uiwiQW