### PR TITLE
docs(shaping): correct the Hermes speech-to-text auth contract

### DIFF
--- a/docs/sdlc-issue-drafts/2026-08-25-build-the-portable-voice-plugin-unattended-orche-2.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-build-the-portable-voice-plugin-unattended-orche-2.md
@@ -278,7 +278,7 @@ proof** — do not repair a launcher or redesign the run during preflight.
 | P6 | Terminal microphone permission is granted (decision D3) | Capture a short sample with `/opt/homebrew/bin/ffmpeg` via AVFoundation | U4 parks; recording cannot be exercised |
 | P7 | Every launch template in the per-run vendor table dry-runs cleanly | `agents --dry-run …` for each row | Stop; the affected role has no validated launcher |
 | P8 | **Voice Forge text-to-speech is reachable and can actually synthesize** (decision D1) | Resolve `VOICE_FORGE_BASE_URL` from the Home Lab deployment receipt; `GET /health` and require a **usable backend**, not merely a healthy process; `GET /v1/audio/voices` and require the configured `VOICE_FORGE_VOICE_ID` to be present; then `POST /v1/audio/speech` with a short real phrase and verify the response is non-empty, playable audio | **Stop. Do not substitute another text-to-speech provider.** A healthy process with no available backend fails this gate |
-| P9 | **Hermes relay speech-to-text resolves xAI and actually transcribes** (decision D2) | `GET {VOICE_HERMES_BASE_URL}/api/health` and require healthy; prove the configured `VOICE_HERMES_PROFILE` exists and resolves `stt.provider: xai` **without displaying any credential**; `POST /api/audio/transcribe?profile=mimir-engineer` with a short real audio sample and require `provider` = `xai` plus a non-empty expected transcript; confirm `voice` never read `auth.json` and stored no bearer | **Stop. Do not substitute another speech-to-text provider.** |
+| P9 | **Hermes relay speech-to-text resolves xAI and actually transcribes** (decision D2) | `GET {VOICE_HERMES_BASE_URL}/api/health` and require healthy — noting that `auth_required: false` disables only the external OAuth/cookie gate and is **not** proof that protected routes accept anonymous requests. Obtain the loopback session token in memory from `GET {VOICE_HERMES_BASE_URL}/`, then prove `/api/profiles` is callable with `X-Hermes-Session-Token` (HTTP 200) and that the configured `VOICE_HERMES_PROFILE` is present. Verify the profile resolves `stt.provider` = `xai` **without exposing any credential** — the transcription response's own `provider` field is the authoritative resolution. Then `POST /api/audio/transcribe?profile=mimir-engineer` with the same header and a short real audio sample, requiring `provider` = `xai` and the expected non-empty transcript. Confirm `voice` never read `auth.json` and never persisted or logged the session token | **Stop. Do not substitute another speech-to-text provider, and never disable Hermes authentication.** |
 
 Preflight is run once, immediately before dispatch, even though this contract already
 records earlier receipts. Record the results in the opening run comment on this issue.
@@ -316,6 +316,7 @@ The run halts and asks the operator when any of these occurs:
 - [ ] The README states the absent provenance manifest and port descriptor plainly per R30, implemented by U1 and verified by U7: `grep -iE "provenance|port descriptor" plugins/voice/README.md` returns a match.
 - [ ] The portable Agent Skill entrypoint exists and no MCP server was added: `test -f plugins/voice/skills/voice/SKILL.md && ! grep -riq "mcpServers" plugins/voice/` exits 0.
 - [ ] No credential is read or stored by the package: `grep -riE "auth\.json|XAI_API_KEY|Bearer " plugins/voice/scripts/` returns no output.
+- [ ] The Hermes session token is never persisted or logged: `grep -riE "HERMES_SESSION_TOKEN.*(open\(|write|log|print)" plugins/voice/scripts/` returns no output.
 - [ ] No Hermes internals are imported and no HTTP dependency was added: `grep -riE "^import hermes|from hermes|import requests|import httpx" plugins/voice/scripts/` returns no output.
 - [ ] No provider endpoint is hard-coded to an IP address: `grep -rE "https?://[0-9]{1,3}(\.[0-9]{1,3}){3}" plugins/voice/scripts/` returns no output.
 
@@ -350,7 +351,7 @@ authority.
 | # | Decision | Status | Ruling |
 | --- | --- | --- | --- |
 | D1 | Text-to-speech provider and egress class | **RESOLVED** | **Voice Forge on the Mac mini**, reached over the local network. Egress class **`local-network`** — not `on-device`. Configured through non-secret `VOICE_FORGE_BASE_URL` (from the Home Lab deployment receipt) and `VOICE_FORGE_VOICE_ID` (a registered Voice Forge voice). No IP address is hard-coded. Synthesis uses `POST /v1/audio/speech` with Voice Forge's OpenAI-compatible request shape |
-| D2 | Speech-to-text provider, credential owner, and egress declaration | **RESOLVED** | **xAI Grok speech-to-text through the local Hermes relay.** `voice` calls `POST {VOICE_HERMES_BASE_URL}/api/audio/transcribe?profile={VOICE_HERMES_PROFILE}`, acceptance values `http://127.0.0.1:8765` and `mimir-engineer`. **Credential variable in `voice`: none.** Credential owner: Hermes xAI OAuth. **Effective audio egress: `external`**, because Hermes forwards the audio to xAI |
+| D2 | Speech-to-text provider, credential owner, and egress declaration | **RESOLVED** | **xAI Grok speech-to-text through the local Hermes relay.** `voice` calls `POST {VOICE_HERMES_BASE_URL}/api/audio/transcribe?profile={VOICE_HERMES_PROFILE}`, acceptance values `http://127.0.0.1:8765` and `mimir-engineer`, attaching the in-memory loopback `X-Hermes-Session-Token` read from the local dashboard root. **No new credential environment variable.** Credential owner: Hermes xAI OAuth. **Effective audio egress: `external`**, because Hermes forwards the audio to xAI |
 | D3 | Audio capture tool and microphone permission | **RESOLVED** | `/opt/homebrew/bin/ffmpeg` using the macOS AVFoundation input device. Terminal microphone permission is confirmed during preflight (gate P6), not assumed at run time |
 | D4 | The Herdr-wide `voice stop` keybinding | **RESOLVED — yes** | The operator adds the documented keybinding. `voice` only preflights and reports its presence (R14) and never writes Herdr configuration (R15) |
 | D5 | Retention posture | **RESOLVED — ephemeral** | Temporary audio deleted after both success and failure; no `voice` transcript log; no telemetry. Planning chooses the smallest clear setting *name*; the behaviour is settled and written down rather than defaulted (R28) |
@@ -361,6 +362,26 @@ refresh, service management, billing, and credentials all remain outside the plu
 `auth.json`, copy a bearer, import Hermes internals, or require an `XAI_API_KEY`. The
 Home Lab System Update session owns upgrading the Mac mini Voice Forge installation and
 making it reachable; this run neither modifies Home Lab nor waits on that session.
+
+**Loopback session token — how `voice` calls the relay.** `auth_required: false` on
+`/api/health` means Hermes' external OAuth/cookie gate is disabled. It does **not** make
+protected API routes anonymous: the running dashboard requires its rotating loopback
+session token on non-public routes, and an anonymous call returns `401`.
+
+`voice` uses the same supported client flow as Hermes Desktop:
+
+1. `GET {VOICE_HERMES_BASE_URL}/` and read the injected `window.__HERMES_SESSION_TOKEN__`
+   value from the served page.
+2. Hold it **in process memory only** and send it as the `X-Hermes-Session-Token` header
+   on `/api/audio/transcribe` requests.
+3. On `401`, refresh the token once from the local root page and retry **once**, because
+   the token rotates when Hermes restarts. **One refresh, one retry — never a loop.**
+
+The token is a transport detail, not a declared credential: no new environment variable
+is introduced, and `VOICE_HERMES_BASE_URL` and `VOICE_HERMES_PROFILE` are unchanged.
+`voice` must never read `auth.json`, copy the xAI OAuth bearer, persist or log the
+session token, pass it in command arguments or evidence, or disable Hermes
+authentication.
 
 Both providers are reached over plain HTTP behind the U1 declaration contract, so the
 provider boundary stays replaceable. `voice` depends on no Hermes Python module and no

--- a/docs/sdlc-issue-drafts/2026-08-25-voice-u1.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-voice-u1.md
@@ -61,7 +61,10 @@ owns the settings surface that U3 and U4 consume:
 | `VOICE_HERMES_PROFILE` | Hermes profile scoping the transcription | `mimir-engineer` |
 
 All four are **non-secret**. `voice` holds no credential of its own: Hermes owns the
-xAI OAuth token and the xAI request. The declaration contract's credential-variable-name
+xAI OAuth token and the xAI request. The one token `voice` touches is Hermes' rotating
+loopback **session** token, read from the local dashboard root at call time and held in
+process memory only — a transport detail owned by U4, never a declared credential, never
+an environment variable, and never persisted or logged. The declaration contract's credential-variable-name
 field is therefore **empty** for both providers — which the contract must permit, since
 R20 requires the field to record a name rather than a value, and here there is no name
 to record.

--- a/docs/sdlc-issue-drafts/2026-08-25-voice-u4.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-voice-u4.md
@@ -56,10 +56,27 @@ scopes the transcription to that profile, deletes its own temporary upload, and 
 the transcript together with the resolving provider. Version-one acceptance values are
 `http://127.0.0.1:8765` and `mimir-engineer`.
 
+**Calling the relay: the loopback session token.** `auth_required: false` on
+`/api/health` disables only Hermes' external OAuth/cookie gate — protected API routes
+still require the dashboard's rotating loopback session token, and an anonymous call
+returns `401`. `voice` uses the same supported flow as Hermes Desktop:
+
+1. `GET {VOICE_HERMES_BASE_URL}/` and read the injected `window.__HERMES_SESSION_TOKEN__`
+   value from the served page.
+2. Keep it **in process memory only** and send it as the `X-Hermes-Session-Token` header
+   on the transcribe request.
+3. On `401`, refresh the token once from the local root page and retry **once** — the
+   token rotates when Hermes restarts. **One refresh, one retry. Never a retry loop.**
+
+This introduces **no new environment variable**: `VOICE_HERMES_BASE_URL` and
+`VOICE_HERMES_PROFILE` are unchanged. The token is a transport detail, not a declared
+credential. Keep it out of command arguments, evidence, logs, and disk.
+
 **The credential boundary is absolute.** `voice` holds no credential: its
 credential-variable field for this provider is empty, and Hermes owns the xAI OAuth
-token and the xAI request. This unit must never read `auth.json`, copy a bearer, import
-any Hermes Python module, depend on Hermes repository code, or require `XAI_API_KEY`.
+token and the xAI request. This unit must never read `auth.json`, copy the xAI OAuth
+bearer, persist or log the Hermes session token, import any Hermes Python module, depend
+on Hermes repository code, require `XAI_API_KEY`, or disable Hermes authentication.
 The boundary is plain HTTP, which keeps the provider replaceable.
 
 **Egress is `external`, not local.** The relay listens on loopback, but Hermes forwards
@@ -115,10 +132,13 @@ parent contract rather than editing across the boundary.
   successful run and after a deliberately failed one.
 - `plugins/voice/tests/test_transcribe.py` — the request posts a base64 audio data URL
   to `/api/audio/transcribe` with the configured profile query parameter, built on
-  `urllib.request`; the returned transcript and provider are consumed; an unreachable
-  relay raises a named refusal rather than substituting; no credential is read and no
-  Hermes module is imported; no transcript file is written anywhere; no telemetry call
-  is made.
+  `urllib.request` with the in-memory `X-Hermes-Session-Token` header; the returned
+  transcript and provider are consumed; a `401` triggers exactly one token refresh from
+  the local root page and one retry, and a second `401` fails by name rather than
+  looping; the token is never written to disk, logged, or placed in command arguments;
+  an unreachable relay raises a named refusal rather than substituting; no credential is
+  read and no Hermes module is imported; no transcript file is written anywhere; no
+  telemetry call is made.
 
 ### Context library links
 
@@ -136,6 +156,8 @@ parent contract rather than editing across the boundary.
 - [ ] No telemetry is emitted (R27, D5): `grep -ricE "telemetry|analytics|posthog" plugins/voice/scripts/` → returns 0.
 - [ ] Transcription targets the Hermes relay endpoint with the profile parameter: `grep -cE "/api/audio/transcribe" plugins/voice/scripts/transcribe.py` → returns at least 1.
 - [ ] No credential is read, stored, or required: `grep -riE "auth\.json|XAI_API_KEY|Bearer " plugins/voice/scripts/transcribe.py` → returns no output.
+- [ ] The session token is attached as a header and never persisted or logged: `grep -cE "X-Hermes-Session-Token" plugins/voice/scripts/transcribe.py` → returns at least 1, and `grep -riE "HERMES_SESSION_TOKEN.*(open\(|write|log|print)" plugins/voice/scripts/transcribe.py` → returns no output.
+- [ ] Exactly one refresh-and-retry on 401, not a loop: `python3 -m pytest plugins/voice/tests/test_transcribe.py -q -k retry` → no failures.
 - [ ] No Hermes internals are imported and no HTTP dependency added: `grep -riE "^import hermes|from hermes|import requests|import httpx" plugins/voice/scripts/transcribe.py` → returns no output.
 
 ### Verification

--- a/docs/sdlc-issue-drafts/2026-08-25-voice-u6.md
+++ b/docs/sdlc-issue-drafts/2026-08-25-voice-u6.md
@@ -66,12 +66,21 @@ short real phrase and verify the response is non-empty, playable audio. On failu
 report by name and **stop — never substitute another text-to-speech provider.**
 
 **Hermes relay speech-to-text (decision D2).** Call
-`GET {VOICE_HERMES_BASE_URL}/api/health` and require healthy; prove the configured
-`VOICE_HERMES_PROFILE` exists and resolves `stt.provider: xai` **without displaying any
-credential**; then `POST /api/audio/transcribe?profile=mimir-engineer` with a short real
-audio sample and require the response `provider` to be `xai` with a non-empty expected
-transcript. Confirm `voice` never read `auth.json` and stored no bearer. On failure,
-report by name and **stop — never substitute another speech-to-text provider.**
+`GET {VOICE_HERMES_BASE_URL}/api/health` and require healthy — but do **not** read
+`auth_required: false` as proof that protected routes accept anonymous requests. It
+disables only the external OAuth/cookie gate; the dashboard still requires its rotating
+loopback session token, and an anonymous call returns `401`.
+
+Obtain that token in memory from `GET {VOICE_HERMES_BASE_URL}/`
+(`window.__HERMES_SESSION_TOKEN__`), then prove `/api/profiles` is callable with the
+`X-Hermes-Session-Token` header (HTTP 200) and that `VOICE_HERMES_PROFILE` is present.
+Verify the profile resolves `stt.provider` = `xai` **without displaying any credential**;
+the transcription response's own `provider` field is the authoritative resolution. Then
+`POST /api/audio/transcribe?profile=mimir-engineer` with the same header and a short real
+audio sample, requiring `provider` = `xai` and a non-empty expected transcript. Confirm
+`voice` never read `auth.json`, stored no bearer, and neither persisted nor logged the
+session token. On failure, report by name and **stop — never substitute another
+speech-to-text provider and never disable Hermes authentication.**
 
 Preflight reports; it never installs, provisions, or manages a service. Use
 `urllib.request` from the standard library for both probes (R31).
@@ -125,8 +134,9 @@ parent contract rather than editing across the boundary.
 - `plugins/voice/tests/test_preflight.py` — a missing provider is reported by name and
   never substituted; a Voice Forge process that is healthy but has **no usable backend**
   fails preflight; a missing `VOICE_FORGE_VOICE_ID` in the voices list fails by name; a
-  Hermes profile that does not resolve `stt.provider: xai` fails by name; no credential
-  value is ever read or printed; an absent Herdr `voice stop` keybinding is reported
+  Hermes profile that does not resolve `stt.provider: xai` fails by name; an anonymous
+  relay call is treated as a token-missing condition rather than a healthy result; no
+  credential value and no session token is ever read from disk, printed, or logged; an absent Herdr `voice stop` keybinding is reported
   rather than installed; no Herdr configuration file is ever written.
 
 ### Context library links
@@ -145,6 +155,7 @@ parent contract rather than editing across the boundary.
 - [ ] A missing prerequisite is named, never substituted (R22, R23): `python3 -m pytest plugins/voice/tests/test_preflight.py -q` → no failures.
 - [ ] Preflight probes both provider contracts: `grep -cE "/health|/v1/audio/voices|/v1/audio/speech|/api/health|/api/audio/transcribe" plugins/voice/scripts/preflight.py` → returns at least 5.
 - [ ] Preflight reads no credential and prints none: `grep -riE "auth\.json|XAI_API_KEY|Bearer " plugins/voice/scripts/preflight.py` → returns no output.
+- [ ] Preflight obtains the loopback token in memory and never persists it: `grep -cE "X-Hermes-Session-Token" plugins/voice/scripts/preflight.py` → returns at least 1, and `grep -riE "HERMES_SESSION_TOKEN.*(open\(|write|log|print)" plugins/voice/scripts/preflight.py` → returns no output.
 - [ ] Herdr configuration is never written (R15): `grep -ricE "herdr.*config.*write|write.*herdr.*config" plugins/voice/scripts/` → returns 0.
 
 ### Verification


### PR DESCRIPTION
Documentation only. Corrects how the `voice` contract calls the local Hermes relay, based
on verified live behavior.

## Root cause

The P9 preflight gate treated `auth_required: false` as proof that protected Hermes
routes accept anonymous requests. It is not. `auth_required: false` disables only the
**external OAuth/cookie gate**; the running 0.20.4 dashboard still requires its rotating
**loopback session token** on non-public API routes and returns `401` without it.

Hermes is configured correctly. The contract was wrong.

## Corrected client flow

`voice` now uses the same supported flow as Hermes Desktop:

1. `GET http://127.0.0.1:8765/` and read the injected `window.__HERMES_SESSION_TOKEN__`.
2. Hold it **in process memory only**; send it as `X-Hermes-Session-Token` on
   `/api/audio/transcribe`.
3. On `401`, refresh once from the local root page and retry **once** — the token rotates
   when Hermes restarts. **One refresh, one retry, never a loop.**

**No new environment variable.** `VOICE_HERMES_BASE_URL` and `VOICE_HERMES_PROFILE` are
unchanged. The session token is a transport detail, not a declared credential.

`voice` must never read `auth.json`, copy the xAI OAuth bearer, persist or log the session
token, place it in command arguments or evidence, or disable Hermes authentication.

## Corrected P9 gate

P9 now obtains the in-memory token, proves `/api/profiles` is callable (HTTP 200),
verifies the profile resolves `stt.provider` = `xai` without exposing credentials, and
transcribes a real sample requiring `provider` = `xai` with the expected non-empty text.
It explicitly warns that `auth_required: false` is not anonymous access.

## Issues amended

`#27` parent (P9 gate, D2 row, token rule, acceptance criteria) · `#28` U1 (session token
distinguished from a declared credential) · `#31` U4 (transcription client) · `#33` U6
(preflight).

`#29`, `#30`, `#32`, `#34` carry no statement this made false and were left untouched.

## Validation

- All 8 cards pass `card_validator`
- `python3 scripts/check_repo.py` — Repository validation passed
- `python3 -m unittest discover -s tests` — 741 tests, OK
- `git diff --check` — clean

Scope: 4 files, 74 insertions, 17 deletions.

https://claude.ai/code/session_01FUnNmNAUKEjwDMe8uiwiQW