### PR TITLE
fix(voice): make the Claude client extension installable and publish a marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,35 @@
+{
+  "name": "infiquetra-agent-plugins",
+  "owner": {
+    "name": "Infiquetra",
+    "email": "hello@infiquetra.com"
+  },
+  "metadata": {
+    "description": "Claude Code distribution of the Infiquetra portable Agent Plugins catalog. Each entry installs a portable package together with its Claude client extension; the packages themselves stay vendor-neutral.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "voice",
+      "source": "./plugins/voice",
+      "version": "0.1.0",
+      "description": "A spoken conversational loop for one explicitly bound, Herdr-managed Claude Code session: the bound session speaks its completed response, the operator answers by voice, and the transcript lands editable and unsubmitted in that same session's input box.",
+      "author": {
+        "name": "Infiquetra",
+        "email": "hello@infiquetra.com"
+      },
+      "repository": "https://github.com/infiquetra/infiquetra-agent-plugins",
+      "license": "MIT",
+      "keywords": [
+        "voice",
+        "speech",
+        "text-to-speech",
+        "speech-to-text",
+        "herdr",
+        "conversational-loop",
+        "accessibility"
+      ],
+      "category": "development"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,10 @@ git diff --check
   [port descriptor](ports/README.md) under `ports/`, never as a constant inside
   a script.
 - Put commands, hooks, native agent definitions, permissions, and client runtime
-  integration in explicit vendor adapters.
+  integration in explicit vendor adapters. A vendor's own packaging manifest is
+  the one thing that may sit outside its adapter, and only where that vendor's
+  tooling refuses to look anywhere else; it carries paths into the adapter, never
+  behaviour.
 - Do not claim a vendor package is generated or portable until the relevant
   build and live compatibility checks prove it.
 - Treat existing vendor repositories as authoritative until a recorded custody

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,16 @@ commands, hooks, permissions, and marketplace metadata belong in an explicit
 Claude adapter; they are not portable core merely because Claude is an initial
 source system.
 
+One narrow exception, forced by the Claude CLI rather than chosen: a Claude
+*packaging* manifest must sit at `<installed root>/.claude-plugin/plugin.json`,
+and a marketplace must sit at `<repository root>/.claude-plugin/marketplace.json`.
+The CLI offers no other location. Those files are distribution metadata only —
+they name paths and carry no command, hook body, agent, or permission — and
+every Claude behaviour they point at stays inside the adapter. See the
+`2026-08-25` decision "Claude installs the package root" in
+[`docs/engineering-journal/DECISIONS.md`](docs/engineering-journal/DECISIONS.md),
+which `tests/test_claude_plugin_packaging.py` enforces in both directions.
+
 Before finishing a change, run:
 
 ```bash

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -2,6 +2,63 @@
 
 ## 2026-08-25
 
+### Claude installs the package root; the client extension keeps the behaviour
+
+**Author.** Jeff Cox and Claude (Voice packaging follow-up, branch
+`orch/voice-claude-packaging`)
+
+**Decision.** The Claude Code distribution of a package in this catalog is the
+*package root*, not its `com.infiquetra.claude/` client extension. For `voice`
+that means `.claude-plugin/plugin.json` sits at `plugins/voice/`, the
+repository carries a Claude marketplace at `.claude-plugin/marketplace.json`
+whose entry names `./plugins/voice` as its source, and the Claude manifest
+declares every component by path into the client extension
+(`"hooks": "./com.infiquetra.claude/hooks/hooks.json"`) rather than holding any
+behaviour itself. `plugins/voice/plugin.json` is untouched and remains the
+portable Agent Plugins manifest.
+
+**Rationale.** Two facts about the installed Claude CLI (2.1.246) decide this,
+and neither is visible from the repository:
+
+1. Claude resolves a plugin only at `<root>/.claude-plugin/plugin.json`. There
+   is no fallback to `<root>/plugin.json`, so the extension's portable manifest
+   read to the CLI as no manifest at all: `claude plugin validate
+   plugins/voice/com.infiquetra.claude` failed with "No manifest found in
+   directory."
+2. An install copies exactly the directory a marketplace entry's `source`
+   names, and nothing above it. Verified by installing a probe marketplace and
+   reading the cache.
+
+The Stop hook imports the portable core and spawns `scripts/speak.py` from it,
+resolving both with `Path(__file__).resolve().parents[2]`. Installing only the
+extension would therefore copy the hook without the core it calls: the plugin
+would install and validate cleanly, then fail at the first spoken response. A
+probe install proved the chosen layout resolves that path correctly inside the
+cache and that Claude registers both the Stop hook and the Voice skill from it.
+
+**Rejected alternatives.** Duplicating or vendoring the portable core inside
+the client extension (this catalog does not keep a second writable copy of a
+package, and the operator ruled it out). Pointing the hook at a checkout via an
+environment variable (an installed plugin that silently depends on a working
+tree at a known path is not installed). Relying on the marketplace entry's
+inline metadata alone — that does validate the *marketplace*, but `claude
+plugin validate plugins/voice` still fails without the manifest, and the
+package must validate on its own.
+
+**Consequence for the repository boundary.** `CLAUDE.md` says Claude-specific
+marketplace metadata belongs in an explicit Claude adapter. These two files are
+the exception the CLI's contract forces, and the exception is narrow on
+purpose: both are pure distribution metadata that name paths and hold no
+command, hook body, agent, or permission. Every Claude *behaviour* remains
+inside `com.infiquetra.claude/`. `tests/test_claude_plugin_packaging.py`
+enforces both halves — that the manifests exist where Claude looks, and that no
+`hooks/`, `agents/`, or `commands/` directory appears at the portable root.
+
+**Revisit when.** Claude Code supports a manifest location other than
+`<root>/.claude-plugin/`, or a marketplace source that installs a directory
+while rooting the plugin beneath it. Either would let the packaging manifest
+move inside the adapter with no other change.
+
 ### Voice plugin version one: one run-wide plan, seven units, acceptance with recorded findings
 
 **Author.** Jeff Cox and Qwen (orchestrated run `orch-2026-08-25-voice`, U7

--- a/plugins/voice/.claude-plugin/plugin.json
+++ b/plugins/voice/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "voice",
+  "version": "0.1.0",
+  "description": "A spoken conversational loop for one explicitly bound, Herdr-managed Claude Code session. Claude installs this package root so the portable core travels with the client extension; every Claude-specific behaviour is declared out of com.infiquetra.claude/.",
+  "author": {
+    "name": "Infiquetra",
+    "email": "hello@infiquetra.com"
+  },
+  "repository": "https://github.com/infiquetra/infiquetra-agent-plugins",
+  "license": "MIT",
+  "keywords": [
+    "voice",
+    "speech",
+    "herdr",
+    "conversational-loop"
+  ],
+  "hooks": "./com.infiquetra.claude/hooks/hooks.json",
+  "skills": "./skills/"
+}

--- a/plugins/voice/README.md
+++ b/plugins/voice/README.md
@@ -19,7 +19,8 @@ the run-wide implementation plan is
 
 | Path | What it is |
 |---|---|
-| [`plugin.json`](plugin.json) | Agent Plugins 1.0 manifest |
+| [`plugin.json`](plugin.json) | Agent Plugins 1.0 manifest — the portable, vendor-neutral one |
+| [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) | Claude Code packaging manifest. A different specification, required by the Claude CLI to sit at the installed package root. Holds no behaviour: it declares the hooks path into `com.infiquetra.claude/` and the portable skills directory |
 | [`scripts/providers.py`](scripts/providers.py) | Provider declaration contract: closed egress set, declarations, named refusals |
 | [`scripts/settings.py`](scripts/settings.py) | The one settings reader: stated names, split defaults, absent never means empty |
 | [`scripts/process.py`](scripts/process.py) | Subprocess discipline: closed stdin and a deadline on every child |
@@ -39,6 +40,31 @@ the run-wide implementation plan is
 Claude-specific files — hooks and the client extension — never live in this
 portable core; they belong under the `com.infiquetra.claude/` client
 extension directory.
+
+## Installing into Claude Code
+
+The repository is a Claude marketplace. From a checkout:
+
+```bash
+claude plugin marketplace add /path/to/infiquetra-agent-plugins
+claude plugin install voice@infiquetra-agent-plugins
+```
+
+Claude installs the **package root** — this directory — so the portable core
+travels with the client extension. That is required rather than tidy: the Stop
+hook imports the core and spawns [`scripts/speak.py`](scripts/speak.py) from
+it, so an install carrying only `com.infiquetra.claude/` would validate, then
+fail at the first spoken response. The reasoning and the rejected alternatives
+are recorded in
+[`docs/engineering-journal/DECISIONS.md`](../../docs/engineering-journal/DECISIONS.md).
+
+Installing does not configure anything. Both providers are still declared by
+the operator, and `voice preflight` still has to pass before the loop runs —
+see [Settings](#settings) and
+[The Herdr-wide stop keybinding](#the-herdr-wide-stop-keybinding).
+
+Restart Claude Code after installing: the Stop hook is registered at session
+start.
 
 ## Providers are declared, never discovered
 

--- a/plugins/voice/com.infiquetra.claude/hooks/hooks.json
+++ b/plugins/voice/com.infiquetra.claude/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/stop_hook.py\"",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/com.infiquetra.claude/hooks/stop_hook.py\"",
             "timeout": 5
           }
         ]

--- a/plugins/voice/tests/test_stop_hook.py
+++ b/plugins/voice/tests/test_stop_hook.py
@@ -329,9 +329,19 @@ class DescriptorAndLayoutTests(StopHookTestCase):
         commands = [
             entry["command"] for entry in entries if entry.get("type") == "command"
         ]
+        # ``${CLAUDE_PLUGIN_ROOT}`` is the *installed package root*, which is
+        # plugins/voice/ -- not this client extension. Claude installs the
+        # package root so the portable core travels with the hook, so the
+        # command has to walk down into the extension. Asserting the resolved
+        # path exists as well as its spelling: a command that merely looks
+        # plausible fails only after a successful install.
         self.assertIn(
-            'python3 "${CLAUDE_PLUGIN_ROOT}/hooks/stop_hook.py"', commands
+            'python3 "${CLAUDE_PLUGIN_ROOT}/com.infiquetra.claude/hooks/stop_hook.py"',
+            commands,
         )
+        for command in commands:
+            relative = command.split("${CLAUDE_PLUGIN_ROOT}/", 1)[1].rstrip('"')
+            self.assertTrue((_PACKAGE / relative).is_file())
         for entry in entries:
             self.assertEqual(entry["timeout"], 5)
 

--- a/tests/test_claude_plugin_packaging.py
+++ b/tests/test_claude_plugin_packaging.py
@@ -1,0 +1,259 @@
+"""The Voice package must remain installable by the Claude CLI, and stay portable.
+
+Claude Code resolves a plugin by looking for ``.claude-plugin/plugin.json`` at
+the *root of the directory it installs*, and it installs exactly the directory a
+marketplace entry's ``source`` names -- nothing above it. Those two facts
+together decide this package's whole layout, and neither is visible from the
+files themselves, so they are pinned here.
+
+The bug this module exists to prevent: ``plugins/voice/com.infiquetra.claude/``
+carried a ``plugin.json`` at its own root, which is where the *portable* Agent
+Plugins spec puts a manifest and is not where Claude looks. ``claude plugin
+validate`` answered "No manifest found in directory. Expected
+.claude-plugin/marketplace.json or .claude-plugin/plugin.json" and the package
+could not be installed at all.
+
+Why the installed root is the package, not the client extension: the Stop hook
+imports the portable core and spawns ``scripts/speak.py`` from it. Installing
+only ``com.infiquetra.claude/`` would copy the hook without the core it calls,
+so the plugin would install cleanly and then fail at the first spoken response.
+Making the extension self-sufficient instead would mean duplicating the core,
+which this catalog does not do. So the installed root is ``plugins/voice/`` and
+the Claude manifest declares its behaviour out of the client extension by path.
+
+That leaves two manifests side by side in the package root, deliberately:
+
+- ``plugins/voice/plugin.json`` -- the portable Agent Plugins manifest, carrying
+  the ``$schema`` that ``scripts/check_repo.py`` enforces. Vendor-neutral.
+- ``plugins/voice/.claude-plugin/plugin.json`` -- Claude's own packaging
+  manifest. A different spec with different fields, required by the CLI to sit
+  at the installed root.
+
+They are not duplicates and neither substitutes for the other. The Claude
+manifest holds no behaviour: every component it declares is a path into
+``com.infiquetra.claude/`` or into the portable surface.
+
+Presence is asserted as well as value throughout. A check that only compared the
+declarations it found could be satisfied by deleting them, which is the
+"guarantee that cannot fail" shape this repository has rejected before.
+
+Standard library only, matching the rest of this suite.
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+#: The repository's Claude marketplace. Claude requires this exact location.
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+
+#: The package root Claude installs, and the two manifests that share it.
+PLUGIN_ROOT = ROOT / "plugins" / "voice"
+CLAUDE_MANIFEST = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
+PORTABLE_MANIFEST = PLUGIN_ROOT / "plugin.json"
+
+#: The Claude client extension. Every Claude-specific behaviour lives under it.
+EXTENSION = PLUGIN_ROOT / "com.infiquetra.claude"
+STOP_HOOK = EXTENSION / "hooks" / "stop_hook.py"
+
+#: The portable Agent Plugins schema, which marks the vendor-neutral manifest.
+#: ``scripts/check_repo.py`` is the authority; it is restated here only to prove
+#: the two manifests are different specs rather than one copied over the other.
+PORTABLE_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+
+#: The plugin name both manifests and the marketplace entry must agree on.
+PLUGIN_NAME = "voice"
+
+#: Directories Claude scans by convention at a plugin root. None may appear at
+#: the portable package root: Claude-specific material belongs in the extension,
+#: and anything found here would be loaded as portable core by every other
+#: vendor adapter that reads this package.
+CLAUDE_CONVENTION_DIRS = ("hooks", "agents", "commands")
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _marketplace_entry() -> dict:
+    for entry in _load(MARKETPLACE).get("plugins", []):
+        if entry.get("name") == PLUGIN_NAME:
+            return entry
+    raise AssertionError(f"no {PLUGIN_NAME!r} entry in {MARKETPLACE.relative_to(ROOT)}")
+
+
+class ClaudeManifestLocationTests(unittest.TestCase):
+    """Where Claude looks, and what it finds when it looks there."""
+
+    def test_the_installable_root_carries_a_manifest_where_claude_looks(self) -> None:
+        # The exact regression: a manifest anywhere else reads to the CLI as no
+        # manifest at all, and the package cannot be installed.
+        self.assertTrue(
+            CLAUDE_MANIFEST.is_file(),
+            f"{CLAUDE_MANIFEST.relative_to(ROOT)} is missing; `claude plugin "
+            "validate` reports 'No manifest found in directory'",
+        )
+
+    def test_the_portable_manifest_is_preserved_beside_it(self) -> None:
+        self.assertTrue(PORTABLE_MANIFEST.is_file())
+        self.assertEqual(_load(PORTABLE_MANIFEST).get("$schema"), PORTABLE_SCHEMA)
+
+    def test_the_two_manifests_are_different_specs_not_one_copied_over(self) -> None:
+        claude = _load(CLAUDE_MANIFEST)
+        self.assertNotIn(
+            "$schema",
+            claude,
+            "the Claude manifest must not carry the portable Agent Plugins "
+            "schema: they are different specifications",
+        )
+        self.assertEqual(claude.get("name"), _load(PORTABLE_MANIFEST).get("name"))
+
+    def test_the_client_extension_keeps_its_own_portable_manifest(self) -> None:
+        # The extension stays a described package in the portable catalog. What
+        # changed is only that Claude installs the package root above it.
+        self.assertTrue((EXTENSION / "plugin.json").is_file())
+
+
+class DeclaredComponentPathTests(unittest.TestCase):
+    """Every path the Claude manifest declares must resolve, and stay in its lane."""
+
+    def test_every_declared_component_path_exists(self) -> None:
+        manifest = _load(CLAUDE_MANIFEST)
+        declared = {
+            key: value
+            for key, value in manifest.items()
+            if key in ("hooks", "skills", "agents", "commands", "mcpServers")
+            and isinstance(value, str)
+        }
+        self.assertTrue(declared, "the Claude manifest declares no component paths")
+        for key, value in declared.items():
+            with self.subTest(component=key):
+                self.assertTrue(
+                    value.startswith("./"),
+                    f"{key} path {value!r} must be relative to the plugin root",
+                )
+                self.assertFalse(
+                    ".." in Path(value).parts,
+                    f"{key} path {value!r} escapes the installed root, which is "
+                    "the only thing the install copies",
+                )
+                self.assertTrue(
+                    (PLUGIN_ROOT / value).exists(),
+                    f"{key} path {value!r} does not resolve under "
+                    f"{PLUGIN_ROOT.relative_to(ROOT)}",
+                )
+
+    def test_the_hooks_declaration_points_into_the_client_extension(self) -> None:
+        hooks = _load(CLAUDE_MANIFEST).get("hooks")
+        self.assertIsInstance(hooks, str, "the hooks path must be declared")
+        resolved = (PLUGIN_ROOT / hooks).resolve()
+        self.assertTrue(
+            resolved.is_relative_to(EXTENSION.resolve()),
+            f"hooks path {hooks!r} must live under "
+            f"{EXTENSION.relative_to(ROOT)}; Claude-specific behaviour does not "
+            "belong in the portable core",
+        )
+
+    def test_no_claude_convention_directory_sits_at_the_portable_root(self) -> None:
+        for name in CLAUDE_CONVENTION_DIRS:
+            with self.subTest(directory=name):
+                self.assertFalse(
+                    (PLUGIN_ROOT / name).exists(),
+                    f"plugins/voice/{name}/ would be read as portable core by "
+                    "every other vendor adapter; it belongs in the extension",
+                )
+
+
+class HookRuntimePathTests(unittest.TestCase):
+    """The two path resolutions that only break after a successful install."""
+
+    def test_the_hook_command_resolves_from_the_installed_plugin_root(self) -> None:
+        # ``${CLAUDE_PLUGIN_ROOT}`` expands to the installed package root. A
+        # stale command path here installs and validates cleanly, then fails at
+        # the first spoken response with nothing pointing back to this file.
+        hooks_file = PLUGIN_ROOT / _load(CLAUDE_MANIFEST)["hooks"]
+        entries = _load(hooks_file)["hooks"]
+        commands = [
+            hook["command"]
+            for matchers in entries.values()
+            for matcher in matchers
+            for hook in matcher["hooks"]
+            if hook.get("type") == "command"
+        ]
+        self.assertTrue(commands, "the hooks descriptor declares no command")
+        for command in commands:
+            with self.subTest(command=command):
+                self.assertIn("${CLAUDE_PLUGIN_ROOT}", command)
+                for token in command.split('"'):
+                    if "${CLAUDE_PLUGIN_ROOT}" not in token:
+                        continue
+                    relative = token.split("${CLAUDE_PLUGIN_ROOT}", 1)[1].lstrip("/")
+                    self.assertTrue(
+                        (PLUGIN_ROOT / relative).is_file(),
+                        f"{relative} does not exist under the installed root",
+                    )
+
+    def test_the_stop_hook_finds_the_portable_core_inside_the_installed_root(
+        self,
+    ) -> None:
+        # The hook reaches the core with ``parents[2]``. That resolution must
+        # land inside the directory the install copies, or the core is simply
+        # absent at runtime -- which is what installing only the extension would
+        # have produced.
+        self.assertTrue(STOP_HOOK.is_file())
+        core = STOP_HOOK.resolve().parents[2] / "scripts"
+        self.assertEqual(
+            core.parent,
+            PLUGIN_ROOT.resolve(),
+            "the hook resolves the portable core outside the installed root",
+        )
+        self.assertTrue((core / "speak.py").is_file())
+
+
+class MarketplaceEntryTests(unittest.TestCase):
+    """The marketplace is how Voice is installed from this repository."""
+
+    def test_the_marketplace_sits_where_claude_looks_and_names_an_owner(self) -> None:
+        self.assertTrue(MARKETPLACE.is_file())
+        payload = _load(MARKETPLACE)
+        self.assertTrue(payload.get("name"))
+        self.assertIsInstance(payload.get("owner"), dict)
+        # `--strict` treats a missing marketplace description as an error, and
+        # continuous integration runs strict.
+        self.assertTrue(payload.get("metadata", {}).get("description"))
+
+    def test_the_entry_source_is_the_package_root_not_the_extension(self) -> None:
+        source = _marketplace_entry().get("source")
+        self.assertIsInstance(source, str)
+        resolved = (ROOT / source).resolve()
+        self.assertEqual(
+            resolved,
+            PLUGIN_ROOT.resolve(),
+            "source must name the package root: Claude copies exactly this "
+            "directory, and the extension alone would arrive without the core",
+        )
+        self.assertTrue((resolved / ".claude-plugin" / "plugin.json").is_file())
+
+    def test_the_entry_and_the_plugin_manifest_agree(self) -> None:
+        # `claude plugin tag` refuses to tag a release whose manifest and
+        # enclosing marketplace entry disagree, so the agreement is contract.
+        entry = _marketplace_entry()
+        manifest = _load(CLAUDE_MANIFEST)
+        for field in ("name", "version"):
+            with self.subTest(field=field):
+                self.assertEqual(entry.get(field), manifest.get(field))
+
+    def test_the_entry_version_matches_the_portable_manifest_too(self) -> None:
+        self.assertEqual(
+            _marketplace_entry().get("version"),
+            _load(PORTABLE_MANIFEST).get("version"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mission_control_rule_audit.py
+++ b/tests/test_mission_control_rule_audit.py
@@ -611,8 +611,21 @@ class PromptAlignmentAuditTests(unittest.TestCase):
         self.assertFalse((PACKAGE / ".claude-plugin" / "plugin.json").exists())
         self.assertTrue((PACKAGE / "com.infiquetra.claude" / "plugin.json").exists())
 
-        # 2. Marketplace is absent from repo root
-        self.assertFalse((ROOT / ".claude-plugin" / "marketplace.json").exists())
+        # 2. Mission Control is not published through a Claude marketplace.
+        #    A repo-root marketplace exists since 2026-08-25, when the `voice`
+        #    package became installable from this repository, so its mere
+        #    presence no longer carries this premise. What matters for Mission
+        #    Control is unchanged and is what is checked: no entry names it, so
+        #    nothing here installs it as a Claude plugin.
+        marketplace = ROOT / ".claude-plugin" / "marketplace.json"
+        if marketplace.exists():
+            listed = {
+                entry.get("name")
+                for entry in json.loads(marketplace.read_text(encoding="utf-8")).get(
+                    "plugins", []
+                )
+            }
+            self.assertNotIn("mission-control", listed)
 
         # 3. Client extensions are relocated under com.infiquetra.claude/
         self.assertFalse((PACKAGE / "agents" / "sdlc-operator.md").exists())


### PR DESCRIPTION
`claude plugin validate plugins/voice/com.infiquetra.claude` fails on the current `main`:

```
✘ directory: No manifest found in directory.
  Expected .claude-plugin/marketplace.json or .claude-plugin/plugin.json
```

The client extension carries its manifest at its own root — where the portable Agent Plugins spec puts one, and not where the Claude CLI looks. Voice cannot be installed at all today. This makes it installable and publishes the marketplace to install it from.

## What the CLI actually requires

Two facts decide the whole layout. Neither is visible from the repository, and both were verified against the installed CLI (2.1.246) rather than assumed:

1. **Claude resolves a plugin only at `<root>/.claude-plugin/plugin.json`.** There is no fallback to `<root>/plugin.json`.
2. **An install copies exactly the directory a marketplace entry's `source` names — nothing above it.** Verified by installing a probe marketplace and reading the resulting cache.

The Stop hook imports the portable core and spawns `scripts/speak.py` from it, resolving both with `Path(__file__).resolve().parents[2]`. Installing only `com.infiquetra.claude/` would copy the hook without the core it calls: the plugin would install and validate cleanly, then fail at the first spoken response.

So the installed root is the **package root**, and the Claude manifest declares its behaviour by path into the client extension.

## Changes

| File | What |
|---|---|
| `.claude-plugin/marketplace.json` | New. One entry, `source: "./plugins/voice"` |
| `plugins/voice/.claude-plugin/plugin.json` | New. Declares `hooks: ./com.infiquetra.claude/hooks/hooks.json` and `skills: ./skills/`. Holds no behaviour |
| `plugins/voice/com.infiquetra.claude/hooks/hooks.json` | Command corrected to `${CLAUDE_PLUGIN_ROOT}/com.infiquetra.claude/hooks/stop_hook.py` — the old spelling pointed at a path that does not exist under the installed root |

`plugins/voice/plugin.json` is **untouched** and remains the portable Agent Plugins manifest with its `$schema`. The two manifests are different specifications sitting side by side, not duplicates. The portable core is neither moved nor duplicated, and no other repository is touched.

## The boundary question, answered rather than skipped

`CLAUDE.md` says Claude-specific marketplace metadata belongs in an explicit Claude adapter. These two files are an exception the CLI's contract forces, and the exception is deliberately narrow: both are pure distribution metadata that name paths and carry no command, hook body, agent, or permission. Every Claude *behaviour* stays inside `com.infiquetra.claude/`.

Rather than let that sit as an unexplained contradiction, `AGENTS.md` and `CLAUDE.md` now state the exception where the rule is stated, and `docs/engineering-journal/DECISIONS.md` records the rationale, the rejected alternatives (vendoring the core into the extension; pointing the hook at a checkout via an environment variable), and a revisit-when condition.

## Tests

`tests/test_claude_plugin_packaging.py` — 13 tests pinning the validated layout and the marketplace entry. Every assertion was confirmed to **fail** against the shape it guards, not merely pass against the fixed one:

| Broken shape reintroduced | Result |
|---|---|
| Claude manifest removed (the original bug) | 2 failures, 5 errors |
| Stale `${CLAUDE_PLUGIN_ROOT}/hooks/...` command | 1 failure |
| `source` pointed at the extension | 1 failure |
| `hooks/` created at the portable root | 1 failure |

`plugins/voice/tests/test_stop_hook.py` pinned the old command spelling; it now asserts the new one **and** that the path resolves, so a plausible-but-wrong command cannot pass again.

One structural premise in `tests/test_mission_control_rule_audit.py` asserted this repository had no root marketplace. That premise explains why an upstream Mission Control test was dropped from custody, and a root marketplace now exists by design — so it checks what actually carries the premise: that no entry names Mission Control.

## Verification

- `claude plugin validate plugins/voice --strict` — passed
- `claude plugin validate . --strict` — passed
- `python3 scripts/check_repo.py` — passed
- `python3 -m unittest discover -s tests` — **754 passed**
- `python3 -m pytest plugins/voice/tests -q` — **270 passed**, 10 consecutive runs, 0 failures
- `git diff --check` — clean

A probe install from this branch registered **Skills (1) voice** and **Hooks (1) Stop**, and confirmed inside the cache that the hook command target resolves, the portable core is present, and `plugin.json` is preserved.
