### PR TITLE
docs(voice): record F8 closed, and de-couple its own regression test from the host

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "voice",
       "source": "./plugins/voice",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "description": "A spoken conversational loop for one explicitly bound, Herdr-managed Claude Code session: the bound session speaks its completed response, the operator answers by voice, and the transcript lands editable and unsubmitted in that same session's input box.",
       "author": {
         "name": "Infiquetra",

--- a/docs/evidence/voice/acceptance.md
+++ b/docs/evidence/voice/acceptance.md
@@ -321,3 +321,57 @@ direct observation or named-refusal evidence. Two R33 inputs are inherently
 human-shaped and remain for an attended pass: speaking into the microphone
 (F5) and parking the bound agent on a permission prompt for AE5 (F4). No
 silent omissions: every gap is a numbered finding.
+
+## Finding disposition as of 2026-08-26
+
+The verdict above is the acceptance record as it stood on 2026-08-25 and is not
+revised. This section is the running ledger of what has since happened to
+F1–F9, so a later reader is not left inferring it from commit history.
+
+| Finding | State | Evidence |
+|---|---|---|
+| F1 — Voice Forge health probe contract drift | **closed** | Probe now accepts `ok: true` with a non-empty `backends_loaded` (`plugins/voice/scripts/preflight.py`, `_backends_loaded`). Live preflight reports "process healthy with a loaded backend". |
+| F2 — Hermes profile probe expects an absent `stt` surface | **closed** | The `stt` assertion is gone (zero occurrences in `preflight.py`); the transcribe round trip is the speech-to-text guarantee, and it passes with `provider: xai`. |
+| F3 — relay silence refused as provider substitution | **closed** | An empty transcript with an absent provider is now refused as "nothing to deliver" (`plugins/voice/scripts/transcribe.py`). The substitution guard is unchanged for a non-empty transcript carrying an unexpected provider. |
+| F4 — AE5's blocked-state branch not exercised live | **open** | Still requires an attended pass with the bound agent parked on a permission prompt. Covered hermetically in `plugins/voice/tests/test_deliver.py`. |
+| F5 — capture device `:0` is the iPhone Continuity microphone | **open** | Environmental, not a code defect. D3 pins `:0` by design; the human-voice half of the loop needs a person speaking into that microphone. |
+| F6 — millisecond flush race can leave an orphan capture wav | **open** | No stray-capture sweep exists. Narrow and artificial: it requires a dead recorder that never wrote a frame. |
+| F7 — `VOICE_RETENTION` is read and tested but never consulted | **open** | `settings.retention()` still has no caller outside its own tests. Behaviour stays safe because the package is structurally ephemeral, but KTD6's "refused by name" contract is decorative until a runtime or preflight path calls it. |
+| F8 — the D4 operator keybinding was not added | **closed** | See below. |
+| F9 / code-review F10 — catalog claim drifted | **closed** | Both `docs/README.md` and the root `README.md` now scope the derived-artifact claim to *ported* packages and state that `voice` is authored here with no upstream pin. |
+
+### F8 closed — the operator keybinding is configured and verified runnable
+
+Closing F8 needed two things that did not exist when it was filed: a stop
+command that stays valid across plugin updates, and a probe that could tell a
+working binding from a plausible-looking one. Both landed first
+(PR [#40](https://github.com/infiquetra/infiquetra-agent-plugins/pull/40),
+released as `0.2.0` in
+PR [#41](https://github.com/infiquetra/infiquetra-agent-plugins/pull/41)).
+
+Operator configuration, reported 2026-08-26:
+
+- Launcher installed at `~/.local/bin/voice`; `command -v voice` resolves it and
+  `voice stop` executed.
+- Herdr custom command added: `prefix+shift+v`, `type = "shell"`,
+  `command = "voice stop"`, description "stop voice playback".
+- `herdr config check` passed; `herdr server reload-config` applied with no
+  diagnostics.
+
+Independently verified in this repository on 2026-08-26, against the `0.2.0`
+install the registry records:
+
+```
+ok  herdr-config: herdr keybinding containing 'voice stop'
+      — 'voice stop' runs /Users/jefcox/.local/bin/voice
+verdict: 10 ok, 0 failed, 0 not-run — pass
+```
+
+The full run covers real Voice Forge synthesis and a live xAI transcription
+round trip (relay 0.20.5). That green line is worth trusting specifically
+because the probe resolves the configured command rather than matching its
+text — the false-green defect this finding's closure depended on. Voice wrote
+no Herdr configuration at any point; the operator made every change.
+
+**Not yet done:** the attended microphone acceptance (F4 and F5) remains
+outstanding and starts only when the operator asks.

--- a/plugins/voice/.claude-plugin/plugin.json
+++ b/plugins/voice/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voice",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A spoken conversational loop for one explicitly bound, Herdr-managed Claude Code session. Claude installs this package root so the portable core travels with the client extension; every Claude-specific behaviour is declared out of com.infiquetra.claude/.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/voice/com.infiquetra.claude/plugin.json
+++ b/plugins/voice/com.infiquetra.claude/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voice",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Claude client extension for the voice package: the Stop hook that lets the one explicitly bound session speak its completed response through the portable voice loop.",
   "author": {
     "name": "Infiquetra",

--- a/plugins/voice/plugin.json
+++ b/plugins/voice/plugin.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "voice",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Portable voice package: a spoken conversational loop for one explicitly bound, Herdr-managed Claude Code session. The bound session speaks its completed response, the operator answers by voice, and the transcript lands editable and unsubmitted in that same session's input box. The portable core carries the provider declaration contract, the stated settings surface, and the subprocess discipline; Claude-specific files live under the com.infiquetra.claude client extension directory."
 }

--- a/plugins/voice/tests/test_preflight.py
+++ b/plugins/voice/tests/test_preflight.py
@@ -525,7 +525,13 @@ class KeybindingProbeTests(PreflightTestBase):
         # marker, and nothing stopped. Reporting that as healthy is worse than
         # not probing, because it retires the operator's own suspicion.
         self.voice_launcher.unlink()
-        result = preflight.probe_keybinding(self.keybinding_path)
+        # PATH is *replaced*, not prepended: this host may well have a real
+        # `voice` installed -- the operator's own launcher lives at
+        # ~/.local/bin/voice -- and a test that only removed the fixture's copy
+        # would pass or fail depending on whose machine ran it. This assertion
+        # is about a PATH with no launcher on it at all.
+        with mock.patch.dict(os.environ, {"PATH": self.bin_dir.name}):
+            result = preflight.probe_keybinding(self.keybinding_path)
         self.assertEqual(result.status, preflight.CHECK_FAILED)
         self.assertIn("cannot run it", result.detail)
         self.assertIn("not on PATH", result.detail)
@@ -569,7 +575,7 @@ class KeybindingProbeTests(PreflightTestBase):
         # Firing a stop as a side effect of asking whether a stop is possible
         # would be its own defect.
         witness = Path(self.bin_dir.name) / "witness"
-        launcher = Path(self.bin_dir.name) / "voice"
+        launcher = self.voice_launcher
         launcher.write_text(
             f"#!/bin/sh\ntouch {witness}\n", encoding="utf-8"
         )


### PR DESCRIPTION
## F8 is closed

Closing it needed two things that did not exist when it was filed: a stop command that stays valid across plugin updates, and a probe that could tell a working binding from a plausible-looking one. Both landed in #40, released as `0.2.0` in #41.

Operator configuration, reported 2026-08-26:

- Launcher at `~/.local/bin/voice`; `command -v voice` resolves it, `voice stop` executed
- Herdr custom command `prefix+shift+v`, `type = "shell"`, `command = "voice stop"`
- `herdr config check` passed; `herdr server reload-config` applied with no diagnostics

Verified independently here against the `0.2.0` install the registry records:

```
ok  herdr-config: herdr keybinding containing 'voice stop'
      — 'voice stop' runs /Users/jefcox/.local/bin/voice
verdict: 10 ok, 0 failed, 0 not-run — pass
```

Voice wrote no Herdr configuration at any point.

## A disposition ledger, not a rewrite

The 2026-08-25 verdict is the record of what acceptance found and stays as written. The ledger is appended after it, so a later reader is not left inferring the current state from commit history.

| | State |
|---|---|
| F1 Forge health probe drift | **closed** |
| F2 Hermes profile `stt` surface | **closed** |
| F3 silence read as substitution | **closed** |
| F4 blocked-state branch unexercised | open — needs the attended pass |
| F5 capture device `:0` is the iPhone mic | open — environmental, not a code defect |
| F6 orphan capture wav race | open — no stray-capture sweep exists |
| F7 `VOICE_RETENTION` has no runtime caller | open — `settings.retention()` still has no caller outside its tests |
| F8 operator keybinding | **closed** |
| F9 / F10 catalog claim drift | **closed** |

Each closed row cites the evidence rather than asserting it.

## A defect your configuration exposed

`test_the_marker_alone_does_not_pass_when_nothing_can_run` deleted the fixture's launcher but only **prepended** the temp directory to `PATH`. So `shutil.which("voice")` still found the real `~/.local/bin/voice`, and the test began failing the moment a real launcher existed — it had been passing only because no `voice` was installed anywhere.

It now replaces `PATH` outright: the assertion is about a `PATH` with no launcher on it at all. Re-confirmed to still fail against the substring-only probe (4 failures, unchanged).

This is the environment-coupled-test hazard the code review flagged as a residual, showing up for real.

## Version

Patch bump to `0.2.1` at all four declaration sites. The packaged tests ship, and a test that fails on any machine with `voice` installed is wrong content to distribute.

## Verification

- `python3 scripts/check_repo.py` — passed
- `python3 -m unittest discover -s tests` — **755 passed**
- `python3 -m pytest plugins/voice/tests -q` — **285 passed**
- `claude plugin validate plugins/voice --strict` and `. --strict` — both passed
- `git diff --check` — clean