### PR TITLE
fix(voice): resolve the stop keybinding instead of matching its text

### DIFF
--- a/docs/engineering-journal/LEARNINGS.md
+++ b/docs/engineering-journal/LEARNINGS.md
@@ -2,6 +2,43 @@
 
 ## 2026-08-25
 
+### A probe that matches text instead of resolving it reports a false green
+
+**Author.** Jeff Cox and Claude (voice stop-command follow-up, branch
+`orch/voice-stop-launcher`)
+
+**Context.** Voice preflight checks an operator-owned Herdr keybinding that
+must invoke the package's stop path. The operator caught the defect before
+acting on the documented instruction.
+
+**Evidence.** `plugins/voice/scripts/preflight.py` tested
+`if KEYBINDING_MARKER in command` — a substring match on `"voice stop"`. The
+package README documented exactly that binding, and `command -v voice` returned
+nothing: the installed `scripts/voice_cli.py` had no shebang and no executable
+bit, and no `voice` existed on `PATH`. Following the documentation would have
+produced a green preflight for a key that parsed, ran, and stopped nothing.
+
+**Mechanism.** The probe and the requirement were about different things.
+The requirement is *can this stop playback*; the probe asked *does this string
+appear*. Those agree only while the documented spelling happens to be
+executable, and nothing enforced that. The failure is worse than an absent
+probe, because a green line retires the operator's own suspicion — the one
+thing that actually caught it here. The same file already knew better:
+`probe_executable`, twenty lines below, checked `os.access(path, os.X_OK)`.
+The keybinding probe simply never adopted the standard its neighbour used.
+
+**Compounding cause.** No stable path exists to bind to. Claude installs under
+`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`, a version bump
+creates a new directory (73 orphaned version directories on this host), and
+there is no `current` or `latest` symlink. So the honest command could not be
+written down at all until a launcher resolved the install at invocation time
+from Claude's own registry, which Claude rewrites on every update.
+
+**Generalizable rule.** A readiness check must resolve the thing it claims is
+ready, not pattern-match the text that names it; and when a check reports on
+something an operator configures, verify the configured value the way the
+runtime will consume it.
+
 ### Claude Code runs Stop hooks synchronously — a hook that does real work must detach
 
 **Author.** Jeff Cox and Qwen (voice run, #29/#34)

--- a/plugins/voice/README.md
+++ b/plugins/voice/README.md
@@ -122,20 +122,62 @@ honoured.
 
 ## The Herdr-wide stop keybinding
 
-Voice preflight checks — and never writes — one operator-owned keybinding: a
-Herdr-wide binding whose command invokes the package's stop path. Add a
-`[[keys.command]]` entry to `~/.config/herdr/config.toml` whose `command`
-string contains `voice stop`; the key itself is yours to choose:
+Voice preflights — and never writes — one operator-owned keybinding: a
+Herdr-wide binding whose command invokes the package's stop path.
+
+### First, put `voice` on PATH
+
+Claude installs a plugin under a *versioned* directory, and a version bump
+creates a new one rather than reusing the old. There is no `current` or
+`latest` symlink, so **no path inside an installed package is stable**, and a
+keybinding written against one stops working at the next release without
+announcing it: the key still exists, the command still parses, nothing runs.
+
+So the binding invokes a small launcher that resolves the current install at
+invocation time, from Claude's own plugin registry — which Claude rewrites on
+every install and update. Write it once:
+
+```bash
+python3 ~/.claude/plugins/cache/infiquetra-agent-plugins/voice/*/com.infiquetra.claude/scripts/install_launcher.py
+```
+
+That writes `~/.local/bin/voice` and nothing else. It refuses to overwrite a
+`voice` it did not generate unless you pass `--force`, and `--print` shows the
+file without writing it. Confirm with `command -v voice`.
+
+The launcher follows version bumps on its own; you never edit the keybinding
+again.
+
+### Then add the binding
 
 ```toml
 [[keys.command]]
 key = "<your key here>"
+type = "shell"
 command = "voice stop"
 description = "stop voice playback"
 ```
 
-Voice reports the keybinding's absence by name; it never creates or repairs
-any Herdr configuration.
+The key is yours to choose. `type = "shell"` runs the command detached in the
+background, which is what a stop key wants — `pane` and `popup` would open a
+terminal to stop audio.
+
+Voice reports this binding's absence by name; it never creates or repairs any
+Herdr configuration.
+
+### What preflight actually checks
+
+Preflight resolves the configured command rather than pattern-matching it: it
+confirms the program is on `PATH` (or is an existing executable file) and that
+any `.py` script named beside it exists. It never *runs* the command — firing a
+stop as a side effect of asking whether a stop is possible would be its own
+defect.
+
+This matters because containing the text `voice stop` and being able to stop
+anything are different claims, and they came apart here: the binding was
+documented before any `voice` existed on `PATH`. A probe that reported that as
+healthy would have been worse than no probe, because it retires your own
+suspicion.
 
 ## Subprocess discipline
 

--- a/plugins/voice/com.infiquetra.claude/scripts/install_launcher.py
+++ b/plugins/voice/com.infiquetra.claude/scripts/install_launcher.py
@@ -1,0 +1,180 @@
+"""Write a stable ``voice`` launcher, so an operator keybinding can survive updates.
+
+Claude installs a plugin under a *versioned* directory --
+``~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`` -- and a version
+bump creates a new directory rather than reusing the old one. There is no
+``current`` or ``latest`` symlink. So no path inside an installed package is
+stable, and a Herdr keybinding written against one silently stops working at the
+next release: the key still exists, the command still parses, and nothing runs.
+
+This writes a small launcher to a directory on ``PATH`` that resolves the
+current install at *invocation* time, from Claude's own installed-plugin
+registry. The registry is the right source because Claude maintains it: it
+rewrites ``installPath`` on every install and update, so the launcher follows a
+version bump with no reconfiguration anywhere.
+
+The emitted launcher is deliberately self-contained. It cannot import anything
+from the package, because finding the package is the job it exists to do.
+
+**This never runs on its own.** It is an explicit operator command, and it
+writes exactly one file, only inside the operator's own executable directory,
+only after saying what it is about to do. Voice writes no Herdr configuration
+here or anywhere else (R15): what the operator does with the resulting command
+is theirs to decide, and the keybinding stays a manual step.
+
+This module lives in the Claude client extension rather than the portable core
+because reading Claude's plugin registry is Claude client knowledge. The
+portable package neither knows nor needs to know how a vendor lays out an
+install.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+#: Claude's installed-plugin registry. Stable across versions, and rewritten by
+#: Claude on every install and update -- which is exactly the property the
+#: versioned install directory lacks.
+REGISTRY = Path("~/.claude/plugins/installed_plugins.json")
+
+#: The plugin's registry key, ``<plugin>@<marketplace>``.
+PLUGIN_KEY = "voice@infiquetra-agent-plugins"
+
+#: Where the launcher goes. First on this operator's ``PATH`` and already the
+#: home of ``herdr``, ``claude``, and ``agent``, so it is the established
+#: convention rather than a new one invented here.
+DEFAULT_LAUNCHER = Path("~/.local/bin/voice")
+
+#: The launcher body. It resolves the newest install by ``lastUpdated`` and
+#: execs the package CLI, forwarding every argument. Failure is reported by
+#: name on stderr: a stop key that silently does nothing is the defect this
+#: whole module exists to prevent.
+LAUNCHER_BODY = '''#!/usr/bin/env python3
+"""Resolve the installed voice package and run its CLI. Generated file.
+
+Regenerate with:
+    python3 <install>/com.infiquetra.claude/scripts/install_launcher.py
+
+Resolution happens on every invocation, so a Claude plugin update that moves
+the package to a new version directory needs no change here.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+REGISTRY = Path({registry!r}).expanduser()
+PLUGIN_KEY = {plugin_key!r}
+
+
+def main() -> int:
+    if not REGISTRY.is_file():
+        print(f"voice: no Claude plugin registry at {{REGISTRY}}", file=sys.stderr)
+        return 1
+    try:
+        entries = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        entries = entries["plugins"][PLUGIN_KEY]
+    except (OSError, ValueError, KeyError):
+        print(
+            f"voice: {{PLUGIN_KEY}} is not installed; "
+            "run `claude plugin install " + PLUGIN_KEY + "`",
+            file=sys.stderr,
+        )
+        return 1
+    if not entries:
+        print(f"voice: {{PLUGIN_KEY}} has no install recorded", file=sys.stderr)
+        return 1
+    newest = sorted(entries, key=lambda e: e.get("lastUpdated", ""))[-1]
+    cli = Path(newest["installPath"]) / "scripts" / "voice_cli.py"
+    if not cli.is_file():
+        print(f"voice: the recorded install has no CLI at {{cli}}", file=sys.stderr)
+        return 1
+    os.execv(sys.executable, [sys.executable, str(cli), *sys.argv[1:]])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def render_launcher() -> str:
+    """The launcher text, with this module's registry contract baked in."""
+    return LAUNCHER_BODY.format(registry=str(REGISTRY), plugin_key=PLUGIN_KEY)
+
+
+def install(destination: Path | str | None = None, *, force: bool = False) -> Path:
+    """Write the launcher and mark it executable. Returns where it landed.
+
+    Refuses to overwrite a file this module did not generate unless ``force``
+    is given: something else called ``voice`` on the operator's ``PATH`` is
+    theirs, and clobbering it silently would be exactly the kind of unrequested
+    write this package does not do.
+    """
+    path = Path(destination).expanduser() if destination else DEFAULT_LAUNCHER.expanduser()
+    body = render_launcher()
+    if path.exists() and not force:
+        existing = path.read_text(encoding="utf-8", errors="replace")
+        if "Generated file." not in existing:
+            raise SystemExit(
+                f"voice: {path} exists and was not generated by this command; "
+                "inspect it, then pass --force to replace it"
+            )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="install_launcher",
+        description=(
+            "Write a stable `voice` launcher onto PATH so a Herdr keybinding "
+            "survives Claude plugin version updates. Writes one file; never "
+            "touches Herdr configuration."
+        ),
+    )
+    parser.add_argument(
+        "--destination",
+        default=None,
+        help=f"where to write the launcher (default: {DEFAULT_LAUNCHER})",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="replace a file this command did not generate",
+    )
+    parser.add_argument(
+        "--print",
+        dest="print_only",
+        action="store_true",
+        help="print the launcher instead of writing it",
+    )
+    arguments = parser.parse_args(argv)
+
+    if arguments.print_only:
+        sys.stdout.write(render_launcher())
+        return 0
+
+    path = install(arguments.destination, force=arguments.force)
+    print(f"voice: launcher written to {path}")
+    directory = str(path.parent)
+    on_path = directory in os.environ.get("PATH", "").split(os.pathsep)
+    if on_path:
+        print(f"voice: {directory} is on PATH — `voice stop` is runnable now")
+    else:
+        print(
+            f"voice: {directory} is NOT on PATH; add it, or the keybinding "
+            "will parse and do nothing"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/voice/scripts/preflight.py
+++ b/plugins/voice/scripts/preflight.py
@@ -39,6 +39,8 @@ import http.client
 import json
 import os
 import re
+import shlex
+import shutil
 import tomllib
 import urllib.error
 import urllib.request
@@ -68,6 +70,8 @@ __all__ = [
     "probe_hermes_profile",
     "probe_sample_round_trip",
     "probe_keybinding",
+    "command_is_runnable",
+    "command_names_stop_path",
     "probe_executable",
     "run_all",
     "format_report",
@@ -97,8 +101,13 @@ SAMPLE_FILE_PREFIX = "preflight-sample-"
 #: The operator's Herdr custom keybindings live here (KTD13, XDG).
 DEFAULT_KEYBINDING_PATH = Path("~/.config/herdr/config.toml")
 
-#: The keybinding probe looks for this in any binding's command string.
+#: The documented binding, and what the probe reports by name.
 KEYBINDING_MARKER = "voice stop"
+
+#: The package CLI, for recognizing a binding that invokes it directly rather
+#: than through the launcher. Both forms are legitimate; only the launcher form
+#: survives a version bump, which is why it is the one documented.
+KEYBINDING_CLI = "voice_cli.py"
 
 _TOKEN_HEADER = "X-Hermes-Session-Token"
 #: The wire contract of KTD9: the session token is served on the dashboard
@@ -552,20 +561,99 @@ def probe_keybinding(config_path: Path | str | None = None) -> ProbeResult:
             CHECK_FAILED,
             f"{path} does not parse as TOML",
         )
-    for command in _keybinding_commands(config):
-        if KEYBINDING_MARKER in command:
-            return ProbeResult(
-                "herdr-config",
-                check,
-                CHECK_OK,
-                "a keybinding command contains " f"{KEYBINDING_MARKER!r}",
-            )
+    marked = [
+        command for command in _keybinding_commands(config) if command_names_stop_path(command)
+    ]
+    if not marked:
+        return ProbeResult(
+            "herdr-config",
+            check,
+            CHECK_FAILED,
+            f"no keybinding command contains {KEYBINDING_MARKER!r}",
+        )
+    reasons = []
+    for command in marked:
+        runnable, detail = command_is_runnable(command)
+        if runnable:
+            return ProbeResult("herdr-config", check, CHECK_OK, detail)
+        reasons.append(detail)
     return ProbeResult(
         "herdr-config",
         check,
         CHECK_FAILED,
-        f"no keybinding command contains {KEYBINDING_MARKER!r}",
+        "a keybinding names the stop path but cannot run it: " + "; ".join(reasons),
     )
+
+
+def command_names_stop_path(command: str) -> bool:
+    """Whether a binding command invokes the package's stop path, in either form.
+
+    Two spellings reach the same stop, and a probe that knew only one would be
+    wrong in a different direction each time:
+
+    - ``voice stop`` -- through the launcher. The documented form, because it is
+      the only one that survives a Claude plugin version bump.
+    - ``... voice_cli.py ... stop`` -- straight at the package CLI. Legitimate,
+      and pinned to a versioned install directory, so it goes stale on update.
+
+    Matching only the first would report a working direct binding as absent.
+    """
+    if KEYBINDING_MARKER in command:
+        return True
+    return KEYBINDING_CLI in command and "stop" in command.split()
+
+
+def command_is_runnable(command: str) -> tuple[bool, str]:
+    """Whether a configured keybinding command could actually execute.
+
+    Containing the marker only proves the operator *meant* the stop path. It
+    does not prove anything runs, and the two came apart in practice: the
+    documented binding was ``voice stop`` while no ``voice`` existed on
+    ``PATH``, so the binding parsed, the key worked, and nothing happened. A
+    probe that reported that as healthy is worse than no probe, because it
+    retires the operator's own suspicion.
+
+    Two things are checked, and neither executes the command -- a preflight that
+    fires a stop as a side effect of asking whether a stop is possible would be
+    its own defect:
+
+    1. The program resolves: a bare name is looked up on ``PATH``; a path is
+       checked for existence and the executable bit.
+    2. Every script argument that names a ``.py`` file exists. This is what
+       catches an interpreter invocation whose script path went stale --
+       ``python3`` resolves perfectly well while the script beside it does not.
+
+    Returns the verdict and the sentence the report shows either way.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False, f"{command!r} does not parse as a shell command"
+    if not tokens:
+        return False, "the keybinding command is empty"
+
+    program, *arguments = tokens
+    if os.sep in program or program.startswith("~"):
+        resolved = Path(program).expanduser()
+        if not resolved.is_file():
+            return False, f"{program!r} does not exist"
+        if not os.access(resolved, os.X_OK):
+            return False, f"{program!r} is present but not executable"
+        located = str(resolved)
+    else:
+        found = shutil.which(program)
+        if found is None:
+            return False, f"{program!r} is not on PATH"
+        located = found
+
+    for argument in arguments:
+        if not argument.endswith(".py"):
+            continue
+        script = Path(argument).expanduser()
+        if not script.is_file():
+            return False, f"{program!r} resolves but its script {argument!r} does not exist"
+
+    return True, f"{KEYBINDING_MARKER!r} runs {located}"
 
 
 def probe_executable(owner: str, stated_path: str) -> ProbeResult:

--- a/plugins/voice/scripts/voice_cli.py
+++ b/plugins/voice/scripts/voice_cli.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """The voice command surface: one small CLI over the portable package.
 
 Commands:

--- a/plugins/voice/skills/voice/SKILL.md
+++ b/plugins/voice/skills/voice/SKILL.md
@@ -61,7 +61,9 @@ its session token, the configured profile resolved among the relay's
 profiles, and one synthesized sample round trip that comes back a
 non-empty transcript from the `xai` speech-to-text provider — the round
 trip is the speech-to-text guarantee; the Herdr-wide `voice stop`
-keybinding presence; and the capture and playback executables. Preflight
+keybinding, checked by resolving its command rather than matching its
+text, because containing `voice stop` and being able to stop anything
+are different claims; and the capture and playback executables. Preflight
 reads and probes only — it never installs, writes, or repairs anything.
 
 ## Settings and privacy

--- a/plugins/voice/tests/test_install_launcher.py
+++ b/plugins/voice/tests/test_install_launcher.py
@@ -1,0 +1,177 @@
+"""The stable ``voice`` launcher: what it writes, and what it refuses to write.
+
+The launcher exists because Claude's install path carries the version --
+``.../voice/0.1.0/`` -- and a version bump creates a new directory rather than
+reusing the old one. A Herdr keybinding written against a versioned path stops
+working at the next release without announcing it. So the binding invokes a
+launcher that resolves the install at *invocation* time.
+
+These tests cover the two things that make it trustworthy: the emitted file is
+genuinely runnable, and installing it never clobbers something that was already
+there under that name.
+
+Standard library only. No network, no writes outside a temporary directory.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+_PACKAGE = Path(__file__).resolve().parents[1]
+_INSTALLER = _PACKAGE / "com.infiquetra.claude" / "scripts" / "install_launcher.py"
+
+sys.path.insert(0, str(_INSTALLER.parent))
+import install_launcher  # noqa: E402
+
+
+class LauncherEmissionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.destination = Path(self.tmp.name) / "bin" / "voice"
+
+    def test_the_written_launcher_is_executable_and_has_a_shebang(self) -> None:
+        path = install_launcher.install(self.destination)
+        self.assertEqual(path, self.destination)
+        self.assertTrue(path.is_file())
+        self.assertTrue(os.access(path, os.X_OK), "the launcher must be executable")
+        self.assertTrue(
+            path.read_text(encoding="utf-8").startswith("#!"),
+            "without a shebang the launcher is not directly runnable",
+        )
+
+    def test_the_launcher_resolves_a_recorded_install_and_forwards_arguments(
+        self,
+    ) -> None:
+        # A complete stand-in for Claude's registry and install, so the whole
+        # resolution path runs without touching the real one.
+        root = Path(self.tmp.name)
+        install_root = root / "cache" / "voice" / "9.9.9"
+        (install_root / "scripts").mkdir(parents=True)
+        (install_root / "scripts" / "voice_cli.py").write_text(
+            "import sys\nprint('cli got:', *sys.argv[1:])\n", encoding="utf-8"
+        )
+        registry = root / "installed_plugins.json"
+        registry.write_text(
+            '{"plugins": {"voice@infiquetra-agent-plugins": ['
+            '{"installPath": "' + str(install_root) + '", '
+            '"version": "9.9.9", "lastUpdated": "2026-01-01T00:00:00.000Z"}]}}',
+            encoding="utf-8",
+        )
+        body = install_launcher.render_launcher().replace(
+            repr(str(install_launcher.REGISTRY)), repr(str(registry))
+        )
+        launcher = root / "voice"
+        launcher.write_text(body, encoding="utf-8")
+        launcher.chmod(0o755)
+
+        done = subprocess.run(
+            [sys.executable, str(launcher), "stop"], capture_output=True, text=True
+        )
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn("cli got: stop", done.stdout)
+
+    def test_the_newest_install_wins_when_several_are_recorded(self) -> None:
+        root = Path(self.tmp.name)
+        registry = root / "installed_plugins.json"
+        entries = []
+        for version, stamp in (("1.0.0", "2026-01-01"), ("2.0.0", "2026-06-01")):
+            install_root = root / version
+            (install_root / "scripts").mkdir(parents=True)
+            (install_root / "scripts" / "voice_cli.py").write_text(
+                f"print('version {version}')\n", encoding="utf-8"
+            )
+            entries.append(
+                '{"installPath": "' + str(install_root) + '", "version": "'
+                + version + '", "lastUpdated": "' + stamp + 'T00:00:00.000Z"}'
+            )
+        registry.write_text(
+            '{"plugins": {"voice@infiquetra-agent-plugins": ['
+            + ", ".join(entries) + "]}}",
+            encoding="utf-8",
+        )
+        body = install_launcher.render_launcher().replace(
+            repr(str(install_launcher.REGISTRY)), repr(str(registry))
+        )
+        launcher = root / "voice"
+        launcher.write_text(body, encoding="utf-8")
+        launcher.chmod(0o755)
+        done = subprocess.run(
+            [sys.executable, str(launcher)], capture_output=True, text=True
+        )
+        self.assertIn("version 2.0.0", done.stdout)
+
+    def test_a_missing_install_is_refused_by_name_not_silently(self) -> None:
+        # A stop key that fails quietly is the defect this whole module exists
+        # to prevent, so the failure path has to say something.
+        root = Path(self.tmp.name)
+        registry = root / "installed_plugins.json"
+        registry.write_text('{"plugins": {}}', encoding="utf-8")
+        body = install_launcher.render_launcher().replace(
+            repr(str(install_launcher.REGISTRY)), repr(str(registry))
+        )
+        launcher = root / "voice"
+        launcher.write_text(body, encoding="utf-8")
+        launcher.chmod(0o755)
+        done = subprocess.run(
+            [sys.executable, str(launcher), "stop"], capture_output=True, text=True
+        )
+        self.assertEqual(done.returncode, 1)
+        self.assertIn("not installed", done.stderr)
+
+
+class LauncherOverwriteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.destination = Path(self.tmp.name) / "voice"
+
+    def test_a_foreign_voice_on_path_is_never_clobbered(self) -> None:
+        self.destination.write_text("#!/bin/sh\necho someone else's\n", encoding="utf-8")
+        with self.assertRaises(SystemExit) as caught:
+            install_launcher.install(self.destination)
+        self.assertIn("not generated by this command", str(caught.exception))
+        self.assertIn("someone else's", self.destination.read_text(encoding="utf-8"))
+
+    def test_force_replaces_a_foreign_file_when_asked(self) -> None:
+        self.destination.write_text("#!/bin/sh\necho other\n", encoding="utf-8")
+        install_launcher.install(self.destination, force=True)
+        self.assertIn("Generated file.", self.destination.read_text(encoding="utf-8"))
+
+    def test_regenerating_over_a_previous_launcher_is_allowed(self) -> None:
+        install_launcher.install(self.destination)
+        install_launcher.install(self.destination)
+        self.assertIn("Generated file.", self.destination.read_text(encoding="utf-8"))
+
+    def test_print_mode_writes_nothing(self) -> None:
+        code = install_launcher.main(["--print"])
+        self.assertEqual(code, 0)
+        self.assertFalse(self.destination.exists())
+
+
+class PackagedCliTests(unittest.TestCase):
+    """The CLI the launcher execs must itself be a runnable file."""
+
+    def test_the_cli_has_a_shebang_and_the_executable_bit(self) -> None:
+        cli = _PACKAGE / "scripts" / "voice_cli.py"
+        self.assertTrue(
+            cli.read_text(encoding="utf-8").startswith("#!"),
+            "the CLI is documented as an operator surface; it needs a shebang",
+        )
+        self.assertTrue(os.access(cli, os.X_OK), "the CLI must be executable")
+
+    def test_the_installer_lives_in_the_claude_extension(self) -> None:
+        # Reading Claude's plugin registry is Claude client knowledge, so it
+        # belongs in the adapter rather than the portable core.
+        self.assertTrue(_INSTALLER.is_file())
+        self.assertFalse((_PACKAGE / "scripts" / "install_launcher.py").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_preflight.py
+++ b/plugins/voice/tests/test_preflight.py
@@ -149,9 +149,18 @@ class PreflightTestBase(unittest.TestCase):
         self.keybinding_path.write_text(GOOD_KEYBINDING_TOML, encoding="utf-8")
         self.capture_bin = Path(self.bin_dir.name) / "capture-bin"
         self.playback_bin = Path(self.bin_dir.name) / "playback-bin"
-        for binary in (self.capture_bin, self.playback_bin):
+        # A resolvable `voice` on PATH. Before the runnability change this
+        # fixture did not need one, which is precisely how the probe came to
+        # report a launcher that did not exist as healthy.
+        self.voice_launcher = Path(self.bin_dir.name) / "voice"
+        for binary in (self.capture_bin, self.playback_bin, self.voice_launcher):
             binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
             binary.chmod(0o755)
+        path_patch = mock.patch.dict(
+            os.environ, {"PATH": self.bin_dir.name + os.pathsep + os.environ["PATH"]}
+        )
+        path_patch.start()
+        self.addCleanup(path_patch.stop)
         env = mock.patch.dict(
             os.environ,
             {
@@ -494,9 +503,10 @@ class KeybindingProbeTests(PreflightTestBase):
         self.assertIn("voice stop", result.detail)
         self.assertEqual(self.keybinding_path.read_bytes(), before)
 
-    def test_config_with_voice_stop_passes(self) -> None:
+    def test_config_with_a_runnable_voice_stop_passes(self) -> None:
         result = preflight.probe_keybinding(self.keybinding_path)
         self.assertEqual(result.status, preflight.CHECK_OK)
+        self.assertIn(str(self.voice_launcher), result.detail)
 
     def test_probe_does_not_require_a_specific_type_field(self) -> None:
         self.keybinding_path.write_text(
@@ -508,6 +518,64 @@ class KeybindingProbeTests(PreflightTestBase):
         )
         result = preflight.probe_keybinding(self.keybinding_path)
         self.assertEqual(result.status, preflight.CHECK_OK)
+
+    def test_the_marker_alone_does_not_pass_when_nothing_can_run(self) -> None:
+        # The regression. `voice stop` was the documented binding while no
+        # `voice` existed on PATH: the key parsed, the command matched the
+        # marker, and nothing stopped. Reporting that as healthy is worse than
+        # not probing, because it retires the operator's own suspicion.
+        self.voice_launcher.unlink()
+        result = preflight.probe_keybinding(self.keybinding_path)
+        self.assertEqual(result.status, preflight.CHECK_FAILED)
+        self.assertIn("cannot run it", result.detail)
+        self.assertIn("not on PATH", result.detail)
+
+    def test_a_stale_script_path_beside_a_real_interpreter_fails(self) -> None:
+        # `python3` resolves perfectly well while the script beside it does
+        # not. Checking only the program would call this runnable.
+        self.keybinding_path.write_text(
+            "[[keys.command]]\n"
+            'key = "f9"\n'
+            'command = "python3 /nonexistent/voice_cli.py stop"\n',
+            encoding="utf-8",
+        )
+        result = preflight.probe_keybinding(self.keybinding_path)
+        self.assertEqual(result.status, preflight.CHECK_FAILED)
+        self.assertIn("does not exist", result.detail)
+
+    def test_an_absolute_launcher_path_is_accepted_when_executable(self) -> None:
+        self.keybinding_path.write_text(
+            "[[keys.command]]\n"
+            'key = "f9"\n'
+            f'command = "{self.voice_launcher} stop"\n',
+            encoding="utf-8",
+        )
+        result = preflight.probe_keybinding(self.keybinding_path)
+        self.assertEqual(result.status, preflight.CHECK_OK)
+
+    def test_a_present_but_non_executable_launcher_fails(self) -> None:
+        self.voice_launcher.chmod(0o644)
+        self.keybinding_path.write_text(
+            "[[keys.command]]\n"
+            'key = "f9"\n'
+            f'command = "{self.voice_launcher} stop"\n',
+            encoding="utf-8",
+        )
+        result = preflight.probe_keybinding(self.keybinding_path)
+        self.assertEqual(result.status, preflight.CHECK_FAILED)
+        self.assertIn("not executable", result.detail)
+
+    def test_the_probe_never_executes_the_configured_command(self) -> None:
+        # Firing a stop as a side effect of asking whether a stop is possible
+        # would be its own defect.
+        witness = Path(self.bin_dir.name) / "witness"
+        launcher = Path(self.bin_dir.name) / "voice"
+        launcher.write_text(
+            f"#!/bin/sh\ntouch {witness}\n", encoding="utf-8"
+        )
+        launcher.chmod(0o755)
+        preflight.probe_keybinding(self.keybinding_path)
+        self.assertFalse(witness.exists())
 
     def test_unparseable_config_is_reported_by_name(self) -> None:
         self.keybinding_path.write_text("[ not toml", encoding="utf-8")


### PR DESCRIPTION
A live configuration defect, caught by the operator before acting on our own documentation.

## The false green

`plugins/voice/scripts/preflight.py` tested the keybinding like this:

```python
if KEYBINDING_MARKER in command:      # KEYBINDING_MARKER = "voice stop"
    return ProbeResult(..., CHECK_OK, ...)
```

The README documented exactly `command = "voice stop"`. And on this machine:

```
$ command -v voice
$                                     # nothing
$ ls -l .../voice/0.1.0/scripts/voice_cli.py
-rw-r--r--                            # no exec bit, no shebang
```

So following our own documentation would have produced a **green preflight for a key that parses, runs, and stops nothing.**

That is worse than having no probe at all, because a green line retires the operator's own suspicion — which is the only thing that caught this. Twenty lines below, `probe_executable` already checked `os.access(path, os.X_OK)`. The keybinding probe simply never adopted the standard its neighbour used.

## Why the command could not just be written down

There is no stable path to bind to:

- Claude installs under `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`
- a version bump creates a **new** directory — `remember: 0.18.0 → 0.19.0 → 0.20.0`, and **73 orphaned version directories** on this host
- there is no `current` or `latest` symlink

Hard-coding `voice/0.1.0/...` would work until the next release and then fail silently. This was raised as a design choice rather than decided unilaterally; the operator chose the launcher.

## Changes

**`com.infiquetra.claude/scripts/install_launcher.py`** — an explicit, operator-run command that writes `~/.local/bin/voice`. The emitted launcher resolves the current install from Claude's own `installed_plugins.json`, which Claude rewrites on every install and update, so it follows version bumps with no reconfiguration anywhere. It is self-contained by necessity: it cannot import from the package it exists to find. It refuses to overwrite a `voice` it did not generate unless forced, and `--print` shows the file without writing it.

It lives in the Claude adapter rather than the portable core because reading Claude's plugin registry is client knowledge. A test enforces that placement.

**Preflight now resolves the command** rather than pattern-matching it: the program must be on `PATH` or be an existing executable file, and any `.py` script named beside it must exist — that second check is what catches `python3 /stale/path/voice_cli.py stop`, where the interpreter resolves perfectly well and the script does not. It never *executes* the command; a test asserts that with a witness file.

**Both spellings are now recognized.** `voice stop` and `python3 .../voice_cli.py stop` reach the same stop. Matching only the first reported a working direct binding as absent — a false negative I introduced and caught while testing, in the opposite direction from the original bug.

**`voice_cli.py` gets a shebang and the executable bit**, so the documented operator surface is actually runnable.

**Docs** now carry the one-time launcher step and add `type = "shell"` to the stanza — `pane` and `popup` would open a terminal to stop audio.

Voice still writes no Herdr configuration, here or anywhere else.

## Mutation proof

Every new test was confirmed to **fail** against the defect it guards:

| Mutation | Tests that fail |
|---|---|
| Restore the substring-only probe (the shipped defect) | **4** |
| Drop the `.py` script-existence check | 1 |
| Remove the CLI's shebang and exec bit | 1 |

## Verification

- `python3 scripts/check_repo.py` — passed
- `python3 -m unittest discover -s tests` — **754 passed**
- `python3 -m pytest plugins/voice/tests -q` — **285 passed** (was 270)
- `claude plugin validate plugins/voice --strict` — passed
- `claude plugin validate . --strict` — passed
- `git diff --check` — clean

The launcher's resolution path is tested end to end against a synthetic registry and install, including newest-version selection and the not-installed failure being reported by name rather than silently.
