### PR TITLE
feat(voice): C3 — Claude adapter authored-rendering surface, turn origin, voice policy (#46)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,8 @@
     {
       "name": "voice",
       "source": "./plugins/voice",
-      "version": "0.2.1",
-      "description": "A spoken conversational loop for one explicitly bound, Herdr-managed Claude Code session: the bound session speaks its completed response, the operator answers by voice, and the transcript lands editable and unsubmitted in that same session's input box.",
+      "version": "0.3.0",
+      "description": "A spoken conversational loop and Auralis bridge adapter for one explicitly bound, Herdr-managed Claude Code session: the bound session receives voice context, submits authored spoken renderings, and speaks completed responses.",
       "author": {
         "name": "Infiquetra",
         "email": "hello@infiquetra.com"

--- a/docs/bridge-v1-from-c10.md
+++ b/docs/bridge-v1-from-c10.md
@@ -1,0 +1,337 @@
+# Auralis Bridge Contract v1
+
+**Status:** Committed Normative Specification  
+**Owner:** Auralis Core (infiquetra/auralis, C10)  
+**Consumer:** Adapter (infiquetra/infiquetra-agent-plugins, capability slice C3)  
+**Schema Version:** 1  
+
+---
+
+## 1. Overview and Scope
+
+This document specifies the normative wire contract for Version 1 of the Auralis Local Bridge. The bridge connects the in-process Auralis Core application with out-of-process coding agent adapters (such as the Claude adapter in `infiquetra/infiquetra-agent-plugins`, capability slice C3).
+
+C3 plans and implements against this specification independently. No Dart source code, data-transfer objects, or internal test helpers from `infiquetra/auralis` are shared across the repository boundary.
+
+---
+
+## 2. Discovery
+
+On a successful start, Auralis Core atomically publishes a connection file containing loopback connection parameters and credentials.
+
+### File Location
+`~/Library/Application Support/Auralis/bridge.json`
+
+### File Format
+A compact JSON object with UTF-8 encoding:
+
+```json
+{"schema":1,"host":"127.0.0.1","port":49152,"token":"<43-character unpadded base64url>"}
+```
+
+### Member Definitions
+- `schema` *(integer)*: Must be the literal integer `1`.
+- `host` *(string)*: Must be the literal string `"127.0.0.1"`.
+- `port` *(integer)*: The live operating-system-assigned TCP port (`1` through `65535`).
+- `token` *(string)*: A 32-byte cryptographically secure random token encoded as 43 unpadded base64url characters.
+
+### Permissions and Lifecycle
+- The file is created with file mode `0600` (read/write by owner only) before publication via atomic rename.
+- A missing, partial, wrong-typed, extra-keyed, schema-unknown, or permission-invalid file indicates that the bridge is unavailable. The adapter must never assume default ports or tokens.
+- On process exit, the listening socket is closed. On restart, a fresh port and token are minted and published atomically.
+
+---
+
+## 3. Authentication
+
+Every HTTP request to the bridge must include valid bearer credentials.
+
+- Header: `Authorization: Bearer <token>`
+- The header name `Authorization` and authentication scheme `Bearer` are ASCII-case-insensitive.
+- The `<token>` string is compared byte-exact against the active per-launch token.
+- A request with a missing, repeated, malformed, or invalid authorization header returns HTTP `401 Unauthorized` with error `unauthorized` before any request body is read and causes no state effect.
+
+---
+
+## 4. Wire Rules and Protocol Standards
+
+1. **Protocol:** HTTP/1.1 over loopback TCP (`127.0.0.1`).
+2. **Payload Format:** UTF-8 JSON.
+3. **Media Type:**
+   - Responses always set `Content-Type: application/json; charset=utf-8`.
+   - Body-bearing requests (`PUT`, `DELETE`, `POST`) must supply `Content-Type: application/json` (optional `charset=utf-8` allowed). Requests declaring another media type or non-UTF-8 charset return `415 Unsupported Media Type` with error `unsupported_media_type`.
+4. **Closed Request Shapes:** Request bodies are closed JSON objects. Missing required members, extra unexpected members, `null` values, wrong types, or empty strings where prohibited return HTTP `400 Bad Request` with error `invalid_request`.
+5. **Schema Field:** Every request body must contain `"schema": 1`. A missing or non-integer schema returns `invalid_request`; an integer schema other than `1` returns `unsupported_schema`.
+6. **Query Strings:** URL query strings must be empty. A non-empty query returns HTTP `400 Bad Request` with error `invalid_request`.
+7. **GET Requests:** Must not include a body. A GET request carrying a body or `Content-Length > 0` returns HTTP `400 Bad Request` with error `invalid_request`.
+8. **Body Size Cap:** Request bodies are limited to at most `1,048,576` raw bytes (1 MiB). A body exceeding this size returns HTTP `413 Request Entity Too Large` with error `body_too_large` without entering the coordinator.
+9. **Identifier Strings:** All identifier strings (`binding_id`, `turn_id`, `agent_session_id`, `pane_id`, `terminal_id`) are non-empty, compared byte-exact, and never trimmed or normalized.
+10. **Response Member Order:** Insignificant. Clients must ignore unknown response members while requiring all documented members.
+
+---
+
+## 5. Complete Adapter Identity
+
+Every presence and rendering request includes a complete, three-component adapter identity object:
+
+```json
+{"agent_session_id":"session-exact","pane_id":"workspace-and-pane-exact","terminal_id":"terminal-exact"}
+```
+
+All three fields participate in byte-exact equality:
+- `agent_session_id` *(string, non-empty)*: The unique agent session identifier.
+- `pane_id` *(string, non-empty)*: The workspace/pane identifier.
+- `terminal_id` *(string, non-empty)*: The terminal identifier.
+
+### C3 Adapter Discovery Rule
+The C3 adapter obtains its identity from its environment and Herdr:
+1. Reads `HERDR_PANE_ID` from its process environment.
+2. Executes the `HERDR_BIN_PATH` executable with arguments `agent`, `list`.
+3. Verifies that the JSON envelope contains `result.type == "agent_list"`.
+4. Finds exactly one record in `result.agents` where `pane_id == HERDR_PANE_ID`.
+5. Copies that record's non-empty `agent_session.value` as `agent_session_id`, that record's `pane_id` as `pane_id`, and that record's `terminal_id` as `terminal_id`.
+6. Any Claude hook or agent request carrying Claude's session identifier must match `agent_session_id`.
+7. The adapter must never copy identity from `GET /v1/current`.
+
+A missing environment value, missing executable, command or envelope failure, zero or multiple matches, a missing component, or a session mismatch means the adapter registers and submits nothing.
+
+---
+
+## 6. Endpoints
+
+The Version 1 surface consists of five route operations across four distinct paths:
+
+| Method and Path | Request Body | HTTP 200 Response | State Effect |
+|---|---|---|---|
+| `GET /v1/health` | *(none)* | `{"schema":1,"service":"auralis-bridge","status":"ok"}` | None. |
+| `PUT /v1/presence` | `{"schema":1,"identity":<identity>}` | `{"schema":1,"disposition":"present","lease_ms":15000,"renew_after_ms":5000}` | Registers or renews the lease for the exact identity. |
+| `DELETE /v1/presence` | `{"schema":1,"identity":<identity>}` | `{"schema":1,"disposition":"absent"}` | Removes the lease for the identity if present. |
+| `GET /v1/current` | *(none)* | `{"schema":1,"binding":<binding|null>,"turn":<turn|null>}` | None. |
+| `POST /v1/rendering` | `{"schema":1,"identity":<identity>,"binding_id":"...","turn_id":"...","text":"..."}` | Accepted or Rejected response shape | Renews identity lease, then synchronously adjudicates the rendering. |
+
+---
+
+### 6.1 `GET /v1/health`
+Returns service liveness and health.
+
+**Response Body:**
+```json
+{"schema":1,"service":"auralis-bridge","status":"ok"}
+```
+
+---
+
+### 6.2 `PUT /v1/presence`
+Registers or renews an adapter's presence lease.
+
+**Request Body:**
+```json
+{
+  "schema": 1,
+  "identity": {
+    "agent_session_id": "session-exact",
+    "pane_id": "workspace-and-pane-exact",
+    "terminal_id": "terminal-exact"
+  }
+}
+```
+
+**Response Body:**
+```json
+{
+  "schema": 1,
+  "disposition": "present",
+  "lease_ms": 15000,
+  "renew_after_ms": 5000
+}
+```
+
+- Creates or extends a 15,000 ms lease for the exact three-part identity.
+- Clients should renew their lease at or before `renew_after_ms` (5,000 ms).
+
+---
+
+### 6.3 `DELETE /v1/presence`
+Removes an adapter's presence lease idempotently.
+
+**Request Body:**
+```json
+{
+  "schema": 1,
+  "identity": {
+    "agent_session_id": "session-exact",
+    "pane_id": "workspace-and-pane-exact",
+    "terminal_id": "terminal-exact"
+  }
+}
+```
+
+**Response Body:**
+```json
+{
+  "schema": 1,
+  "disposition": "absent"
+}
+```
+
+---
+
+### 6.4 `GET /v1/current`
+Returns a snapshot of the active bridge binding epoch and current turn.
+
+**Response Body (when bound with an open turn):**
+```json
+{
+  "schema": 1,
+  "binding": {
+    "binding_id": "opaque",
+    "identity": {
+      "agent_session_id": "session-exact",
+      "pane_id": "workspace-and-pane-exact",
+      "terminal_id": "terminal-exact"
+    }
+  },
+  "turn": {
+    "turn_id": "opaque",
+    "binding_id": "opaque",
+    "state": "open"
+  }
+}
+```
+
+**Response Rules:**
+- `binding` is `null` when no bridge binding epoch is active.
+- `turn` is `null` when no voice turn is active in the single-slot registry (and must be `null` whenever `binding` is `null`).
+- When present, `turn.state` is exactly one of:
+  - `"open"`: Turn is actively awaiting an authored or fallback rendering.
+  - `"authored_accepted"`: An authored rendering was accepted for this turn.
+  - `"fallback_accepted"`: A fallback rendering was accepted for this turn.
+  - `"canceled"`: The turn was canceled (due to stop, barge-in, retirement, or replacement).
+
+---
+
+### 6.5 `POST /v1/rendering`
+Submits an authored speech rendering for the current turn.
+
+**Request Body:**
+```json
+{
+  "schema": 1,
+  "identity": {
+    "agent_session_id": "session-exact",
+    "pane_id": "workspace-and-pane-exact",
+    "terminal_id": "terminal-exact"
+  },
+  "binding_id": "opaque",
+  "turn_id": "opaque",
+  "text": "plain authored text"
+}
+```
+
+**Accepted Response:**
+```json
+{
+  "schema": 1,
+  "binding_id": "opaque",
+  "turn_id": "opaque",
+  "disposition": "accepted"
+}
+```
+
+**Rejected Response:**
+```json
+{
+  "schema": 1,
+  "binding_id": "opaque",
+  "turn_id": "opaque",
+  "disposition": "rejected",
+  "reason": "binding_not_current"
+}
+```
+
+#### Adjudication Order and Rejection Vocabulary
+Submitted authored renderings are adjudicated in the following strict order:
+1. `no_binding`: No bridge binding epoch is active.
+2. `binding_not_current`: The offered `binding_id` does not match the active epoch.
+3. `adapter_not_bound`: The offered `identity` does not match the bound epoch identity.
+4. `turn_not_current`: The offered `turn_id` does not match the current turn slot.
+5. `turn_canceled`: The current turn has been canceled.
+6. `fallback_already_began`: A fallback rendering was already accepted for this turn.
+7. `duplicate_rendering`: An authored rendering was already accepted for this turn.
+8. `empty_rendering`: The `text` member is empty or contains only whitespace (`text.trim().isEmpty`).
+9. **Accepted**: The text is accepted verbatim and spoken.
+
+- `empty_rendering` does not resolve or consume the turn; a subsequent non-empty submission may still be accepted.
+- Rejection reasons 1 through 7 are terminal for the offered `(binding_id, turn_id)` pair.
+
+---
+
+## 7. Transport Errors and Precedence
+
+Non-200 responses return `Content-Type: application/json; charset=utf-8` and a JSON body formatted as:
+```json
+{"schema":1,"error":"<code>"}
+```
+
+### Transport Error Table
+
+| Status | `error` Code | Description and Exact Case |
+|---:|---|---|
+| 400 | `invalid_json` | The request body is not one complete JSON object. |
+| 400 | `invalid_request` | A required member is missing, extra, null, empty where prohibited, or wrong-typed; the query is non-empty; HTTP is not version 1.1; or a GET carries a body. |
+| 400 | `unsupported_schema` | `schema` exists as an integer but is not 1. |
+| 401 | `unauthorized` | The bearer header is missing, repeated, malformed, or wrong. |
+| 404 | `not_found` | The path is not one of the five exact paths. |
+| 405 | `method_not_allowed` | The path exists under another method; `Allow` is `GET` for health/current, `PUT, DELETE` for presence, and `POST` for rendering. |
+| 413 | `body_too_large` | More than 1,048,576 raw body bytes arrive. |
+| 415 | `unsupported_media_type` | A body-bearing request is not `application/json` or declares a non-UTF-8 charset. |
+| 500 | `internal_error` | An unexpected server exception occurs; no exception detail is returned. |
+
+### `Allow` Headers for 405 Method Not Allowed
+- `GET /v1/health` -> `Allow: GET`
+- `GET /v1/current` -> `Allow: GET`
+- `/v1/presence` -> `Allow: PUT, DELETE`
+- `POST /v1/rendering` -> `Allow: POST`
+
+### Processing Precedence
+Requests are evaluated in the following exact order:
+1. **Path matching:** Non-existent path returns `404 not_found`.
+2. **Method matching:** Disallowed method returns `405 method_not_allowed` with `Allow` header.
+3. **Authentication:** Missing or invalid Bearer token returns `401 unauthorized`.
+4. **HTTP version & query:** Non-1.1 version or non-empty query string returns `400 invalid_request`.
+5. **GET-body prohibition / Media type:** GET with body returns `400 invalid_request`; non-JSON body-bearing request returns `415 unsupported_media_type`.
+6. **Body size:** Body exceeding 1,048,576 bytes returns `413 body_too_large`.
+7. **JSON decoding:** Malformed JSON or non-object body returns `400 invalid_json`.
+8. **Schema validation:** Missing/non-integer schema returns `400 invalid_request`; integer schema != 1 returns `400 unsupported_schema`.
+9. **Closed-shape validation:** Extra, missing, null, or wrong-typed members return `400 invalid_request`.
+10. **Coordinator entry:** Synchronous execution and adjudication.
+
+---
+
+## 8. Identifier, Retry, and Extension Semantics
+
+### Identifiers
+- Turn identifiers (`turn_id`) and binding identifiers (`binding_id`) are opaque lowercase UUID v4 strings assigned exclusively by Auralis Core.
+- The adapter obtains active identifiers from `GET /v1/current`, verifies its identity match, and carries the exact pair through its agent surface.
+
+### Retry Rules
+- **Discovery / Unavailability:** If `bridge.json` is absent, connection is refused, 401 is received, or health check fails, the adapter re-reads `bridge.json` at least once per second until registration succeeds.
+- **500 Internal Error:** Guarantees no coordinator entry. The adapter may perform one byte-equivalent retry after confirming bridge health.
+- **4xx Client Errors:** Must not be retried without correcting the request or contract violation.
+- **Lost Rendering Response:** If a rendering response is lost after the request may have reached Core, the adapter may retry only the byte-equivalent request with the same identifiers. An earlier acceptance returns `duplicate_rendering` while that turn remains current; a later turn, fallback, cancellation, or retirement returns its normal higher-priority reason, and none emits again.
+- **Fail Closed:** Unknown HTTP statuses, unknown error codes, or invalid response formats must fail closed and never be treated as accepted.
+
+### Extension Rules
+- Future additions within Version 1 introduce new `/v1/` paths.
+- Any new turn-scoped request, response, or event must carry both `binding_id` and `turn_id`.
+- Breaking field changes, meaning changes, or validation modifications require incrementing the protocol version to `/v2` and `schema: 2`.
+
+---
+
+## 9. Downstream Consumption Contract
+
+- **C3 (Adapter - `infiquetra/infiquetra-agent-plugins`):** Runs the presence renewal loop, implements the wire contract, verifies identity equality, and carries Core-assigned identifiers through MCP.
+- **C5 (Audio):** Calls `startTurn()` on recording, `acceptFallback()` prior to fallback speech, and `cancelTurn()` on barge-in. Consumes `RenderingAccepted` and `BindingRetirement` events.
+- **C7 (Rolling Text View):** Appends spoken text only upon playback confirmation from C5.
+- **C8 (Approvals):** Uses `applyConfirmed()` with C2 binding confirmations to guard approval delivery.
+- **C9 (Diagnostic Logging):** Implements durable logging sink for `BridgeLog` events without sensitive data or text payload.

--- a/docs/engineering-journal/DECISIONS.md
+++ b/docs/engineering-journal/DECISIONS.md
@@ -2,6 +2,116 @@
 
 ## 2026-08-27
 
+### Auralis C3 adapter packaging: voice 0.3.0, mcpServers path into client extension, and acceptance evidence note
+
+**Author.** Claude for Jeff Cox (Auralis C3 adapter U5 closeout, issue #46, branch
+`orch/auralis-c3-adapter-build-c3-u5`)
+
+**Decision.** Packaging for the Auralis C3 Claude adapter (`voice` 0.3.0) extends the Claude
+packaging layout pinned on 2026-08-25: `plugins/voice/.claude-plugin/plugin.json` gains
+`"mcpServers": "./com.infiquetra.claude/mcp/servers.json"` pointing to the server configuration
+inside the client extension, keeping the packaging manifest pure distribution metadata
+without command strings. Version is bumped to `0.3.0` across all four sites bound by
+`tests/test_claude_plugin_packaging.py` (`plugins/voice/plugin.json`,
+`plugins/voice/.claude-plugin/plugin.json`, `plugins/voice/com.infiquetra.claude/plugin.json`,
+`.claude-plugin/marketplace.json`). Acceptance evidence for the nine C3 slice requirements is
+captured in [`docs/evidence/voice/auralis-c3-acceptance.md`](../evidence/voice/auralis-c3-acceptance.md),
+recording the five-route wire pin, the AE26 reject-then-accept proof across in-process and
+declared-argv subprocess layers, and the joint AE36 cross-repository dependency on
+`infiquetra/auralis`.
+
+**Rationale.** Preserves the repository boundary rule (packaging manifest carries paths into
+the client extension; behaviour and commands live under `com.infiquetra.claude/`). Four-site
+version agreement prevents `claude plugin update` cache-staleness bugs. A dedicated
+acceptance note keeps the Auralis V1 requirements namespace separate from the earlier 0.2.x
+voice ledger.
+
+**Rejected alternatives.** Inline `mcpServers` object in the packaging manifest (violates
+metadata-only manifest rule); bumping version at only some sites (fails packaging test);
+merging C3 evidence into the 0.2.x `acceptance.md` (collides the two R-ID numbering schemes).
+
+**Revisit when.** Claude Code changes plugin MCP server manifest resolution, or the Auralis
+Bridge Contract v2 merges.
+
+**Refs.** [`docs/plans/2026-08-27-auralis-c3-adapter.md`](../plans/2026-08-27-auralis-c3-adapter.md),
+[`docs/evidence/voice/auralis-c3-acceptance.md`](../evidence/voice/auralis-c3-acceptance.md),
+`tests/test_claude_plugin_packaging.py`.
+
+### Auralis C3 plan repair: a tracked byte-pinned wire snapshot, a locked turn-record transaction, and a gate-owned rejected-syntax contract
+
+**Author.** Claude for Jeff Cox (Auralis C3 plan repair against the blocking doc review,
+issue #46, branch `orch/auralis-c3-adapter-plan-c3-repair`)
+
+**Decision.** The repair of
+[`docs/plans/2026-08-27-auralis-c3-adapter.md`](../plans/2026-08-27-auralis-c3-adapter.md)
+(doc-review findings F1–F12, disposition table at the plan's end) fixes four load-bearing
+choices. First: the wire contract is pinned by a **tracked byte-identical snapshot**
+([`docs/bridge-v1-from-c10.md`](../bridge-v1-from-c10.md)) of
+`docs/bridge/bridge-v1.md` in `infiquetra/auralis` at accepted revision
+`695cd0ecfddf44e0d6e3386da318bd5fde4a1926`, SHA-256
+`eb47d141e5c1b87bae0bd1c0799386a3aa8806635251db14fc806469b5db19eb` — a clean checkout and
+the hosted CI must resolve the plan's links without reading another repository's unmerged
+branch, and byte-identity keeps the pin hash-verifiable. Second: the shared per-turn
+record is mutated only through one `fcntl.flock`-serialized read-apply-write entrypoint
+(plan KTD11); atomic write-replace is only the torn-write defense, because whole-file
+replacement cannot prevent two writers from erasing each other's updates. Third: the R121
+rendering gate owns a complete, closed rejected-syntax contract (setext headings,
+reference links, autolinks, indented code included) rather than inheriting the speak-path
+cleanup recognizers, whose documented scope is narrower than Markdown. Fourth: the two
+Herdr identity values the bridge contract mandates are read through `settings.py`'s
+extended closed `SETTING_NAMES` set, preserving the package's sole-environment-reader
+rule instead of adding a second reader.
+
+**Rejected alternatives.** An external permalink as the only wire pin (CI and clean
+implementation checkouts cannot resolve it); deleting the contract reference (the plan
+must stay traceable to a specific revision); `O_CREAT|O_EXCL` lock files (crash-stale
+locks need their own cleanup protocol) and SQLite (disproportionate to one single-turn
+JSON document); "one writer per field family" as a concurrency claim (the reviewed
+lost-update defect); direct environment reads in `adapter_identity.py` (breaks the stated
+sole-reader contract).
+
+**Revisit when.** The C10 contract merges to `auralis` main (the snapshot then re-pins to
+the merged revision), the turn record outgrows a single turn, or a bridge v2 changes the
+wire.
+
+### Auralis C3 adapter plan: the R121 gate lives in the adapter surface, and the MCP server is the adapter's long-lived process
+
+**Author.** Claude for Jeff Cox (Auralis C3 planning, issue #46, branch
+`orch/auralis-c3-adapter-plan-c3-adapter`)
+
+**Decision.** The plan at
+[`docs/plans/2026-08-27-auralis-c3-adapter.md`](../plans/2026-08-27-auralis-c3-adapter.md)
+extends the voice package into the Claude adapter end of the Auralis local bridge, with
+two load-bearing choices and eight supporting ones (KTD1–KTD10 in the plan). First: the
+plain-spoken-text rule (Auralis requirement R121) is enforced in the adapter's Model
+Context Protocol submission tool, not on the wire — the bridge contract's adjudication
+vocabulary carries no content-form reason, Core accepts text verbatim, and the tool
+answers with a three-class result vocabulary (adapter content rejections
+`fenced_code_block` / `markdown_formatting`, Core rejections relayed verbatim, and named
+availability conditions), never a cleaned rewrite. Second: the plugin-declared MCP stdio
+server is the adapter's one long-lived process, so the bridge presence-renewal loop lives
+in it, while every Claude hook stays an ephemeral one-shot client; submissions target the
+`(binding_id, turn_id)` pair captured at prompt time, never a fresh snapshot at
+submission time.
+
+**Rationale.** The agent-facing surface is the only place R121 *can* live without a
+cross-lane wire change; splitting the reason vocabulary keeps adapter judgment, Core
+judgment, and availability impossible to confuse. Plugin MCP servers persist for the
+session (verified against current Claude Code documentation), which meets the lease
+cadence no hook process can hold; the prompt-time pair makes Core's own
+`turn_not_current` adjudication the arbiter of staleness instead of silently retargeting
+a late rendering.
+
+**Rejected alternatives.** Repairing submissions with the existing cleanup pass (R121
+forbids repair); asking C10 for a wire-level content reason (Core custody); a separate
+presence daemon (new lifecycle surface, nothing needs it); fresh identifier reads at
+submission (wrong-turn hazard); an inline `mcpServers` object in the Claude packaging
+manifest (a command in a metadata-only file — the declaration is a string path into
+`com.infiquetra.claude/` instead).
+
+**Revisit when.** A bridge v2 adds content adjudication or changes identifier custody, or
+the Claude client changes plugin MCP-server lifecycle. The full per-decision revisit
+conditions are in the plan's KTD section.
 ### The agent-launcher port carries the contract as a byte copy and supersedes the Claude-runtime docs
 
 **Author.** Jeff Cox and Qwen Code (issue #22, branch `port/agent-launcher`,

--- a/docs/evidence/voice/auralis-c3-acceptance.md
+++ b/docs/evidence/voice/auralis-c3-acceptance.md
@@ -1,0 +1,140 @@
+# Auralis C3 Claude adapter — acceptance evidence
+
+- **Date:** 2026-08-27
+- **Unit:** U5, run `orch-auralis-c3-adapter`, issue [#46](https://github.com/infiquetra/infiquetra-agent-plugins/issues/46)
+- **Plan:** [`docs/plans/2026-08-27-auralis-c3-adapter.md`](../../plans/2026-08-27-auralis-c3-adapter.md)
+- **Scope:** Capability slice C3 (Claude adapter end of the versioned local bridge, voice 0.3.0)
+- **Requirements authority:** `infiquetra/auralis` at immutable revision [`b49de1ba4d39cbd8a1e582d72bddca85bf528f8a`](https://github.com/infiquetra/auralis/blob/b49de1ba4d39cbd8a1e582d72bddca85bf528f8a/docs/brainstorms/2026-08-26-auralis-v1-requirements.md) (R20, R21, R22, R23, R25, R106, R107, R121, R122)
+
+This document records the acceptance evidence for capability slice C3: the adapter
+side of the versioned local bridge running inside the Claude Code process space,
+shipping as `voice` package version `0.3.0`.
+
+---
+
+## Wire authority and provenance
+
+The normative wire contract is **Auralis Bridge Contract v1**, authored by capability
+slice C10 in `infiquetra/auralis` at revision `695cd0ecfddf44e0d6e3386da318bd5fde4a1926`.
+The byte-identical snapshot is committed in this repository at
+[`docs/bridge-v1-from-c10.md`](../../bridge-v1-from-c10.md):
+
+- **Snapshot SHA-256:** `eb47d141e5c1b87bae0bd1c0799386a3aa8806635251db14fc806469b5db19eb`
+- **Wire route count:** Exactly five frozen routes (`GET /v1/health`, `PUT /v1/presence`, `DELETE /v1/presence`, `GET /v1/current`, `POST /v1/rendering`). No sixth route is added or required.
+- **Contract status flag:** Accepted at Saga Code Review, not yet merged to `auralis` `main`. All wire literals are centralized in `plugins/voice/scripts/bridge_client.py` and tested against the independent-literals fixture `plugins/voice/tests/bridge_stub.py`.
+
+---
+
+## Suite execution at final commit
+
+| Command | Result |
+|---|---|
+| `python3 scripts/check_repo.py` | `Repository validation passed.` |
+| `python3 -m unittest discover -s tests -v` | All tests pass (`Ran 773 tests ... OK`) |
+| `python3 -m unittest discover -s plugins/voice/tests -v` | All 23 test modules pass (450 tests) |
+| `python3 -m pytest plugins/*/tests -q` | `762 passed, 282 subtests passed in 26.91s` |
+| `claude plugin validate plugins/voice --strict` | `✔ Validation passed` |
+| `git diff --check` | Clean (no trailing whitespace or whitespace errors) |
+
+---
+
+## Requirements traceability matrix (C3 slice)
+
+| R-ID | Requirement summary | Adapter-boundary share | Test evidence |
+|---|---|---|---|
+| **R20** | Bound agent authors spoken rendering; adapter never summarizes, shortens, or rewrites content | Gate rejects non-plain text without transformation; plain text is forwarded byte-identical | `plugins/voice/tests/test_rendering_gate.py`, `plugins/voice/tests/test_mcp_server.py` |
+| **R21** | MCP surface for submitting authored spoken rendering | Plugin stdio MCP server exposes `submit_spoken_rendering` tool forwarding to `POST /v1/rendering` | `plugins/voice/tests/test_mcp_server.py` |
+| **R22** | Unrendered turn completion falls back to cleaned written response rather than silence | Adapter submits only gated plain text, never fabricates submissions, records `fallback` outcome, and suppresses local speak | `plugins/voice/tests/test_stop_hook.py`, `plugins/voice/tests/test_r122_adapter_boundary.py`; joint AE36 |
+| **R23** | Fallback turn is visibly marked, distinguishable from authored | Adapter records disjoint `fallback` vs `authored` outcome; Core marks `fallback_accepted` via in-process `acceptFallback()` | `plugins/voice/tests/test_stop_hook.py`, `plugins/voice/tests/test_turn_record.py`; joint AE36 |
+| **R25** | No persistent verbosity mode; preferences carried as instructions; no adapter content alteration | Policy store renders instructions text only; adapter has no content transformation path | `plugins/voice/tests/test_voice_policy.py` |
+| **R106** | Explicit origin signal for every turn while bound | `UserPromptSubmit` hook queries `GET /v1/current`, matches identity, and injects originated / not-originated signal | `plugins/voice/tests/test_user_prompt_submit_hook.py` |
+| **R107** | Voice policy and armed Brief Next Turn override transmitted as instructions; consumed on transmission | Injected into Auralis-originated turns; one-shot `brief_next_turn` is atomically consumed on transmission | `plugins/voice/tests/test_user_prompt_submit_hook.py`, `plugins/voice/tests/test_voice_policy.py` |
+| **R121** | Plain spoken text only; Markdown/code rejected with named reasons; never silently cleaned | Gate rejects with `fenced_code_block` or `markdown_formatting`; resubmission of plain text accepted (AE26) | `plugins/voice/tests/test_rendering_gate.py`, `plugins/voice/tests/test_mcp_server.py` |
+| **R122** | Rejected rendering with no replacement falls back under R22 | Turn record carries named rejections; Stop hook records `fallback` outcome across production processes | `plugins/voice/tests/test_mcp_server.py`, `plugins/voice/tests/test_stop_hook.py`, `plugins/voice/tests/test_r122_adapter_boundary.py`; joint AE36 |
+
+---
+
+## Acceptance examples (AE) status
+
+### AE26 — Markdown rejected, not cleaned; plain resubmission accepted: **PASS**
+
+- **In-process tool tests:** `plugins/voice/tests/test_mcp_server.py::AE26AndSurfaceRenderingTests::test_ae26_reject_then_accept_no_repair` drives the `submit_spoken_rendering` MCP tool:
+  1. A submission with Markdown emphasis and fenced code block returns `disposition: rejected_content`, `reason: fenced_code_block`, with detected classes named in detail. Nothing is forwarded to `POST /v1/rendering`. The turn record retains the verbatim rejected text (no cleaned rewrite).
+  2. A plain-text resubmission on the same turn is forwarded byte-identical to `POST /v1/rendering` with the captured `(binding_id, turn_id)` pair and accepted.
+- **Declared executable entrypoint:** `plugins/voice/tests/test_mcp_server.py::ExecutableEntrypointTests::test_declared_mcp_server_entrypoint_subprocess` copies the package to an installed-root temporary location and spawns the exact declared argv (`python3 <installed-root>/scripts/mcp_server.py`) over real stdio pipes:
+  1. MCP `initialize` echoes protocol version `2024-11-05` and server info `auralis-voice` `0.3.0`.
+  2. `tools/list` returns `submit_spoken_rendering` with closed input schema.
+  3. `tools/call submit_spoken_rendering` with Markdown heading and bold returns `rejected_content` (`markdown_formatting`).
+  4. `tools/call submit_spoken_rendering` with plain text returns `accepted`.
+- **Adapter-boundary rejection-to-fallback lifecycle:** `plugins/voice/tests/test_r122_adapter_boundary.py::R122AdapterBoundaryTests::test_r122_adapter_boundary_rejection_no_replacement_settles_fallback` drives the complete multi-process sequence: real `user_prompt_submit_hook.py` subprocess -> real `mcp_server.py` subprocess rejecting Markdown -> no replacement -> real `stop_hook.py` subprocess recording outcome `fallback`.
+
+### AE34 — Joint bridge acceptance with Core (C10): **READY**
+
+The adapter implementation stands ready for joint cross-repository testing:
+- Loopback bridge client (`bridge_client.py`) discovers `bridge.json` and implements discovery retry, `GET /v1/health`, `PUT /v1/presence`, `DELETE /v1/presence`, `GET /v1/current`, and `POST /v1/rendering`.
+- Three-part adapter identity resolver (`adapter_identity.py`) resolves `agent_session_id`, `pane_id`, and `terminal_id` through Herdr and stated settings (`HERDR_PANE_ID`, `HERDR_BIN_PATH`).
+- Lost-response duplicate reconciliation (F8 / §8) is verified at both client and MCP surface layers.
+- Joint execution will be scheduled by the orchestrator across repositories once C10 lands on `main`.
+
+### AE36 — Joint rejection-to-fallback end-to-end acceptance (C3 / C5 / C10): **DEPENDENCY RECORDED (OPEN)**
+
+- **Executable home:** Repository `infiquetra/auralis` (Dart integration test suite).
+- **Owner:** Capability slice C5 (Audio), with a Dart test harness standing in until C5 is built.
+- **Mechanism:** `acceptFallback()` is an in-process Dart API on Core's `turn_coordinator.dart`; it is deliberately not a wire route.
+- **Procedure:**
+  1. Dart test starts Core on loopback and writes temporary `bridge.json`.
+  2. Test starts this adapter's MCP server as a subprocess, registering presence over the real wire.
+  3. Harness opens a voice turn on the coordinator.
+  4. Real `user_prompt_submit_hook.py` runs, captures `(binding_id, turn_id)` at prompt time.
+  5. Test submits Markdown to MCP server; C3 gate answers `rejected_content`; turn stays `open`.
+  6. No replacement is submitted; real `stop_hook.py` runs and records outcome `fallback`.
+  7. Harness calls in-process `acceptFallback({bindingId, turnId, text})`.
+  8. Closing wire assertion: `GET /v1/current` reports the same captured turn in state `fallback_accepted` (R23 mark).
+- **Status:** Open cross-repository dependency on `infiquetra/auralis`, tracked here and in the plan.
+
+---
+
+## Performed manual checks
+
+In accordance with U4 and the plan's verification instructions:
+- **Context injection:** In a live Herdr-managed session with the mock bridge showing an open bound turn, `user_prompt_submit_hook.py` injects the Auralis origin notice, expected rendering directive, and rendered voice policy instructions into `hookSpecificOutput.additionalContext`.
+- **Double-speech suppression:** When the session is wire-bound to an active bridge binding, `stop_hook.py` reconciles the turn record (recording `authored` or `fallback`) and exits 0 without spawning the legacy `scripts/speak.py` process.
+
+---
+
+## Record of guard-mutation checks
+
+During the implementation of U1 and U2, every validation guard and detector was mutation-tested (relaxed -> verified named test failure -> restored):
+
+1. **U1 Token and Identifier Grammar Guards (`test_bridge_client.py`):**
+   - Base64url token alphabet guard: mutated to accept `+` and `/` -> `test_token_grammar_violations_refuse_and_make_no_wire_requests` subtests failed -> restored.
+   - Base64url padding guard: mutated to accept `=` -> `test_token_grammar_violations_refuse_and_make_no_wire_requests` subtest failed -> restored.
+   - Token length guard: mutated to accept 32 chars -> `test_token_grammar_violations_refuse_and_make_no_wire_requests` subtests failed -> restored.
+   - Core UUID version guard: mutated to accept UUIDv1 -> `test_malformed_uppercase_or_wrong_version_identifier_refuses_snapshot` subtests failed -> restored.
+   - Core UUID lowercase guard: mutated to accept uppercase -> `test_malformed_uppercase_or_wrong_version_identifier_refuses_snapshot` subtests failed -> restored.
+2. **U2 Rendering Gate Detector Classes (`test_rendering_gate.py`):**
+   - Fenced code block detector: relaxed to require 4 backticks -> `test_gate_rejects_fenced_code_block` and `test_fenced_code_block_backticks` failed -> restored.
+   - Indented code block detector: relaxed -> `test_indented_code_block` and `test_tab_indented_code_line` failed -> restored.
+   - ATX heading detector: relaxed -> `test_atx_heading`, `test_empty_atx_heading`, `test_tab_delimited_atx_heading` failed -> restored.
+   - Setext heading detector: relaxed -> `test_setext_heading` and `test_one_character_setext_underline` failed -> restored.
+   - List marker detector: relaxed -> `test_list_marker`, `test_ordered_list_marker_non_one`, `test_multi_digit_ordered_marker_parenthesis`, `test_bullet_marker_at_end_of_line` failed -> restored.
+   - Blockquote detector: relaxed -> `test_blockquote` and `test_blockquote_no_space_after_gt` failed -> restored.
+   - Horizontal rule detector: relaxed -> `test_horizontal_rule`, `test_spaced_horizontal_rule`, `test_underscore_horizontal_rule` failed -> restored.
+   - Table pipe detector: relaxed -> `test_table_pipe_row` and `test_pipe_row_no_leading_or_trailing_pipe` failed -> restored.
+   - Link reference definition detector: relaxed -> `test_link_reference_definition` and `test_link_ref_def_multi_word_label` failed -> restored.
+   - Hard line break detector: relaxed -> `test_hard_line_break_trailing_spaces`, `test_hard_line_break_backslash`, `test_hard_break_three_trailing_spaces` failed -> restored.
+   - Raw HTML detector: relaxed -> `test_raw_html_tag_and_comment` and `test_raw_html_attribute_tag_and_non_tag_openers` failed -> restored.
+   - Backslash escape detector: relaxed -> `test_backslash_escape` and `test_backslash_escape_bracket` failed -> restored.
+   - Emphasis / strong pair detector: relaxed -> `test_gate_rejects_markdown_emphasis`, `test_emphasis_strong`, `test_three_asterisk_emphasis_run` failed -> restored.
+   - Strikethrough detector: relaxed -> `test_strikethrough` and `test_one_tilde_strikethrough` failed -> restored.
+   - Inline code span detector: relaxed -> `test_inline_code_span` and `test_two_backtick_code_span` failed -> restored.
+   - Inline and reference link detector: relaxed -> `test_inline_link_image`, `test_inline_link_empty_bracket_text`, `test_reference_link` failed -> restored.
+   - Autolink detector: relaxed -> `test_autolink` failed -> restored.
+   - Flock transaction deadline guard (`test_turn_record.py`): mutated to ignore deadline -> `test_lock_acquisition_timeout_raises_turn_record_busy` and `test_stubbed_clock_acquisition_budget_refusal` failed -> restored.
+
+---
+
+## Conclusion and Verdict
+
+**PASS — Unit U5 packaging, versioning, documentation, and evidence are complete.**
+All nine slice requirements (R20, R21, R22, R23, R25, R106, R107, R121, R122) and acceptance criteria are satisfied at the adapter boundary.

--- a/docs/plans/2026-08-27-auralis-c3-adapter.md
+++ b/docs/plans/2026-08-27-auralis-c3-adapter.md
@@ -1,0 +1,1431 @@
+---
+title: Auralis C3 Claude adapter implementation plan
+type: feat
+status: active
+date: 2026-08-27
+origin: https://github.com/infiquetra/auralis/blob/b49de1ba4d39cbd8a1e582d72bddca85bf528f8a/docs/brainstorms/2026-08-26-auralis-v1-requirements.md
+backend: inline
+---
+
+# Auralis C3 Claude adapter implementation plan
+
+## Summary
+
+Implementation plan for [infiquetra/infiquetra-agent-plugins#46](https://github.com/infiquetra/infiquetra-agent-plugins/issues/46),
+capability slice C3 of the Auralis V1 hierarchy (lane D): the adapter end of the versioned
+local bridge, built by extending the existing `plugins/voice` package in this repository.
+Five implementation units (U1–U5) add a bridge wire client and adapter identity resolver, a
+plain-spoken-text rendering gate, a voice-policy store, a Model Context Protocol (MCP)
+authored-rendering surface, three Claude hooks (turn origin, PreToolUse capture, completion
+reconciliation), and the packaging that ships it all as voice `0.3.0`. Everything is
+standard-library Python at the repository floor `python>=3.12`, tested with `unittest`,
+with no third-party dependency — the same constraints the voice package proved at `0.2.1`.
+
+Base for the run: `f981ed4` on `origin/main`, re-resolved at planning preflight on
+2026-08-27 and verified equal to `origin/main` at that time. Backend is **inline** for
+every unit.
+
+**Revised 2026-08-27** against the blocking document review at
+[`docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review.md`](../reviews/2026-08-27-auralis-c3-adapter-plan-doc-review.md);
+all twelve findings (F1–F12) are repaired — the per-finding disposition table is at the
+end of this document.
+
+**Revised again 2026-08-27** against the cycle-2 focused re-review at
+[`docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle2.md`](../reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle2.md),
+which recorded ten findings closed and two (F3, F5) partially closed. Both are completed
+in this revision — F3 by the joint AE36 test section and the bounded adapter-boundary
+claim, F5 by the closed Markdown grammar in U2 — and the cycle-2 disposition table sits
+beside the cycle-1 table at the end of this document. Nothing recorded as closed was
+reopened.
+
+**Revised a third time 2026-08-27** against the cycle-3 focused re-review at
+[`docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle3.md`](../reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle3.md),
+which closed F3 and adjudicated F5 still partially closed: the class table's rejecting
+rows gave illustrative spellings a literal matcher could satisfy while missing valid
+forms. This revision completes F5 and touches nothing else — every rejecting row now
+states a precise matching rule (the full marker set, the full separator set, and the
+permitted trailing context), every class gains a test scenario a literal-spelling
+implementation would fail, and the class table is declared the gate's self-contained
+normative grammar. The cycle-3 row extends the cycle-2 disposition table at the end of
+this document; nothing recorded as closed was touched.
+
+## Problem Frame
+
+Auralis V1 is a private, single-operator macOS application that gives one bound,
+Herdr-managed coding-agent session a spoken conversational loop. Its Core (repository
+`infiquetra/auralis`, slice C10) exposes a loopback HTTP bridge; the agent side of that
+bridge — the piece that runs inside the Claude Code process space — is this slice, and it
+is the only Auralis V1 slice that lands outside the `auralis` repository. Without it, the
+bound agent has no way to know a turn came in by voice, no instructions about how the
+operator wants speech rendered, and no surface through which to submit the spoken rendering
+it authors. The slice is complete on its own at this boundary: the plain-text submission
+contract is observable at the surface with no audio (acceptance example AE26), and AE34
+later proves interoperation with C10.
+
+**R-ID namespace note.** Every R-number in this document (R20, R121, …) is an Auralis V1
+requirements-document ID from
+[`2026-08-26-auralis-v1-requirements.md`](https://github.com/infiquetra/auralis/blob/b49de1ba4d39cbd8a1e582d72bddca85bf528f8a/docs/brainstorms/2026-08-26-auralis-v1-requirements.md),
+an immutable commit permalink at revision `b49de1ba4d39cbd8a1e582d72bddca85bf528f8a`
+(verified present at that revision on 2026-08-27; the short form `b49de1b` used elsewhere
+in run artifacts resolves to this full SHA). The voice package's own earlier plan and acceptance ledger use a
+*different* R1–R33 numbering from the voice 0.2.x run; the two namespaces do not overlap in
+meaning, and this plan never uses the voice-run numbering.
+
+## Wire authority — the pin, and the one honest flag on it
+
+The normative wire contract is **Auralis Bridge Contract v1**, authored by capability
+slice C10 in `infiquetra/auralis`, whose Saga Code Review is accepted. Its authoritative
+home is `docs/bridge/bridge-v1.md` in `infiquetra/auralis` at revision
+`695cd0ecfddf44e0d6e3386da318bd5fde4a1926` (the accepted-review revision, currently on the
+`auralis` run branch `orch/auralis-v1-phase1`). Because this repository's implementation
+and CI run from clean checkouts that cannot see another repository's unmerged branch, a
+**tracked byte-identical snapshot** of that exact revision is committed here at
+[`docs/bridge-v1-from-c10.md`](../bridge-v1-from-c10.md). The snapshot carries no local
+header or edit of any kind, so its integrity is checkable by hash alone:
+
+- Snapshot SHA-256: `eb47d141e5c1b87bae0bd1c0799386a3aa8806635251db14fc806469b5db19eb`.
+- Reproduction: `git -C <auralis checkout> show 695cd0ecfddf44e0d6e3386da318bd5fde4a1926:docs/bridge/bridge-v1.md | shasum -a 256`
+  yields the same digest (verified 2026-08-27).
+
+The contract defines discovery, authentication, the five routes, request/response bodies,
+transport errors, processing precedence, the adjudication order and rejection vocabulary,
+identifier semantics, retry rules, and extension rules, and it names C3 as its consumer.
+Every contract citation in this plan (a "§" reference) is a section of that snapshot.
+
+**Flag:** the contract has **not yet merged to `auralis` main**. This adapter's wire
+assumptions are pinned to the accepted-review revision above, not to a released artifact.
+Mitigations: every wire literal is centralized in one module (U1) and one stub fixture
+(`plugins/voice/tests/bridge_stub.py`, U1), so a contract change before merge is a bounded
+re-touch; the joint acceptance AE34 re-validates the wire against the real Core before the
+run closes. If C10 amends the contract, the snapshot is refreshed by the same
+extract-and-hash procedure and the new revision and digest are recorded here.
+
+C10's own acceptance stub deliberately imports no production bridge library, so the wire is
+provable from independent literals on both sides. This adapter's tests stand on the same
+discipline (KTD9).
+
+## Grounded facts (verified 2026-08-27 in this repository)
+
+- Branch `orch/auralis-c3-adapter-plan-c3-adapter` is at `f981ed4`, equal to
+  `origin/main` after `git fetch` at preflight.
+- The voice package is the proven first thin adapter: its Stop hook detaches and speaks
+  only for the one bound session
+  ([`stop_hook.py:64`](../../plugins/voice/com.infiquetra.claude/hooks/stop_hook.py)), the
+  binding store is atomic machine-local JSON
+  ([`binding.py:110`](../../plugins/voice/scripts/binding.py)), and settings are a closed
+  stated set ([`settings.py:81`](../../plugins/voice/scripts/settings.py)).
+- The Claude packaging layout is pinned by the 2026-08-25 decision "Claude installs the
+  package root" in [`DECISIONS.md`](../engineering-journal/DECISIONS.md) and enforced both
+  ways by `tests/test_claude_plugin_packaging.py`, including four-site version agreement
+  (`plugins/voice/plugin.json`, `plugins/voice/.claude-plugin/plugin.json`,
+  `plugins/voice/com.infiquetra.claude/plugin.json`, `.claude-plugin/marketplace.json`).
+- CI is the `Validate` workflow ([`ci.yml`](../../.github/workflows/ci.yml)): hermetic
+  `scripts/check_repo.py` + repo `unittest` suite + `git diff --check`, plus a
+  `plugin-tests` job that runs `pytest plugins/*/tests -q` on Python 3.12. New tests must
+  pass under both runners; plain `unittest` suites satisfy both.
+- `check_repo.py` also validates markdown link targets, plugin manifest `$schema`
+  literals, skill frontmatter, and secret-free values — so this plan document itself, the
+  new manifests, and every test fixture must use resolving links and inert example
+  credentials (a bridge-token fixture must be an obviously fake value).
+- Markdown-recognition precedent for the R121 gate already exists in the package: the
+  speak path's cleanup pass defines exact regex classes for fences, headings, emphasis,
+  links, inline code, lists, blockquotes, horizontal rules, and table pipes
+  ([`text_cleanup.py:27`](../../plugins/voice/scripts/text_cleanup.py)). Its own module
+  docstring bounds it as a small line-and-regex cleanup whose fidelity beyond the tested
+  classes is not a goal — so it *seeds* the gate's overlapping detector classes but does
+  not bound them: the gate owns a complete rejected-syntax contract of its own (KTD1,
+  U2), and never the transformation (R121 forbids repair).
+- Claude Code platform facts, verified against current documentation on 2026-08-27
+  (plugins-reference and hooks pages at code.claude.com):
+  - `.claude-plugin/plugin.json` `mcpServers` accepts a **string path** to a separate
+    JSON config file, exactly like `hooks` — so the packaging manifest can stay pure
+    distribution metadata and the server command can live inside the client extension.
+  - `${CLAUDE_PLUGIN_ROOT}` expands inside MCP server `command`/`args`; plugin MCP
+    servers start when the plugin is enabled and persist for the session (not respawned
+    per call) — a long-lived adapter process exists for free (KTD2).
+  - `UserPromptSubmit` hooks inject context via plain stdout on exit 0 or via
+    `hookSpecificOutput.additionalContext`; stdin carries `session_id` and `prompt`.
+  - `PreToolUse` stdin carries `tool_name`, `tool_input`, and `tool_use_id`; exit 0 with
+    no output leaves the permission flow completely unchanged (observe-only is
+    supported). This matches the X1 exploration finding, which reported no refutation.
+  - `Stop` stdin carries `last_assistant_message` (already relied on at voice 0.2.1).
+- X1 (the PreToolUse exploration gate) reported no refutation: exact `tool_name`,
+  structured `tool_input`, immutable `tool_use_id`; an allow-list is matchable and
+  compare-and-submit is expressible through the hook's own permissionDecision schema.
+  Treated as given per the card.
+- Open voice findings F6 (stray-capture sweep, #43) and F7 (`VOICE_RETENTION` never
+  consulted at runtime, #44) do not intersect this slice's surfaces and stay untouched.
+
+## Requirements
+
+The slice owns nine of the run's 136 requirements. Each row states what must hold, what
+part of it is observable at this slice boundary, and where it is traced.
+
+| R-ID | Requirement (condensed) | At this boundary | Traced by |
+|---|---|---|---|
+| R20 | The bound agent authors the spoken rendering; Auralis and its adapter never compose, summarize, shorten, or rewrite response content | No code path in the adapter transforms rendering text; the gate rejects, never repairs; accepted text is forwarded byte-identical | `plugins/voice/tests/test_rendering_gate.py`, `plugins/voice/tests/test_mcp_server.py` |
+| R21 | Auralis exposes an MCP surface through which the bound agent submits an authored spoken rendering for the current turn | The adapter *is* that surface in the agent's process space: an MCP stdio server with a `submit_spoken_rendering` tool that forwards to `POST /v1/rendering` | `plugins/voice/tests/test_mcp_server.py` |
+| R22 | A turn completed without an authored rendering falls back to the cleaned full written response rather than silence | C3 owns this requirement, but its mechanism is C5's in-process `acceptFallback()` (see "The R22/R23 fallback seam"). The adapter's share: submit only gated plain text, never fabricate a submission, let the turn complete with no accepted authored rendering, and durably record that completion. Fallback initiation, content sourcing, and speech are Core/C5 (joint AE36) | `plugins/voice/tests/test_stop_hook.py`, `plugins/voice/tests/test_r122_adapter_boundary.py`; joint AE36 |
+| R23 | A fallback turn is visibly marked as a fallback, distinguishable from an authored response | The distinguishing mark is Core's `fallback_accepted` turn state (contract §6.4), written when C5 calls `acceptFallback()`. The adapter's share: keep the two outcomes disjoint in its own record (`fallback` vs `authored`) so the adapter-side evidence agrees with the Core-side mark (joint AE36) | `plugins/voice/tests/test_stop_hook.py`, `plugins/voice/tests/test_turn_record.py`; joint AE36 |
+| R25 | No persistent verbosity mode; preferences are carried to the agent as instructions; no adapter content decision | The policy module renders preferences to instruction text only; the adapter has no verbosity state that alters content and no transformation path | `plugins/voice/tests/test_voice_policy.py` |
+| R106 | For every turn, tell the agent whether the turn originated through Auralis | UserPromptSubmit hook queries `GET /v1/current`, matches identity, and injects an explicit originated/not-originated signal on every turn while bound | `plugins/voice/tests/test_user_prompt_submit_hook.py` |
+| R107 | Carry the operator's current voice policy and preferences, including an armed one-shot Brief Next Turn override, to the agent as instructions; transmit, never apply | Policy (with armed override) rides the same injection on Auralis-originated turns; the one-shot is consumed on transmission | `plugins/voice/tests/test_user_prompt_submit_hook.py`, `plugins/voice/tests/test_voice_policy.py` |
+| R121 | The agent-facing surface accepts plain spoken text only; Markdown or fenced code is rejected at submission with a named reason; never silently cleaned or reformatted | The gate rejects with `fenced_code_block` or `markdown_formatting` before anything reaches the wire; resubmission of plain text is accepted (AE26) | `plugins/voice/tests/test_rendering_gate.py`, `plugins/voice/tests/test_mcp_server.py` |
+| R122 | A rendering rejected under R121 with no acceptable replacement before turn completion falls back under R22, marked as a fallback | The turn record carries the rejection(s) with named reasons; completion capture then records outcome `fallback` — the **adapter-side half** of the rejection-to-fallback path, observable in adapter state. The Core-side half — the same turn marked `fallback_accepted` — is observable only in `infiquetra/auralis` and is proven by the joint AE36 test (see "The joint AE36 test" section) | `plugins/voice/tests/test_mcp_server.py`, `plugins/voice/tests/test_stop_hook.py`, `plugins/voice/tests/test_r122_adapter_boundary.py`; joint AE36 |
+
+## High-level design
+
+One walk of a voice turn, naming every new module. Auralis Core starts a voice turn (the
+operator spoke); the operator's transcribed prompt reaches the bound Claude session. The
+**UserPromptSubmit hook** (`user_prompt_submit_hook.py`, U4) reads `bridge.json` via the
+**bridge client** (`bridge_client.py`, U1), resolves the adapter's three-part identity via
+the **identity resolver** (`adapter_identity.py`, U1), calls `GET /v1/current`, and — when
+an open turn exists and the bound identity is this session — writes the turn's
+`(binding_id, turn_id)` into the **turn record** (`turn_record.py`, U2) and injects
+context: this turn originated through Auralis, a spoken rendering is expected, and here are
+the operator's current voice-policy instructions rendered by the **policy store**
+(`voice_policy.py`, U2), including any armed one-shot Brief Next Turn override (consumed on
+transmission). A turn with no open voice turn gets the explicit opposite signal while
+bound, and no signal at all when the bridge or binding is absent.
+
+During the turn, the **PreToolUse hook** (`pre_tool_use_hook.py`, U4) appends
+`{tool_name, tool_input, tool_use_id}` observations to the same single-turn record —
+observe-only, never a permission decision.
+
+When the agent authors its spoken rendering, it calls the `submit_spoken_rendering` tool on
+the **MCP server** (`mcp_server.py`, U3) — the plugin-declared stdio server that is also
+the adapter's long-lived process, running the presence-renewal loop (`PUT /v1/presence` on
+the lease cadence, `DELETE` on shutdown). The tool runs the **rendering gate**
+(`rendering_gate.py`, U2): Markdown or fenced code is rejected with a named reason and
+nothing touches the wire; plain text is forwarded byte-identical to `POST /v1/rendering`
+using the *prompt-time captured* identifier pair, and Core's disposition (accepted, or a
+wire rejection reason) is relayed verbatim. Every submission and disposition lands in the
+turn record.
+
+When the turn settles, the extended **Stop hook** (`stop_hook.py`, U4) reconciles: if this
+session is wire-bound and the voice turn ended without an accepted authored rendering, it
+records outcome `fallback`; if a rendering was accepted, outcome `authored`. While
+wire-bound it suppresses the legacy local speak path — Auralis owns speech — and when not
+wire-bound the 0.2.1 behaviour is byte-for-byte unchanged. The recorded outcome is
+adapter-side *evidence* of the turn's disposition, not the fallback mechanism itself; the
+mechanism is Core/C5's, per the seam below.
+
+## The R22/R23 fallback seam — who does what
+
+C3 owns requirements R22 and R23, but the mechanism that satisfies them lives in Auralis
+Core: the contract's downstream-consumption table (§9) assigns `acceptFallback()` to
+capability slice C5 (Audio), which calls it prior to fallback speech, exactly as it calls
+`startTurn()` on recording and `cancelTurn()` on barge-in. `acceptFallback()` is an
+in-process Core API. It is deliberately **not** one of the five wire routes, and this plan
+neither invents a wire operation for it nor asks C10 for one. This section states the
+ownership boundary explicitly so the split cannot be misread as a missing path.
+
+**What the adapter (C3) is responsible for.**
+
+- Rejecting a non-plain-text authored rendering at submission with a named reason under
+  R121 (`fenced_code_block` / `markdown_formatting`), forwarding nothing to the wire, and
+  never cleaning, rewriting, or substituting content.
+- Never fabricating a submission: when no acceptable rendering is authored (including the
+  R122 case — a named rejection with no replacement), the adapter lets the turn complete
+  with **no accepted authored rendering**. On the wire this is simply the absence of an
+  accepted `POST /v1/rendering` for the captured `(binding_id, turn_id)`; the turn slot
+  Core holds for that pair stays in state `open` as far as C3's actions are concerned.
+- Durably recording the adapter-side view: the turn record carries the named rejection(s)
+  and the settled outcome (`fallback` vs `authored`, disjoint), which is the observable
+  R122 evidence trail at this repository's boundary.
+- Suppressing the legacy local speak path while wire-bound, so Core's fallback speech is
+  never doubled by a local one.
+
+**What Core and C5 are responsible for** (inside `infiquetra/auralis`, out of C3's
+custody).
+
+- Deciding the fallback moment for a turn that has no accepted authored rendering, and
+  initiating fallback speech: C5 calls `acceptFallback()` prior to fallback speech (§9).
+- Sourcing the fallback content — R22's "cleaned full written response". How Core obtains
+  the completed written response is Core-side design inside C10/C5's custody; no committed
+  wire route carries it, and the adapter neither can nor should supply it.
+- Marking the fallback visibly: `acceptFallback()` transitions the turn to the
+  `fallback_accepted` state (§6.4), the Core-side mark R23 requires, distinguishable from
+  `authored_accepted`.
+
+**How R22 and R23 are therefore discharged.** R22's condition ("turn completed without an
+authored rendering") is jointly produced: the adapter guarantees no un-gated or fabricated
+rendering is ever accepted, and Core observes the absence of an accepted rendering for the
+turn. R22's action (speak the full written response instead of silence) and R23's mark
+(`fallback_accepted`) are executed entirely by Core/C5 through `acceptFallback()`. The
+adapter's `fallback` outcome record is the C3-side half of the evidence; the Core-side
+half is the turn state. The two halves are joined at the acceptance boundary, not on the
+wire.
+
+**Named cross-slice dependency (satisfied at AE36, not by C3 alone).** C3 cannot alone
+make a fallback audible or marked. For R22/R23 to hold end to end, C5 must (a) detect the
+fallback moment for an unrendered completed turn, (b) obtain the turn's completed full
+written response by a Core-side mechanism, and (c) call `acceptFallback()` so the turn is
+spoken and marked `fallback_accepted`. That is a legitimate dependency on C5's slice — the
+contract already assigns C5 the API — and the joint acceptance AE36 is where the
+cross-boundary behaviour is proven. If C5's implementation cannot source the written
+response, that is C5/C10's finding to surface in their slice; nothing in this plan papers
+over it, and no adapter-local JSON label is claimed to substitute for the Core-side mark.
+The executable form of that proof — where it runs, who owns it, and the step-by-step
+procedure — is the next section.
+
+## The joint AE36 test — executable home, owner, and procedure
+
+The cycle-2 doc review asked where the joint rejection-to-fallback proof actually
+executes. Plainly: **it cannot execute in this repository.** `acceptFallback()` is an
+in-process Dart API on Core's turn coordinator
+(`lib/src/core/bridge/turn_coordinator.dart:537` in `infiquetra/auralis` at the pinned
+revision `695cd0ecfddf44e0d6e3386da318bd5fde4a1926`, returning a `RenderingDisposition`);
+it is deliberately not one of the frozen five wire routes, so no Python process in this
+repository can drive it. The only wire-observable turn state is `GET /v1/current`, whose
+`turn.state` is exactly one of `open`, `authored_accepted`, `fallback_accepted`,
+`canceled` — and that `fallback_accepted` is observable there is already proven by Core's
+own suite (`test/core/bridge/bridge_server_test.dart` lines 391, 424, and 431 at the same
+revision, which drive `acceptFallback()` on a fresh open turn and read the state back over
+the wire).
+
+**Executable home: `infiquetra/auralis`.** The joint AE36 test is a Dart-side integration
+test in the `auralis` repository — the only process space that can both make the
+`acceptFallback()` call and host the turn state the closing assertion reads. It lands
+beside Core's existing bridge tests (the exact file path is the `auralis` lane's custody;
+this plan fixes the procedure and the obligations, not another repository's file layout).
+
+**Owner: the C5 slice in `infiquetra/auralis`, with a Dart-side harness standing in until
+C5 is built.** C5 is the production caller of `acceptFallback()` and is not yet built, so
+the test's C5 role is played by a Dart test harness making the same in-process call C5
+will make. This is a **named cross-repository dependency of this plan**: the joint AE36
+test is an obligation on the `auralis` repository, recorded here, in the
+acceptance-mapping row for AE36, and in U5's acceptance evidence note as an open item
+until the joint run closes it — not left implied.
+
+**What C3 must supply — all already guaranteed by U3/U5, nothing new.** The joint test
+consumes this repository's adapter as a black box: processes launchable at their declared
+argv from an installed-root-shaped copy of `plugins/voice` (U3's executable-entrypoint
+discipline, pinned by U5's packaging test), bridge discovery through the `HOME`-relative
+`bridge.json` location the contract's §2 fixes (no code seam needed), state directed by
+`VOICE_STATE_DIR`, and identity through the two KTD9 environment names backed by a
+stand-in Herdr executable fixture answering `agent list` with exactly one pane. If any of
+those stops being launchable that way, this repository — not the joint test — is broken.
+
+**The procedure.** Each step names the process, the repository it runs in, and the call:
+
+1. **Start Core (`auralis`, in-process).** The Dart test constructs the real turn
+   coordinator and bridge server on a loopback port and writes a real discovery
+   `bridge.json` under a temporary `HOME`'s `Library/Application Support/Auralis/`.
+2. **Start the adapter (this repository, as a subprocess).** The test launches the real
+   MCP server at its declared argv with `HOME`, `VOICE_STATE_DIR`, and the two KTD9
+   identity names pointed at the fixtures above. The server discovers the bridge and
+   registers presence over the real wire (`PUT /v1/presence`); Core's binding epoch binds
+   that identity.
+3. **Open the voice turn (`auralis`, in-process).** The harness starts a turn on the
+   coordinator exactly as C5 will on recording, so `GET /v1/current` shows an open turn
+   for the bound identity. The test holds this turn's `(binding_id, turn_id)` pair — the
+   join key for every later assertion.
+4. **Capture at prompt time (this repository, as a subprocess).** The real
+   `user_prompt_submit_hook.py` runs with a stdin payload for the bound session; it reads
+   `GET /v1/current` and writes the captured pair into the adapter's turn record.
+5. **The real C3 rejection (this repository, over the MCP pipes).** The test calls
+   `tools/call submit_spoken_rendering` with Markdown text. The gate answers the named
+   `rejected_content` reason; Core observes no `POST /v1/rendering` for the pair, and the
+   turn stays `open`.
+6. **No replacement; the turn completes (this repository, as a subprocess).** Nothing
+   further is submitted. The real `stop_hook.py` runs with a Stop payload for the same
+   session; the adapter records outcome `fallback` and spawns no speech.
+7. **Drive the fallback (`auralis`, in-process — the call this repository cannot
+   make).** The harness, standing in for C5, calls
+   `acceptFallback({bindingId: <captured binding_id>, turnId: <captured turn_id>,
+   text: <the harness's stand-in cleaned written response>})` on the same coordinator and
+   checks the returned `RenderingDisposition` reports acceptance.
+8. **The closing assertion (`auralis`, over the wire).** `GET /v1/current` now reports
+   the **same turn** — `turn_id` equal to the step-3 pair's — in state
+   **`fallback_accepted`**. That is the R23 mark, on the very turn whose rendering the
+   real C3 gate rejected in step 5, reached with no replacement, no fabricated
+   submission, and no sixth route.
+
+Every wire interaction in the procedure uses only the five frozen routes; the one call
+outside them (`acceptFallback()`) is made in-process by the Dart harness, exactly as C5
+will make it in production. No bridge route is added or proposed.
+
+**What this repository's own suite claims after this correction.** The in-repository test
+formerly named as the end-to-end R122 proof is renamed
+`plugins/voice/tests/test_r122_adapter_boundary.py` (U4) and claims exactly its half:
+real prompt hook → real MCP server process → real Stop hook → the adapter record's
+named-rejection-then-`fallback` trail for the captured pair. The Core-side
+`fallback_accepted` half is proven only by the joint AE36 test above. Neither half alone
+is R122's end-to-end proof; the join between them is the shared `(binding_id, turn_id)`
+pair.
+
+## Key Technical Decisions
+
+### KTD1 — R121 enforcement lives in the adapter surface, with a three-class result vocabulary
+
+**Decision.** The plain-spoken-text rule is enforced in the adapter's MCP surface, before
+the wire. The tool result vocabulary has three disjoint classes: `rejected_content` with
+adapter-owned reasons (`fenced_code_block`, `markdown_formatting`), `rejected_by_core`
+relaying the wire's adjudication vocabulary verbatim (`no_binding` … `empty_rendering`),
+and `unavailable` with a named operational condition (`bridge_unavailable`, `not_bound`,
+`no_current_turn`, `transport_error`, `turn_record_busy`). Precedence for content reasons: any fence yields
+`fenced_code_block`; otherwise any other detected class yields `markdown_formatting`, with
+the detected classes and first offending line named in the detail. The gate enforces a
+**complete, closed rejected-syntax contract owned by the gate itself** — the full class
+list is enumerated in U2's design notes — not the narrower recognizer set of the speak
+path's cleanup pass, whose documented scope (a small line-and-regex cleanup, fidelity
+beyond its tested classes explicitly not a goal) is too small to prove R121.
+
+**Rationale.** The bridge's adjudication order (contract §6.5) contains no plain-text
+reason — Core accepts text verbatim — so the agent-facing surface is the only place R121
+*can* live. Splitting the vocabulary keeps adapter judgments, Core judgments, and
+availability states impossible to confuse, and rejection reasons are named so the agent can
+resubmit (R121's whole point). Everything except content form is left to Core: a single
+adjudicator for turn currency, duplicates, and emptiness avoids duplicated logic that could
+drift.
+
+**Rejected.** Cleaning the submission with the existing cleanup pass (R121 explicitly
+forbids repair); asking C10 for a wire-level plain-text reason (Core endpoint is C10's
+custody; adapter-side enforcement needs no cross-lane edit); pre-checking emptiness
+adapter-side (duplicates Core's `empty_rendering` adjudication for no gain).
+
+**Revisit when.** A bridge v2 adds content adjudication to the wire, or the run amends
+R121's detection classes.
+
+### KTD2 — The MCP server process is the adapter's long-lived process; hooks are one-shot clients
+
+**Decision.** The presence lifecycle (discovery retry at the contract cadence,
+`PUT /v1/presence` renewal at or before `renew_after_ms` as returned by Core, re-discovery
+on credential rotation, best-effort `DELETE /v1/presence` on stdin EOF) lives in a
+background thread of the plugin-declared MCP stdio server. Hooks are ephemeral processes
+that each perform single cheap bridge reads and exit.
+
+**Rationale.** Verified platform fact: plugin MCP servers start when the plugin is enabled
+and persist for the whole session — a supervised long-lived process the package gets for
+free, in exactly the process that also owns the submission tool. The lease cadence
+(15,000 ms lease, renew at 5,000 ms) cannot be met by ephemeral hook processes.
+Multiple concurrent Claude sessions each run their own server and register their own
+identity; the contract's presence model is per-identity leases and Core's binding epoch
+chooses one, so this is contract-clean.
+
+**Rejected.** A separate daemon with its own installer and lifecycle (new operational
+surface, nothing needs it); presence renewal from hooks (cannot hold the cadence); no
+presence at all (the contract names C3 as running the presence renewal loop).
+
+**Revisit when.** The client changes plugin-MCP lifecycle, or bridge v2 changes the lease
+model.
+
+### KTD3 — Turn origin is resolved at prompt time from `GET /v1/current`, explicit both ways while bound, silent otherwise
+
+**Decision.** The UserPromptSubmit hook decides origin per turn: Auralis-originated if and
+only if `GET /v1/current` shows an open turn whose binding identity equals this session's
+resolved identity (byte-exact, all three components, and the hook payload's `session_id`
+must equal the resolved `agent_session_id`). While a binding epoch for this session is
+active, every turn gets an explicit signal — originated or not-originated (R106's "for
+every turn"). When the bridge is unavailable, discovery fails, identity does not resolve,
+or no binding epoch names this session, the hook stays silent: no expectation exists, and
+injecting "not through Auralis" into every unbridged session forever would be noise.
+
+**Rationale.** `GET /v1/current` is the contract's designated snapshot for exactly this
+question, and the single-slot turn registry makes "open turn + my identity" a precise
+definition of an Auralis-originated turn: a typed prompt while bound has no open voice
+turn and reads not-originated.
+
+**Rejected.** Always-explicit signalling even with no bridge (permanent noise in every
+Claude session on the machine); Core marking the prompt text itself (Core-side change, not
+in the committed contract; also fragile against prompt editing).
+
+**Revisit when.** The bridge exposes an explicit turn-origin field, or R106's wording is
+amended by the operator.
+
+### KTD4 — Submissions use the prompt-time captured identifier pair, never a fresh read
+
+**Decision.** The `(binding_id, turn_id)` pair captured by the UserPromptSubmit hook at
+turn origin is stored in the turn record and used verbatim for `POST /v1/rendering`. The
+MCP server never re-reads `GET /v1/current` to pick identifiers at submission time. No
+captured pair (or a record from a different `session_id`) means there is nothing to submit:
+the tool answers `unavailable` / `no_current_turn`.
+
+**Rationale.** Contract §8: the adapter "obtains active identifiers from `GET /v1/current`,
+verifies its identity match, and carries the exact pair through its agent surface." A fresh
+read at submission time would silently retarget a late rendering at whatever turn is
+current — the wrong-turn hazard. Using the captured pair makes Core's own adjudication
+(`turn_not_current`, `turn_canceled`) the arbiter of staleness, which is exactly what the
+vocabulary is for.
+
+**Rejected.** Fresh `GET /v1/current` at submission (wrong-turn hazard); passing
+identifiers through the injected context and making the agent echo them (leaks wire
+plumbing into agent-visible instructions and trusts the agent to copy opaque strings
+correctly).
+
+**Revisit when.** Bridge v2 changes identifier custody.
+
+### KTD5 — Voice policy is an adapter-local store; transmit-only; the one-shot override is consumed on transmission
+
+**Decision.** Policy and preferences live in an adapter-owned JSON file in the package
+state directory, managed by `voice_policy.py` with the package's atomic-write and
+absent-vs-corrupt-reported conventions. The store carries free-form preference instructions
+plus one boolean one-shot: Brief Next Turn. Rendering to instruction text is the only
+consumer; nothing in the adapter ever applies a preference to content (R25). The one-shot
+is consumed atomically when transmitted into a turn's injected instructions. Arming and
+inspection get minimal CLI verbs on the existing `voice` CLI (`voice policy …`).
+
+**Rationale.** No committed bridge route carries policy, and inventing an Auralis-owned
+file or asking C10 for a route would cross custody. An adapter-local source keeps R107
+fully demonstrable at this boundary — the named card test is "voice policy including an
+armed override reaching the agent" — and the source hides behind one small module so a
+future bridge extension can replace it without touching the transmission path.
+Consume-on-transmission is the plain meaning of "one-shot for the next turn": it applies to
+the next Auralis-originated turn's instructions, exactly once, even if that turn then falls
+back.
+
+**Rejected.** Reading Auralis-owned application files (custody violation, undocumented
+surface); a new bridge route (C10's custody); consume-on-acceptance (would let one arming
+apply to several turns if submissions keep failing, which is not "one-shot").
+
+**Revisit when.** A `/v1/` policy route is published by Core — the store becomes a cache
+of the wire value behind the same render function.
+
+### KTD6 — A wire-bound completion suppresses the legacy local speak path; the legacy path is otherwise untouched
+
+**Decision.** The Stop hook gains one early branch: when the completing `session_id`
+resolves to this machine's adapter identity and the bridge currently shows a binding epoch
+for that identity, the hook does not spawn the local speak child; instead it reconciles the
+turn record (outcome `authored` if the captured turn reached an accepted authored
+rendering, `fallback` otherwise) and exits 0. On any bridge doubt — discovery failure,
+transport error, no epoch — the legacy 0.2.1 behaviour runs unchanged.
+
+**Rationale.** Auralis owns speech custody; a bound session that also speaks locally would
+double-speak every turn. Failing toward the legacy path keeps voice 0.2.1 users whole when
+Auralis is absent or broken. The reconciliation half is C3's contribution to R22/R23/R122:
+it is the adapter-side detector and durable marker of "completed without an accepted
+rendering." It is evidence, not the fallback mechanism — fallback speech and the
+`fallback_accepted` mark are Core/C5's through `acceptFallback()`, per "The R22/R23
+fallback seam" above; the Stop hook hands nothing to Core and needs no wire route to do
+its half.
+
+**Rejected.** Removing the legacy speak path (breaks the shipped standalone voice loop);
+suppressing on mere `bridge.json` existence (a stale file would silence a working local
+loop; the epoch check is the honest signal).
+
+**Revisit when.** Auralis reaches always-on daily use and the legacy path is retired by an
+operator decision.
+
+### KTD7 — PreToolUse capture is observe-only, scoped, and single-turn-retained
+
+**Decision.** The PreToolUse hook records `{tool_name, tool_input, tool_use_id}`
+observations into the current turn record only when that record shows an Auralis-originated
+turn for this `session_id`. It always exits 0 with no output on every path — it never
+emits `permissionDecision` or any hook decision field, so the permission flow is byte-for-
+byte unchanged. An allow-list (a stated list in the policy store) selects which tool names
+are recorded; empty list means record all. The turn record holds only the current turn and
+is replaced at the next turn origin — no accumulating tool-input log exists.
+
+**Rationale.** The card's objective is *capture*, X1 proved the payload shape, and
+stop-condition 4 forbids touching permission boundaries — observe-only is the only
+compliant posture, and the platform documents that exit 0 with no output leaves the flow
+unchanged. Single-turn retention keeps the capture inside the package's ephemeral-state
+posture: `tool_input` can contain sensitive content, and a growing log would be a new
+privacy surface this slice has no mandate to open.
+
+**Rejected.** Emitting `permissionDecision` (stop condition 4); recording every session's
+every tool call (privacy surface, no requirement needs it); a persistent capture journal
+(same).
+
+**Revisit when.** The approvals slice (C8) lands a bridge surface that consumes tool-use
+data — the capture shape here is its input.
+
+### KTD8 — The MCP server is stdlib-only stdio JSON-RPC with a minimal method set
+
+**Decision.** `mcp_server.py` implements the MCP stdio transport directly: UTF-8
+newline-delimited JSON-RPC 2.0 messages; methods `initialize` (echoing the client's
+protocol version when supported, else answering with the newest supported version),
+`notifications/initialized`, `tools/list`, `tools/call`, `ping`; unknown methods answer
+JSON-RPC method-not-found; nothing but protocol frames is ever written to stdout. One tool
+is exposed: `submit_spoken_rendering`, input schema `{text: string}` (closed object). Tool
+results carry a single text content block whose body is compact JSON with the KTD1
+disposition vocabulary; `isError` stays false for adjudicated rejections — the submission
+protocol worked and the verdict is data the agent acts on.
+
+**Rationale.** The repository floor forbids third-party dependencies, and the package's
+whole discipline is stdlib seams; the MCP subset needed for one tool is small and
+testable. One tool keeps the agent surface minimal: origin and expectation arrive by
+injection (KTD3), so no status/query tool is needed in V1.
+
+**Rejected.** The official MCP Python SDK or FastMCP (third-party dependency, floor
+violation); an HTTP-transport MCP server (more moving parts, no consumer needs it);
+additional query tools (surface growth without a requirement).
+
+**Revisit when.** A second consumer needs more of the protocol, or the MCP stdio framing
+spec changes.
+
+### KTD9 — Tests stand on independent contract literals; seams are parameters, not new settings
+
+**Decision.** Bridge tests run against a stdlib `http.server` stub speaking the literal
+shapes of [`docs/bridge-v1-from-c10.md`](../bridge-v1-from-c10.md) — the same
+independent-literals discipline as C10's acceptance stub, with no shared helpers across
+the repository boundary. The stub lives in one owned fixture module,
+`plugins/voice/tests/bridge_stub.py` (U1). Token fixtures are inert example values (the
+secret-free check in `check_repo.py` stays green). The bridge discovery path
+(`~/Library/Application Support/Auralis/bridge.json`) is a module constant with a
+parameter seam for tests — **no `VOICE_BRIDGE_FILE` override is added**, because the
+contract fixes the location and an env override would just be a second way to break
+discovery. The two environment values the contract's §5 identity rule mandates
+(`HERDR_PANE_ID`, `HERDR_BIN_PATH`) are **read through `settings.py`, the package's sole
+environment reader**: its closed `SETTING_NAMES` tuple
+([`settings.py:81`](../../plugins/voice/scripts/settings.py)) is extended from eight to
+ten stated names, both with no default (absent or empty → the module's named refusal,
+which `adapter_identity.py` reports as "register and submit nothing" per §5). The set
+stays closed and secret-free; no module outside `settings.py` reads the environment.
+
+**Rationale.** Two ends proving one wire from two independent readings of the same
+document is the run's stated bridge-acceptance design; parameter seams follow the
+package's hermetic-seams decision (2026-08-25). Routing the contract-mandated identity
+names through the settings module preserves the package's one-reader rule *and* the
+closed-set rule — the set is extended in its owning module, not bypassed by a second
+reader — and the refusal-by-name semantics of `_stated` are exactly the §5 failure
+posture.
+
+**Rejected.** Sharing stub or fixture code with `infiquetra/auralis` (the contract
+explicitly forbids cross-repository test helpers); a `VOICE_BRIDGE_FILE` setting (opens a
+misconfiguration class the contract exists to prevent); `adapter_identity.py` reading
+`HERDR_PANE_ID` / `HERDR_BIN_PATH` directly (a second environment reader, violating the
+settings module's stated contract).
+
+**Revisit when.** The contract's discovery location changes (it would arrive as a v2).
+
+### KTD10 — Packaging: `mcpServers` as a string path into the client extension; version 0.3.0 at all four sites
+
+**Decision.** `plugins/voice/.claude-plugin/plugin.json` gains
+`"mcpServers": "./com.infiquetra.claude/mcp/servers.json"` — a path, not an inline
+object — and the server config (command `python3`,
+`${CLAUDE_PLUGIN_ROOT}/scripts/mcp_server.py`) lives in that new file inside the client
+extension. The version becomes `0.3.0` at all four sites the packaging test binds
+together, and `tests/test_claude_plugin_packaging.py` is extended to assert the
+`mcpServers` declaration is a path that resolves into the client extension.
+
+**Rationale.** The repository boundary rule says the packaging manifest carries paths and
+no behaviour; the string-path form is documented and verified, so the command line (which
+*is* behaviour wiring) stays inside `com.infiquetra.claude/`. Minor version bump: new
+backward-compatible capability on a proven package.
+
+**Rejected.** Inline `mcpServers` object in the packaging manifest (a command in a file
+the repo rule requires to be metadata-only); a separate new plugin for the adapter (the
+card mandates extending the voice package, and a second package would duplicate the core).
+
+**Revisit when.** The Claude CLI changes manifest resolution (same revisit condition as
+the 2026-08-25 packaging decision).
+
+### KTD11 — Turn-record mutations are one locked transaction; atomic replace is only the torn-write defense
+
+**Decision.** Four processes mutate one turn record (the UserPromptSubmit hook creates
+it, the MCP server appends submissions, the PreToolUse hook appends observations, the
+Stop hook settles the outcome). Every mutation goes through **one entrypoint**,
+`turn_record.mutate(fn)`, which serializes writers with an exclusive `fcntl.flock` lock
+on a sidecar lock file (`<record>.lock` beside the record in the state directory) and
+performs the whole read-current → apply → atomic write-replace sequence *inside* the
+critical section. Lock acquisition is a non-blocking attempt retried on a monotonic
+deadline (budget in the timeout table below); an expired deadline is a named refusal
+(`turn_record_busy`), never a blind write. No writer anywhere in the adapter performs its
+own read-modify-replace on the record; atomic `os.replace` remains solely the torn-write
+defense for readers.
+
+**Rationale.** Atomic replacement makes each write complete but does nothing about two
+writers reading the same prior document and each replacing it — the lost-update
+interleaving that could erase a named R121 rejection or an accepted disposition and flip
+the R122 result. An exclusive advisory lock held across read-apply-write is the smallest
+standard-library construct that makes each mutation a transaction; `fcntl.flock` works on
+both the macOS target and the Linux CI runner, and a sidecar lock file keeps the record
+itself replaceable while locked. This is the same defect family that has bitten this run
+twice in Core, which is why the mechanism is specified here rather than left to an
+implementer's comment.
+
+**Rejected.** Atomic replace alone with "one writer per field family" (two processes can
+still interleave read-modify-replace on the whole file — the exact reviewed defect);
+`O_CREAT|O_EXCL` lock files (stale-lock cleanup on crash becomes its own protocol; flock
+releases with the process); an SQLite record (heavier machinery than one single-turn JSON
+document warrants, and the package's stores are uniformly JSON files).
+
+**Revisit when.** The record outgrows a single turn or gains cross-process readers with
+consistency needs beyond one file.
+
+## Timeout budget (normative numbers)
+
+Every deadline in this plan is a number here; units cite this table instead of saying
+"short" or "stated". All HTTP calls are loopback. Behaviours on expiry are named; no
+expiry may surface as acceptance or as a broken turn.
+
+| Operation | Owner | Budget | On expiry |
+|---|---|---:|---|
+| HTTP connect (any bridge call) | U1 `bridge_client.py` | 250 ms | Named `transport_error`; fail closed |
+| `GET /v1/health`, `GET /v1/current` (overall per call) | U1 | 1,000 ms | Named `transport_error`; caller treats bridge as unavailable |
+| `PUT /v1/presence`, `DELETE /v1/presence` (overall) | U1 (server presence thread) | 2,000 ms | Renewal failure → 1 Hz re-discovery per §8; never blocks the tool path |
+| `POST /v1/rendering` (overall, per attempt) | U1 | 2,000 ms | Named `transport_error`; lost-response retry rules per §8 (single byte-equivalent retry) |
+| Herdr `agent list` subprocess | U1 `adapter_identity.py` | 2,000 ms | Named identity refusal; register and submit nothing (§5) |
+| Turn-record lock acquisition (`mutate`) | U2 `turn_record.py` | 500 ms (10 ms retry interval, monotonic clock) | Named `turn_record_busy`; per-writer behaviour below |
+| UserPromptSubmit hook (hooks.json `timeout`) | U4 | 5 s (package convention, matches Stop) | Client kills the hook; no injection that turn |
+| — internal budget: discovery read + identity + one GET + record write | U4 | ≤ 3,500 ms worst case (sum of rows above) | Any internal expiry → emit nothing, exit 0 |
+| PreToolUse hook (hooks.json `timeout`) | U4 | 5 s | Client kills the hook; observation lost, permission flow untouched |
+| Stop hook (hooks.json `timeout`, existing) | U4 | 5 s (unchanged) | Client kills the hook |
+| — internal budget: one bridge snapshot on the KTD6 branch | U4 | 1,000 ms | Bridge doubt → legacy 0.2.1 path runs |
+| Presence renewal cadence | U3 | at/before `renew_after_ms` (5,000 ms) per §6.2 | Missed renewal → re-registration path; lease expiry is Core's to enforce |
+
+Per-writer behaviour on `turn_record_busy`: the UserPromptSubmit hook emits no injection
+and exits 0 (an uncaptured turn later reads as `no_current_turn`); the PreToolUse hook
+drops the observation and exits 0; the MCP server answers the tool call
+`unavailable` / `turn_record_busy` without touching the wire; the Stop hook falls toward
+the safe side — while wire-bound it still suppresses local speech (suppression is decided
+by the binding epoch, not by the record) and leaves the outcome unsettled rather than
+guessing. Deadline behaviour is tested with a stubbed clock at each owning boundary
+(U1/U2 scenarios), never with wall-clock sleeps.
+
+## Implementation Units
+
+Waves: U1 and U2 are independent; U3 depends on U1+U2; U4 depends on U1+U2+U3 (its
+adapter-boundary scenario launches U3's real server process); U5 lands last. All unit file
+sets are disjoint. Backend is inline for every unit, so execution order is simply
+U1 → U2 → U3 → U4 → U5.
+
+### U1. Bridge wire client and adapter identity resolver
+
+One portable-core module per side of the wire question: `bridge_client.py` speaks the
+contract, `adapter_identity.py` answers who this adapter is.
+
+**Files:** `plugins/voice/scripts/bridge_client.py` (new),
+`plugins/voice/scripts/adapter_identity.py` (new),
+`plugins/voice/scripts/settings.py` (edit: extend `SETTING_NAMES` with `HERDR_PANE_ID`
+and `HERDR_BIN_PATH`, both no-default, per KTD9),
+`plugins/voice/tests/bridge_stub.py` (new: the shared independent-literals bridge stub —
+see below),
+`plugins/voice/tests/test_bridge_client.py` (new),
+`plugins/voice/tests/test_adapter_identity.py` (new),
+`plugins/voice/tests/test_settings.py` (edit: the two new stated names' presence, refusal,
+and closed-set scenarios).
+
+**Shared stub fixture custody.** `plugins/voice/tests/bridge_stub.py` is the one stub
+fixture every bridge-facing suite uses (U1's own suites, U3's server suites, U4's hook
+suites, and the U4 adapter-boundary scenario). It is owned by U1 alone; no other unit edits it.
+It is a plain module (no `test_` prefix, so neither `unittest` discovery nor the CI
+`pytest` job collects it as a suite), holding the stdlib `http.server` stub that speaks
+the contract literals plus its request-capture surface, and is imported by sibling suites
+under the package's existing explicit `sys.path.insert` test convention. Wire literals
+live in exactly two places: `bridge_client.py` (production) and `bridge_stub.py` (test) —
+the two independent readings KTD9 requires.
+
+**Requirements:** wire substrate for R21, R106, R122 — discovery (§2), authentication
+(§3), wire rules (§4), identity (§5), the five routes (§6), transport errors and
+precedence (§7), identifier/retry/fail-closed semantics (§8) of
+[`docs/bridge-v1-from-c10.md`](../bridge-v1-from-c10.md).
+
+**Depends on:** nothing.
+
+**Backend:** inline.
+
+**Design notes.** `bridge_client.py`: strict discovery (exact four keys, exact types,
+literal host, port range, full token grammar — exactly 43 characters drawn only from the
+base64url alphabet `[A-Za-z0-9_-]`, no `=` padding — file mode `0600`, any deviation reads
+"unavailable" — never a default port or token); bearer header on every request; closed
+JSON request bodies with `schema: 1`; the numeric deadlines of the timeout budget table on
+every call (`http.client` over loopback, monotonic-clock deadline discipline); a total
+error mapping of the §7 table; fail-closed on unknown status, unknown error code, or
+malformed response; **Core-identifier grammar validation** — `binding_id` and `turn_id`
+read from `GET /v1/current` must be opaque lowercase UUID v4 strings per §8, and a
+malformed, uppercase, or wrong-version identifier means the snapshot is refused (treated
+as bridge-unavailable) and the pair is never captured or carried; retry rules as
+first-class behavior — 1 Hz re-discovery until registration, single byte-equivalent retry
+after 500 only, never retry 4xx, byte-equivalent-only retry for lost rendering responses.
+**Lost-response retry context (the `duplicate_rendering` reconciliation):** when a
+rendering response is lost after the request may have reached Core, the client marks the
+in-flight submission as a byte-equivalent retry; if that retry answers
+`duplicate_rendering`, the contract's §8 sentence ("an earlier acceptance returns
+`duplicate_rendering` while that turn remains current") makes the disposition decidable —
+the earlier identical submission was accepted — so the client returns **accepted** with
+detail `accepted_on_retry`, never a rejection. Outside that retry context,
+`duplicate_rendering` relays verbatim as `rejected_by_core` (terminal for the pair per
+§6.5 — the result detail states an authored rendering was already accepted, so the agent
+is never invited to submit a replacement). `adapter_identity.py`: the §5 rule verbatim —
+`HERDR_PANE_ID` and `HERDR_BIN_PATH` resolved **through `settings.py`'s extended stated
+set** (KTD9), the executable run with `agent list` under the package's subprocess
+discipline (`process.py`) inside its 2,000 ms deadline, envelope check
+`result.type == "agent_list"`, exactly-one pane match, all three components non-empty, and
+the never-copy-from-`GET /v1/current` rule stated in the module contract. Every failure is
+a named refusal; any failure means register and submit nothing.
+
+**Test scenarios** (`plugins/voice/tests/test_bridge_client.py`,
+`plugins/voice/tests/test_adapter_identity.py`,
+`plugins/voice/tests/test_settings.py`):
+
+- Discovery: a valid file parses; each malformation (missing, partial JSON, wrong type
+  per member, extra key, `schema: 2`, empty token, mode `0644`) independently reads
+  unavailable, and no default is ever substituted.
+- Token grammar (the §2 literal, one fixture per violation): a 42- and a 44-character
+  token; a 43-character token containing a non-base64url character (`+`, `/`); a token
+  carrying `=` padding — each reads unavailable, and **no presence or rendering request
+  follows** (asserted against the stub's request capture).
+- Core-identifier grammar (the §8 literal): a `GET /v1/current` snapshot whose
+  `binding_id` or `turn_id` is uppercase, not a UUID at all, or a UUID of the wrong
+  version — each refuses the snapshot, captures no pair, and no rendering request ever
+  carries the malformed value.
+- Auth: the header is `Authorization: Bearer <token>` byte-exact; a stub returning 401
+  yields a named unauthorized condition and triggers re-discovery, never acceptance.
+- Each of the five routes round-trips its documented 200 body against the stub; response
+  parsing requires all documented members and ignores unknown ones.
+- Transport errors: each §7 row maps to its named condition; an undocumented status and
+  an unknown error code both fail closed.
+- Deadlines: with a stubbed clock, a call exceeding its timeout-budget row yields the
+  named `transport_error` (never acceptance, never a hang); the deadline values asserted
+  are the table's numbers.
+- Retry: after a stubbed 500 the client performs at most one byte-identical retry and
+  only after a health re-check; a 400 is never retried; the rendering retry path resends
+  byte-identical bodies with the same identifiers.
+- Lost-response reconciliation (the F8 case): the stub accepts a rendering but drops the
+  response; the client's single byte-equivalent retry answers `duplicate_rendering`; the
+  client returns accepted with detail `accepted_on_retry`. The same
+  `duplicate_rendering` reason *outside* retry context relays as `rejected_by_core`.
+- Identity: the happy path copies the three components exactly; missing env var, missing
+  executable, malformed envelope, zero matches, two matches, and an empty component each
+  produce a named refusal.
+- Settings: `HERDR_PANE_ID` and `HERDR_BIN_PATH` are stated members of `SETTING_NAMES`;
+  absent and empty each produce the module's named refusal (no default); the closed-set
+  regression (nothing outside the ten-name tuple is read) still holds.
+
+Each grammar and validation guard above is **mutation-checked once during
+implementation**: the guard is deliberately relaxed, the named test is observed failing,
+and the guard is restored — recorded in the U5 acceptance note so a permanently green
+suite cannot hide a vacuous guard.
+
+**Verification:** `cd plugins/voice && python3 -m unittest discover -s tests -v`;
+`python3 scripts/check_repo.py`; `git diff --check`.
+
+### U2. Rendering gate, voice policy store, and turn record
+
+The three small pure state-and-judgment modules everything else composes: R121's gate,
+R107's policy source, and the per-turn record that makes R122's path observable.
+
+**Files:** `plugins/voice/scripts/rendering_gate.py` (new),
+`plugins/voice/scripts/voice_policy.py` (new),
+`plugins/voice/scripts/turn_record.py` (new),
+`plugins/voice/scripts/voice_cli.py` (edit: add `policy` verbs),
+`plugins/voice/tests/test_rendering_gate.py` (new),
+`plugins/voice/tests/test_voice_policy.py` (new),
+`plugins/voice/tests/test_turn_record.py` (new).
+
+**Requirements:** R121, R20 (gate: detect and name, never transform); R25, R107 (policy:
+store, render to instructions, one-shot arming); R23, R122 substrate (turn record:
+submissions, dispositions, outcome marking).
+
+**Depends on:** nothing.
+
+**Backend:** inline.
+
+**Design notes.** `rendering_gate.py` owns the **complete R121 rejected-syntax
+contract** — a closed, enumerated class list documented in the module as the boundary's
+authority (KTD1). The paired-marker and line-anchor recognizers of
+[`text_cleanup.py`](../../plugins/voice/scripts/text_cleanup.py) seed the overlapping
+classes, but the cleanup pass's documented scope does not bound the gate: the gate adds
+the Markdown forms the cleanup pass never needed.
+
+**The completeness rule — how the class table is closed, not merely long.** The
+recognizer's construct inventory is the block and inline construct list of base Markdown
+(its leaf blocks, container blocks, and inline constructs) plus the two GitHub-flavored
+extensions a coding agent routinely emits: pipe tables and strikethrough. (Full
+GitHub-flavored linkification is deliberately not in the inventory — it would reject bare
+spoken URLs, an accepted non-class below.) Every construct in that inventory is disposed
+of in exactly one of three stated ways; none is left without a rule:
+
+1. a **rejecting class** in the table below;
+2. a **structural non-class** — ordinary newlines and blank-line paragraph breaks are how
+   plain multi-paragraph speech text is written, never formatting (this disposes of the
+   paragraph, blank-line, and soft-line-break productions);
+3. a **prose-collision non-class** — a construct whose recognizer cannot be separated
+   from ordinary spoken punctuation at acceptable false-positive cost is deliberately
+   accepted, documented in the module with its rationale, and given an accepting test.
+   The single member is the HTML entity reference (`&amp;`, `&#39;`): its shape collides
+   with ordinary prose such as `AT&T;` mid-sentence, and R121's ground is Markdown
+   rejection, not HTML sanitization.
+
+The recognizers are line-and-inline regexes, not a Markdown parser; the completeness
+claim is construct coverage of the stated inventory, not parser equivalence. On a
+rejection surface, over-detection inside a class is safe — the guarded boundary is the
+stated non-class list, each entry with an accepting test.
+
+**Grammar authority — the class table is the grammar (cycle-3 F5).** Of the two
+acceptable closures — pin an external base-Markdown specification and version, or make
+the plan's own class table the self-contained grammar — this plan takes the second: the
+class table below, the block-indentation rule, and the stated non-class list are
+together the gate's **normative grammar**, and the implementation and its tests are
+held to these rows, not to any external document. Why: the recognizers are deliberately
+line-and-inline regexes serving a cooperative resubmission contract — R121's consumer
+is an agent told to resubmit plain text, and a missed form costs one stray spoken
+character — so pinning an external specification would create a parser-conformance
+obligation out of proportion to this boundary, while the self-contained table keeps
+KTD1 literally true: the module documents the boundary's whole authority. The
+completeness rule above records the informative derivation source (base Markdown's
+construct list plus the two named extensions); the derivation is informative, the rows
+are normative. Each rejecting row is therefore written as a **matching rule** — the
+full marker set, the full separator set, and the permitted trailing context (a space, a
+tab, or the end of the line, wherever the row says so) — never an example spelling. An
+implementation that matches only the literal characters an illustration happens to use
+(only `1.` and `1)`, only a space after `#`) does not satisfy its row.
+
+**The block-indentation rule (stated once, for every line-anchored class).** Markdown
+allows up to three spaces of indentation before any block construct, so every
+line-anchored class below matches at a **line anchor** — the start of a line followed by
+zero to three optional spaces — while a line indented four or more spaces (or with a
+leading tab) is itself the indented-code-block class. No indentation depth exempts block
+syntax from rejection: at three spaces a list, heading, blockquote, fence, or any other
+block form rejects under its own class; at four it rejects as indented code.
+
+| Detected class | Reason |
+|---|---|
+| Fenced code block (at a line anchor, a run of three or more backticks or three or more tildes; the rest of the line — the info string — may be anything, including nothing) | `fenced_code_block` |
+| Indented code block (a non-blank line whose leading whitespace is four or more spaces, or contains a tab, outside a continuation of plain prose) | `markdown_formatting` (class `indented_code_block` in the detail) |
+| ATX heading (at a line anchor, one to six `#`, followed by a space, a tab, or the end of the line — the empty heading, `#` through `######` alone on a line, is valid Markdown and rejects) | `markdown_formatting` |
+| Setext heading (a non-blank line followed by a line-anchored underline: a run of one or more `=` or one or more `-` — one character kind, any length — followed by nothing but optional spaces or tabs) | `markdown_formatting` |
+| List marker (at a line anchor, a bullet marker — `-`, `+`, or `*` — or an ordered marker — one to nine ASCII digits of any value followed by `.` or `)` — with either marker followed by a space, a tab, or the end of the line) | `markdown_formatting` |
+| Blockquote marker (`>` at a line anchor; no following space or text is required) | `markdown_formatting` |
+| Horizontal rule (at a line anchor, three or more `-`, `_`, or `*`, all the same character, with only spaces or tabs permitted between and after them and nothing else on the line) | `markdown_formatting` |
+| Table pipe row (a line containing one or more pipe characters at any position — GitHub-flavored table rows require no leading or trailing pipe, so one rule covers header, delimiter, and data rows) | `markdown_formatting` |
+| Link-reference definition (at a line anchor, `[`, one or more characters containing no unescaped `]`, then `]:`, followed by a space, a tab, the destination text, or the end of the line — the destination may sit on the next line) | `markdown_formatting` |
+| Hard line break (a non-final line ending in two or more spaces, or ending in a backslash) | `markdown_formatting` (class `hard_line_break` in the detail) |
+| Raw HTML (`<` immediately followed by any of: an ASCII letter — an open tag; `/` then an ASCII letter — a closing tag; `!--` — a comment; `!` then an ASCII letter — a declaration; `?` — a processing instruction; or `![CDATA[` — a character-data section; the opener alone rejects, no closing `>` required) | `markdown_formatting` (class `raw_html` in the detail) |
+| Backslash escape (a backslash immediately before any of the thirty-two ASCII punctuation characters — U+0021–U+002F, U+003A–U+0040, U+005B–U+0060, U+007B–U+007E; a backslash before any other character is not this class) | `markdown_formatting` (class `backslash_escape` in the detail) |
+| Emphasis / strong pairs (a delimiter run of one or more `*` or one or more `_`, any length, immediately followed by non-whitespace, matched later by a same-character run immediately preceded by non-whitespace; `_` runs must additionally sit at word edges — not flanked on the outside by a letter, digit, or underscore — which is what accepts `snake_case`) | `markdown_formatting` |
+| Strikethrough pair (a run of one or two `~` immediately followed by non-whitespace, matched later by an equal-length run immediately preceded by non-whitespace — covering both the two-tilde published form and the one-tilde form GitHub also renders) | `markdown_formatting` (class `strikethrough` in the detail) |
+| Inline code span (a run of one or more backticks matched later in the text by a second run of exactly equal length) | `markdown_formatting` |
+| Inline link / image (a `[` … `]` pair — the text may be empty — immediately followed, with no intervening character, by a `(` … `)` pair — the destination may be empty — with or without a leading `!`) | `markdown_formatting` |
+| Reference-style link (a `[` … `]` pair immediately followed by a second `[` … `]` pair, the second either empty — the collapsed form — or carrying any label — the full form; a single bracketed span with no second pair is the accepted `[sic]` non-class) | `markdown_formatting` |
+| Autolink (`<`, then a scheme — an ASCII letter followed by one to thirty-one letters, digits, `+`, `.`, or `-` — then `:`, then zero or more characters none of which is whitespace, `<`, or `>`, then `>`; no `//` is required, so `<mailto:…>` forms match; or `<`, an email shape — one or more non-whitespace characters other than `<` or `>`, `@`, one or more such characters — then `>`) | `markdown_formatting` |
+
+Stated non-classes (accepted as plain, each a named accepting test): arithmetic asterisks
+(`2 * 3`), identifier underscores (`snake_case`), mid-sentence hyphens, spaced comparison
+angle brackets (`x < y` — a space after `<` cannot open a raw-HTML tag), a bare bracketed
+aside (`[sic]` — without a matching reference definition it is not a link, and
+definitions themselves are rejected), a colon-labelled line (`note: …`), a bare spoken
+URL (not an autolink without angle brackets; base Markdown does not linkify bare URLs,
+which is one reason the inventory stays base Markdown), an ampersand in prose even
+directly before a semicolon (`AT&T;` — the entity-reference prose-collision non-class
+above), a backslash before a letter or digit (a Windows path such as `C:\Users`),
+trailing spaces on the text's final line or on a line before a blank line (Markdown
+strips them; they are not a hard break, and they are invisible in speech), and blank-line
+paragraph separation (the structural non-class). The gate exports a verdict (`plain`, or
+a named rejection with detected classes and first offending line) and has no
+transformation function at all; the class table above, together with the completeness
+rule and the block-indentation rule, is the module's documented contract and the test
+suite's checklist. `voice_policy.py` follows the `binding.py` store pattern:
+atomic write-replace, absent-vs-corrupt reported by name; fields are stated preference
+instruction lines plus the `brief_next_turn` one-shot; `consume_brief_next_turn()` is
+atomic; `render_instructions()` produces the injected text and applies nothing.
+`turn_record.py`: one current-turn JSON file in the state directory, replaced at each turn
+origin; carries `session_id`, the captured `(binding_id, turn_id)`, origin, submissions
+with dispositions and reasons, tool-use observations, and the settled outcome
+(`authored` / `fallback`); **all mutations run through the single `mutate(fn)`
+entrypoint — the KTD11 flock transaction with the timeout table's 500 ms acquisition
+budget — and the module exposes no other write path**. CLI: `voice policy show` and
+`voice policy brief-next-turn` verbs on the existing parser in
+[`voice_cli.py:156`](../../plugins/voice/scripts/voice_cli.py).
+
+**Test scenarios** (`plugins/voice/tests/test_rendering_gate.py`,
+`plugins/voice/tests/test_voice_policy.py`, `plugins/voice/tests/test_turn_record.py`):
+
+- Gate rejects a fenced code block with reason `fenced_code_block`, and Markdown emphasis
+  with reason `markdown_formatting`, each naming the detected class and line (the AE26
+  core, both named-reason halves the card requires).
+- **Every row of the class table has at least one rejecting scenario** — including the
+  forms beyond the cleanup pass's scope: a setext heading, a reference-style link, a
+  link-reference definition, an autolink, an indented code block, a hard line break in
+  **both** syntaxes (a non-final line ending in two trailing spaces, and one ending in a
+  backslash), a raw HTML tag and an HTML comment, a backslash escape (`\*`), and a
+  strikethrough pair each yield their stated reason and class.
+- **Every line-anchored class additionally has a three-space-indented rejecting
+  variant** — a three-space-indented list marker, ATX heading, blockquote, fence,
+  horizontal rule, setext underline, and link-reference definition each still reject
+  under their own class (the block-indentation rule proven per class, not per cited
+  example). Plus the seam scenario: the same list marker at three leading spaces rejects
+  as a list, at four as indented code — rejected on both sides of the boundary, with no
+  depth at which it passes.
+- **Every rejecting class additionally has at least one rule-not-spelling scenario** — a
+  case a literal transcription of a cycle-2 example spelling would miss, proving the
+  row's full marker set, separator set, and trailing context: an ordered-list marker
+  other than `1` (`7. item`), a multi-digit ordered marker (`12) item`), and a bullet
+  marker at the end of a line (a line holding only `-`); an empty ATX heading (`##`
+  alone on a line) and a tab-delimited one (`#`, a tab, then text); a fence run of four
+  backticks; a tab-indented code line; a one-character setext underline (a paragraph
+  line followed by a lone `=`); a blockquote with no space after the `>`; a spaced
+  horizontal rule (`- - -`) and an underscore one (`___`); a pipe row with no leading or
+  trailing pipe (`cell | cell`); a link-reference definition with a multi-word label; a
+  hard break of three trailing spaces; an attribute-carrying raw-HTML tag
+  (`<div class="x">`) and a non-tag opener (a declaration or a processing instruction);
+  a backslash escape of a bracket (`\[`); a three-asterisk emphasis run (`***text***`);
+  a one-tilde strikethrough pair (`~text~`); a two-backtick code span; an inline link
+  whose bracketed text is empty (`[]` immediately followed by a parenthesized
+  destination); a full reference link with a multi-word label; and an autolink
+  whose scheme is not followed by `//` (`<mailto:ops@example.com>`). Each yields its
+  class's stated reason.
+- **Every stated non-class has an accepting scenario**: arithmetic asterisks, identifier
+  underscores, mid-sentence hyphens, `x < y`, a bare `[sic]`, a colon-labelled line, a
+  bare spoken URL, `AT&T;` mid-sentence, a backslash-before-letter path (`C:\Users`),
+  trailing spaces on the final line and on a line before a blank line, and a
+  multi-paragraph plain text separated by blank lines each pass as `plain`.
+- A submission containing both a fence and emphasis yields `fenced_code_block` (stated
+  precedence).
+- The gate exposes no function that returns modified text (R20 asserted structurally: the
+  module's public surface is verdicts only); each detector class is mutation-checked once
+  during implementation (relaxed → named test fails → restored), recorded in the U5
+  acceptance note.
+- Policy: arming `brief_next_turn` then consuming it yields the brief instruction exactly
+  once; a second consume reports unarmed; corrupt and absent store states are reported by
+  name; `render_instructions()` output contains the stated preferences verbatim and
+  nothing derived from any response content.
+- CLI: the `policy` verbs round-trip arming and showing through `main()`.
+- Turn record: origin write replaces the previous turn's record; submissions and
+  dispositions append; outcome settles once; a record for a different `session_id` is
+  refused by name.
+- **Interleaving (the KTD11 proof, deterministic — no sleeps, no luck):** two concurrent
+  `mutate` calls from separate threads, each holding its own file descriptor, with an
+  event-controlled pause injected inside the first writer's critical section; the second
+  writer provably does not enter until the first completes, and the final record contains
+  **both** updates (the lost-update case a bare read-modify-replace would produce is the
+  failing assertion). A third scenario holds the lock past the 500 ms acquisition budget
+  (stubbed clock) and observes the named `turn_record_busy` refusal, never a blind write.
+
+**Verification:** same three commands as U1.
+
+### U3. MCP authored-rendering surface with the presence lifecycle
+
+The adapter's long-lived process: the MCP stdio server exposing `submit_spoken_rendering`,
+gating locally, forwarding verbatim, relaying dispositions, and running presence.
+
+**Files:** `plugins/voice/scripts/mcp_server.py` (new),
+`plugins/voice/tests/test_mcp_server.py` (new).
+
+**Requirements:** R21, R20, R121 (surface behavior), R122 (submission half).
+
+**Depends on:** U1 (bridge client, identity), U2 (gate, turn record).
+
+**Backend:** inline.
+
+**Design notes.** Protocol per KTD8. Tool flow per submission: read the current turn
+record; no captured pair for this session → `unavailable` / `no_current_turn`; gate the
+text (KTD1) → `rejected_content` with the named reason, recorded, nothing on the wire;
+otherwise `POST /v1/rendering` with the captured pair and byte-identical text →
+`accepted` (including the U1 client's `accepted_on_retry` reconciliation for a lost
+response answered `duplicate_rendering`) or `rejected_by_core` with the wire reason
+relayed verbatim, recorded either way; transport failure → `unavailable` with the named
+condition, fail-closed (never reported as accepted). All record writes go through
+`turn_record.mutate` (KTD11); the server holds no other write path. Presence thread per
+KTD2: discovery at 1 Hz until registered, renewal at the response's `renew_after_ms`,
+re-discovery on 401 or connection refusal, best-effort `DELETE` on stdin EOF, and the
+thread never writes to stdout.
+
+**Two test layers, per the repository's executable-entrypoint rule** (`AGENTS.md`: a
+package entrypoint must be run the way a user runs it — component tests alone have
+shipped broken imports before; see `tests/test_client_entrypoints.py`). Fine-grained
+scenarios drive the server loop in process over injected byte streams with the U1 stub.
+On top of that, one **process-level scenario launches the exact declared argv** —
+`python3 <installed-root>/scripts/mcp_server.py`, the byte-for-byte expansion of the
+`servers.json` declaration (`${CLAUDE_PLUGIN_ROOT}` → the installed root) — as a real
+subprocess from an installed-root-shaped directory (the `plugins/voice` tree copied to a
+temporary directory, exercising imports as installed), with real stdin/stdout pipes.
+Environment for the subprocess uses only existing stated seams: `VOICE_STATE_DIR` and the
+two KTD9 identity names point at test fixtures, and `HOME` points at a temporary home
+whose `Library/Application Support/Auralis/bridge.json` names the U1 stub's live port —
+no new setting and no code-level seam is needed. U5's packaging test pins the
+`servers.json` declaration to the same command/args literals this scenario launches, so
+the declaration and the proof cannot drift apart (independent-literals discipline, KTD9).
+
+**Test scenarios** (`plugins/voice/tests/test_mcp_server.py`):
+
+- `initialize` → `tools/list` exposes exactly `submit_spoken_rendering` with the closed
+  input schema; unknown methods get JSON-RPC method-not-found; stdout carries only
+  protocol frames.
+- AE26 end-to-end at the surface: a submission containing Markdown emphasis and a fenced
+  code block is rejected with a named reason, nothing is forwarded, no cleaned variant
+  exists anywhere in adapter state; a plain-text resubmission on the same turn is
+  forwarded and accepted by the stub — proving reject-then-accept with no repair.
+- The forwarded body is byte-identical to the submitted text (R20) and carries the
+  prompt-time captured pair, not the stub's current turn (KTD4: with the stub's current
+  turn advanced, the submission still targets the captured pair and the stub's
+  `turn_not_current` is relayed verbatim as `rejected_by_core`).
+- Each wire rejection reason in the §6.5 vocabulary relays verbatim; an unknown
+  disposition or malformed response fails closed as `unavailable`, never `accepted`.
+- With no turn record, and with a record for another session, the tool answers
+  `unavailable` / `no_current_turn` without touching the wire.
+- Presence: against the stub, the server registers with the resolved identity, renews on
+  cadence (stubbed clock), re-registers after a token rotation (401 → re-discovery), and
+  sends `DELETE` on shutdown; identity-resolution failure means no registration and the
+  tool reports `unavailable` / `not_bound`.
+- Lost-response reconciliation at the surface (the F8 case end to end at this layer): the
+  stub accepts the first `POST /v1/rendering` but drops the response; the single
+  byte-equivalent retry answers `duplicate_rendering`; the tool result is **accepted**
+  with detail `accepted_on_retry`, the turn record's disposition is an authored
+  acceptance (so KTD6 reconciliation must read `authored`, never `fallback`), and the
+  result invites no replacement submission.
+- **Executable entrypoint (the declared process, as Claude runs it):** launch the exact
+  declared argv from the installed-root-shaped directory over real process pipes and
+  complete, in order: MCP `initialize`, `tools/list` (exactly `submit_spoken_rendering`),
+  a rejected `tools/call` (Markdown → named `rejected_content` reason), and an accepted
+  `tools/call` (plain text → forwarded to the stub, `accepted` relayed). This scenario
+  fails on a broken import, a wrong interpreter floor, a framing error, or stray stdout —
+  none of which the in-process layer can catch.
+- Every submission and disposition appears in the turn record (the R122 evidence trail),
+  written through `turn_record.mutate` only.
+
+**Verification:** same three commands as U1.
+
+### U4. Claude hooks: turn origin and policy injection, PreToolUse capture, completion reconciliation
+
+The client-extension half: two new hooks, the Stop-hook extension, and the hook wiring.
+
+**Files:** `plugins/voice/com.infiquetra.claude/hooks/user_prompt_submit_hook.py` (new),
+`plugins/voice/com.infiquetra.claude/hooks/pre_tool_use_hook.py` (new),
+`plugins/voice/com.infiquetra.claude/hooks/stop_hook.py` (edit),
+`plugins/voice/com.infiquetra.claude/hooks/hooks.json` (edit: add `UserPromptSubmit` and
+`PreToolUse` entries, `timeout: 5` each, matching the existing Stop entry and the timeout
+budget table),
+`plugins/voice/tests/test_user_prompt_submit_hook.py` (new),
+`plugins/voice/tests/test_pre_tool_use_hook.py` (new),
+`plugins/voice/tests/test_stop_hook.py` (edit: bridged-branch scenarios),
+`plugins/voice/tests/test_r122_adapter_boundary.py` (new: the adapter-boundary
+rejection-to-fallback record proof below; named in cycle 1 as `test_r122_end_to_end.py`
+and renamed because the adapter suite proves the adapter-side half only — the Core-side
+half is the joint AE36 test).
+
+**Requirements:** R106, R107 (transmission), R22/R23 (adapter share per the fallback
+seam), R122 (completion half and the adapter-boundary evidence path; the Core-side half
+is the joint AE36 test), PreToolUse capture per X1.
+
+**Depends on:** U1, U2, U3 (the adapter-boundary scenario launches U3's real server process).
+
+**Backend:** inline.
+
+**Design notes.** All three hooks keep the package's iron hook rule: every path exits 0,
+a hook never breaks a turn. `user_prompt_submit_hook.py` implements KTD3/KTD4: resolve,
+query, match; on an Auralis-originated turn write the captured pair to the turn record and
+emit `hookSpecificOutput.additionalContext` containing the origin statement, the
+rendering expectation, the submission-tool pointer, the plain-spoken-text rule, and the
+rendered policy instructions with the one-shot consumed on transmission; on a bound but
+non-originated turn emit the explicit negative; on any unavailable state emit nothing.
+`pre_tool_use_hook.py` implements KTD7 (observe-only, scoped, allow-list filtered, no
+output ever). `stop_hook.py` gains the KTD6 branch ahead of the legacy path, using only
+cheap local reads plus one bridge snapshot (1,000 ms deadline; on expiry, bridge doubt →
+legacy path), preserving the detach discipline. All three hooks mutate the turn record
+only through `turn_record.mutate` (KTD11), with the per-writer `turn_record_busy`
+behaviour of the timeout budget table. Hook internal deadlines are the timeout table's
+rows; every expiry path still exits 0.
+
+**Test scenarios** (`plugins/voice/tests/test_user_prompt_submit_hook.py`,
+`plugins/voice/tests/test_pre_tool_use_hook.py`,
+`plugins/voice/tests/test_stop_hook.py`,
+`plugins/voice/tests/test_r122_adapter_boundary.py`):
+
+- **R122 at the adapter boundary, across the production processes**
+  (`test_r122_adapter_boundary.py` — the scenario exists because a helper-level assertion
+  cannot prove the path; it must fail if the submission record schema, the
+  session/identifier join, the completion handoff, or the fallback marker drifts). Every
+  boundary on the adapter's side is the real one: the U1 stub bridge shows
+  an open turn bound to the resolved identity; the **real `user_prompt_submit_hook.py`**
+  runs as a subprocess with a real stdin payload and writes the captured pair into the
+  turn record; the **real MCP server process** (U3's declared argv, real pipes) receives
+  `tools/call submit_spoken_rendering` with Markdown and answers the named
+  `rejected_content` reason — the stub's request capture proves **nothing was forwarded**
+  to `POST /v1/rendering`; **no replacement is submitted**; the **real `stop_hook.py`**
+  then runs as a subprocess with a Stop payload for the same `session_id`, and the
+  assertion reads the turn record through the production module: the same turn —
+  identified by the captured `(binding_id, turn_id)` — now carries outcome `fallback`,
+  the earlier named rejection still present, no speak child spawned. The joined artifact
+  was written entirely by the production processes, not assembled by the test. **What
+  this scenario proves — and only this:** the adapter-side half of R122 (named rejection,
+  no replacement, completion, and the durable `fallback` outcome for the captured pair).
+  It does not observe Core's `fallback_accepted` mark and cannot — `acceptFallback()` is
+  an in-process Dart API in `infiquetra/auralis`, unreachable from this repository's
+  Python suite. The Core-side half is proven only by the joint AE36 test (see "The joint
+  AE36 test — executable home, owner, and procedure").
+
+- The card-named origin test: with the stub showing an open turn bound to this session,
+  the injected context states the turn originated through Auralis and a rendering is
+  expected; with the stub bound but no open turn, the context states the opposite; with
+  no bridge, no binding, an identity mismatch, or a resolution failure, the hook emits
+  nothing — origin signalling present only under a binding, explicit both ways there.
+- The card-named policy test: stated preferences and an armed Brief Next Turn override
+  appear verbatim in the injected instructions of the next Auralis-originated turn; the
+  arming is consumed exactly once; the following turn's instructions omit the brief
+  directive; a non-originated turn transmits no policy and consumes nothing.
+- The captured pair lands in the turn record at origin (KTD4's source of truth).
+- PreToolUse: on an Auralis-originated turn the record gains
+  `{tool_name, tool_input, tool_use_id}` observations; allow-list filtering records only
+  named tools when the list is non-empty; on non-originated turns and unbound sessions
+  nothing is recorded; the hook writes no stdout on any path and exits 0 on malformed
+  input (permission flow provably untouched at the hook contract level).
+- Stop hook: wire-bound with the captured turn unaccepted → no speak spawn, outcome
+  `fallback` recorded (R122's adapter-side terminal half; with a prior gate rejection in
+  the record, the record now shows the named-rejection-then-fallback trail); wire-bound with an
+  accepted rendering → outcome `authored`, no speak spawn; unbound or bridge-unavailable
+  → the existing 0.2.1 spawn behaviour, asserted by the existing suite continuing to
+  pass unmodified in those scenarios.
+
+**Verification:** same three commands as U1, plus one stated manual check at acceptance
+time (recorded, and actually performed, per the card): in a live bound session, the
+injected context is visible to the agent and no double-speech occurs on an authored turn.
+
+### U5. Packaging, versions, docs, and journal
+
+Ship it: the MCP declaration, the four-site version bump, README, packaging-test
+extension, journal capture, and the slice's acceptance evidence note.
+
+**Files:** `plugins/voice/plugin.json` (edit: version),
+`plugins/voice/.claude-plugin/plugin.json` (edit: version, `mcpServers` path),
+`plugins/voice/com.infiquetra.claude/plugin.json` (edit: version, description),
+`plugins/voice/com.infiquetra.claude/mcp/servers.json` (new),
+`.claude-plugin/marketplace.json` (edit: version, description),
+`plugins/voice/README.md` (edit: adapter section),
+`tests/test_claude_plugin_packaging.py` (edit: `mcpServers` path assertions),
+`docs/evidence/voice/auralis-c3-acceptance.md` (new),
+`docs/engineering-journal/DECISIONS.md` (edit),
+`docs/engineering-journal/LEARNINGS.md` (edit, if the build surfaced a non-obvious
+mechanism worth a dated entry).
+
+**Requirements:** distribution rules (the packaging boundary and its enforcement),
+version agreement, AE26 traceability, and the R-to-test trace table the card's closeout
+needs.
+
+**Depends on:** U3, U4.
+
+**Backend:** inline.
+
+**Design notes.** Version `0.3.0` per KTD10 at all four sites. The new
+`servers.json` declares the stdio server with `${CLAUDE_PLUGIN_ROOT}`-anchored command;
+the packaging test grows assertions that the declaration is a string path resolving into
+`com.infiquetra.claude/`, that the declared script exists, and that the declared
+command/args are byte-for-byte the literals U3's executable-entrypoint scenario launches
+(the declaration and its proof cannot drift apart). The new acceptance note is
+this slice's own ledger (separate file from the 0.2.x ledger to keep the two R-ID
+namespaces apart): the AE26 test evidence, the R-to-test trace for all nine requirements,
+the performed manual check from U4, AE34 joint-readiness status, the wire-pin provenance
+(source revision `695cd0ecfddf44e0d6e3386da318bd5fde4a1926` and snapshot SHA-256) with the
+not-yet-merged flag restated, the R22/R23 cross-slice dependency on C5 restated for the
+AE36 closeout — including the joint AE36 test's executable home (`infiquetra/auralis`)
+and its procedure reference, held open until the joint run closes it — and the record of
+the guard-mutation checks U1 and U2 performed (each guard: relaxed, named failing test
+observed, restored).
+
+**Test expectation:** the extended `tests/test_claude_plugin_packaging.py` scenarios
+(version agreement at four sites including the new value; `mcpServers` is a path into the
+client extension; every declared component path exists). No other new suite — the unit is
+packaging and documentation; behavior is covered by U1–U4.
+
+**Verification:** full card set — `cd plugins/voice && python3 -m unittest discover -s
+tests -v`, `python3 scripts/check_repo.py`, repo-root
+`python3 -m unittest discover -s tests -v`, `python3 -m pytest plugins/*/tests -q`,
+`git diff --check`; plus `claude plugin validate plugins/voice` as the installability probe
+the packaging decision used.
+
+## Scope Boundaries
+
+Out of scope (true non-goals, from the card and the parent):
+
+- Any change in `infiquetra/auralis` — the Core bridge endpoint is C10's. No new
+  `/v1/` route is proposed anywhere in this plan.
+- Any speech provider, audio capture, playback, or user interface. Fallback *speech* and
+  its audible marking are Core/C5 (AE36); this adapter contributes detection and durable
+  marking only.
+- Cleaning, rewriting, or reformatting any authored rendering (R121 — the gate rejects).
+- Any content decision from preferences (R25 — transmit only).
+- Any permission decision from the PreToolUse hook (stop condition 4; KTD7).
+- Sourcing the fallback's written-response text to Core, initiating fallback speech, or
+  marking the turn `fallback_accepted`. Those are Core/C5's through the in-process
+  `acceptFallback()` API (contract §9) — see "The R22/R23 fallback seam", which names the
+  cross-slice dependency and where it is proven (AE36). No committed wire route carries
+  the written response, and this plan neither implements nor invents one.
+- Board writes, PR merge, issue closure — coordinator-owned per the card.
+- The open voice findings F6 (#43) and F7 (#44) — tracked separately, untouched here.
+
+Deferred to follow-up work (real work, later slices or extensions):
+
+- Policy over the wire (KTD5's revisit): adapter store becomes a cache of a Core-published
+  policy when such a route exists.
+- Approvals consumption of the PreToolUse capture (C8's future bridge surface; KTD7's
+  revisit).
+- Retiring the legacy local speak path once Auralis is the daily driver (KTD6's revisit).
+
+## Risks and pre-mortem
+
+The most likely failure first: **the pinned contract moves before it merges.** The bridge
+contract this adapter builds against is accepted at review but unmerged in `auralis`; if
+C10 amends a literal (a reason string, a member name), the adapter would pass its own
+tests and fail the joint acceptance. Contained by the tracked byte-pinned snapshot (a
+divergence is detectable by hash, and a refresh is one extract-and-record step per the
+wire-authority section) and by centralizing every literal in `bridge_client.py` plus the
+one stub fixture `bridge_stub.py` (a contract diff is a bounded re-touch), and surfaced
+honestly in the plan, the evidence note, and AE34.
+
+- **Harness-behavior assumptions.** Context injection visibility and MCP server lifetime
+  are platform behaviors verified against current documentation, not testable hermetically.
+  Contained by U4's stated manual check in a live session, which the card requires to be
+  performed, not merely stated.
+- **Double-speech regression.** If the KTD6 suppression misfires, a bound turn speaks
+  twice (Auralis and legacy path). Contained by both-ways tests in
+  `test_stop_hook.py` and the U4 manual check.
+- **False-positive plain-text rejections.** Over-eager detectors would reject honest
+  spoken prose (an asterisk in "2 * 3", an underscore in a module name). Contained by
+  reusing the 0.2.1-proven paired-marker recognizers and by the stated non-class list in
+  U2 — every accepting case, including the entity-collision, path-backslash, and
+  trailing-whitespace cases the closed grammar added, is a named scenario in
+  `test_rendering_gate.py`.
+- **State races between hook processes and the MCP server.** Contained by KTD11: every
+  turn-record mutation is a locked read-apply-write transaction through
+  `turn_record.mutate`, proven by deterministic interleaving tests; atomic write-replace
+  remains only the torn-write defense for readers (a torn read reads as absent, a named
+  unavailable state). Field-family conventions (origin by the prompt hook, submissions by
+  the server, outcome by the Stop hook) still describe who writes what, but the lock —
+  not the convention — is what prevents lost updates.
+- **Per-prompt latency.** The prompt hook adds one `bridge.json` read, at most one Herdr
+  subprocess call, and one loopback GET, bounded by the timeout budget table (worst case
+  ≤ 3,500 ms inside the 5 s hook timeout), with the cheap no-bridge-file exit first — a
+  session with no Auralis pays one `stat()`.
+
+## Acceptance mapping
+
+| Acceptance | Where it lands |
+|---|---|
+| AE26 — Markdown rejected, not cleaned; plain resubmission accepted (covers R121, R20) | Runnable at this boundary: `test_rendering_gate.py` + the `test_mcp_server.py` AE26 scenario (in-process and at the declared executable), plus the adapter-boundary R122 record proof in `test_r122_adapter_boundary.py`; evidence recorded in `docs/evidence/voice/auralis-c3-acceptance.md` (U5) |
+| AE34 — joint bridge acceptance with C10 | Readiness from this side: U1/U3 green against the independent-literals stub; the joint run itself is coordinator-scheduled across repositories |
+| AE19, AE23, AE35, AE36 — joint with C5/C10/C1 | Out of this slice's hands; the adapter contributions they consume (presence, origin, submission, fallback-outcome recording) are the tested surfaces above. AE36 in particular is where the named R22/R23 cross-slice dependency on C5's `acceptFallback()` path is proven end to end — its executable home (`infiquetra/auralis`), owner (the C5 slice, Dart harness standing in), and step-by-step procedure are specified in "The joint AE36 test — executable home, owner, and procedure", and the obligation is recorded there as a named cross-repository dependency |
+
+## Verification
+
+```bash
+cd plugins/voice && python3 -m unittest discover -s tests -v
+cd ../.. && python3 scripts/check_repo.py
+python3 -m unittest discover -s tests -v
+python3 -m pytest plugins/*/tests -q
+git diff --check
+```
+
+## Unattended decisions log
+
+Decisions taken without an operator in the loop, per the run's operating rule, each from a
+known set with the most defensible option:
+
+- **Backend: inline** — directed by the orchestrator for this run; recorded in the
+  frontmatter. The saga recommender's suggestion (`team-execution`) is recorded on the
+  saga tick as the recommendation alongside the directed choice.
+- **Destination: `pr`** — the card's Done state requires a merged PR with the coordinator
+  merging and closing; a worker never merges its own PR, so the saga destination is
+  open-a-PR.
+- **Board transitions: skipped** — the plan skill's phase would move the card to
+  Shaping/Ready, but this card states the coordinator is the only board writer
+  ("Never: … write the Operations board"). The card's custody rule wins.
+- **Plan filename as given** — `docs/plans/2026-08-27-auralis-c3-adapter.md` exactly as
+  the card directed, without the `-plan` suffix convention; review tooling recognizes the
+  document by its section markers, not its name.
+- **`origin:` frontmatter is the cross-repository requirements-document URL** — the
+  upstream WHAT lives in `infiquetra/auralis`, so no repo-relative path exists; the URL
+  is an immutable commit permalink at `b49de1ba4d39cbd8a1e582d72bddca85bf528f8a`, never a
+  moving branch.
+- **R22/R23 read as slice-owned requirements discharged across the C3/C5 seam** — the
+  adapter share (submit only gated text, never fabricate, record the completion durably)
+  is planned here; fallback initiation, content, speech, and the `fallback_accepted` mark
+  are Core/C5's through `acceptFallback()`, proven jointly at AE36 (see "The R22/R23
+  fallback seam"). The alternative reading — that C3 must make fallback audible — would
+  require owning speech, which the card forbids.
+
+Decisions taken during the 2026-08-27 plan repair (doc-review findings F1–F12), same
+operating rule:
+
+- **F1 pin mechanism: a tracked byte-identical snapshot** of the contract at the
+  accepted-review revision, hash-verifiable against `infiquetra/auralis`
+  (`695cd0e…`, SHA-256 recorded in the wire-authority section). Chosen over an
+  external permalink alone because a clean checkout of *this* repository — including the
+  hosted `Validate` CI — must resolve the plan's links and read the contract without
+  access to another repository's unmerged branch; chosen over deleting the reference
+  because the plan must stay traceable to a specific revision of a specific document.
+- **F4 transaction mechanism: `fcntl.flock` on a sidecar lock file** (KTD11). Chosen
+  over `O_CREAT|O_EXCL` lock files (crash-stale locks need their own cleanup protocol;
+  flock releases with the process) and over SQLite (disproportionate to one single-turn
+  JSON document).
+- **F7 reconciliation: extend the closed `SETTING_NAMES` set inside `settings.py`**
+  rather than adding a second environment reader — the sole-reader rule is the package's
+  load-bearing invariant; the closed set is extended in its owning module (KTD9).
+- **F5 classing: indented code blocks reject under `markdown_formatting`** with class
+  `indented_code_block` named in the detail — the two-reason vocabulary is settled by
+  KTD1/AE26, and `fenced_code_block` stays literally about fences.
+- **F8 reconciliation source: the retry context plus the contract's §8 sentence**, not an
+  extra `GET /v1/current` corroboration read — §8 makes `duplicate_rendering` on a
+  byte-equivalent retry decisively mean the earlier acceptance, and an extra wire read
+  would add failure modes without adding information.
+
+Decisions taken during the 2026-08-27 cycle-2 plan repair (findings F3 and F5 only),
+same operating rule:
+
+- **AE36 joint-test home: the `auralis` repository** — forced rather than chosen:
+  `acceptFallback()` is an in-process Dart API and the five-route wire is frozen, so no
+  test in this repository can drive or observe the fallback transition, and the only
+  alternative (a sixth route) is forbidden by the review and by C10's acceptance.
+- **The in-repository R122 test renamed `test_r122_adapter_boundary.py`** — the cycle-1
+  name `test_r122_end_to_end.py` itself carried the overclaim F3 records; the cycle-1
+  disposition table below keeps the old name as accurate history of that cycle.
+- **Markdown grammar inventory: base Markdown's construct list plus GitHub-flavored pipe
+  tables and strikethrough** — the cycle-1 table already treated pipe tables as in scope,
+  and those two extensions are the forms a coding agent actually emits. Chosen over "base
+  Markdown only" (would leave the agent-typical `~~…~~` unrejected) and over the full
+  GitHub-flavored grammar (its bare-URL linkification would reject bare spoken URLs, an
+  accepted non-class since cycle 1).
+- **HTML entity references are a named prose-collision non-class, not a rejecting
+  class** — the `&name;` shape collides with ordinary prose such as `AT&T;` mid-sentence,
+  and R121 grounds Markdown rejection, not HTML sanitization; the exclusion is documented
+  and tested rather than silently absent, which is what keeps the class table closed.
+
+Decisions taken during the 2026-08-27 cycle-3 plan repair (finding F5 only), same
+operating rule:
+
+- **Grammar authority: the plan's class table is itself the normative grammar**, chosen
+  over pinning an external base-Markdown specification and version (both closures were
+  acceptable to the review). The recognizers are deliberately line-and-inline regexes
+  serving a cooperative resubmission contract, so an external pin would buy a
+  parser-conformance obligation out of proportion to a boundary where a missed form
+  costs one resubmission prompt — and KTD1 already names the module the boundary's
+  documented authority. The external construct list stays recorded in the completeness
+  rule as the informative derivation source.
+- **Strikethrough runs match one or two tildes**, chosen over the strict two-tilde
+  published spelling: GitHub also renders the one-tilde form, and over-detection inside
+  a rejecting class is safe, so the wider rule covers both readings rather than leaking
+  one.
+- **The pipe-row rule is any line containing a pipe character**, chosen over recognizing
+  only delimiter-shaped rows: GitHub-flavored table rows require no leading or trailing
+  pipe, one rule covers header, delimiter, and data rows in a single line-level regex,
+  and no stated accepting non-class contains a pipe.
+
+## Doc-review disposition (2026-08-27)
+
+Where each finding of
+[`2026-08-27-auralis-c3-adapter-plan-doc-review.md`](../reviews/2026-08-27-auralis-c3-adapter-plan-doc-review.md)
+was repaired in this document.
+
+| Finding | Repair |
+|---|---|
+| F1 (wire pin not committed) | The snapshot `docs/bridge-v1-from-c10.md` is now a **tracked** file, byte-identical (SHA-256-verified) to `docs/bridge/bridge-v1.md` in `infiquetra/auralis` at accepted revision `695cd0e…`; the wire-authority section states the provenance, digest, and refresh procedure. Clean checkouts and CI resolve every link |
+| F2 (no R22/R23 path) | New section "The R22/R23 fallback seam": C3 owns the requirements, C5's in-process `acceptFallback()` (contract §9) is the mechanism, responsibilities on each side are enumerated, and the cross-slice dependency on C5 is named and routed to AE36. R22/R23 table rows, KTD6, and scope boundaries rewritten to match |
+| F3 (R122 proved only via fixtures) | New `plugins/voice/tests/test_r122_end_to_end.py` (U4, now depending on U3): real prompt hook, real MCP server process at the declared argv, real Stop hook, one production-written turn record asserted end to end |
+| F4 (lost updates on the turn record) | New KTD11: every mutation is a locked read-apply-write transaction through `turn_record.mutate` (`fcntl.flock`, sidecar lock, 500 ms budget, named `turn_record_busy` refusal), with deterministic interleaving tests; atomic replace demoted to torn-write defense only |
+| F5 (incomplete Markdown detector) | The gate owns a complete, closed rejected-syntax contract (class table in U2) including setext headings, reference links and definitions, autolinks, and indented code; stated non-classes get named negative tests; `text_cleanup.py` is a seed, not a bound |
+| F6 (MCP server never run as declared) | U3 gains the executable-entrypoint scenario: the exact declared argv launched from an installed-root-shaped directory over real pipes through initialize / tools list / rejected call / accepted call; U5's packaging test pins `servers.json` to the same literals |
+| F7 (identity reads outside `settings.py`) | `SETTING_NAMES` extended to ten names inside `settings.py` (sole reader preserved); `settings.py` and `test_settings.py` assigned to U1; KTD9 rewritten |
+| F8 (`duplicate_rendering` after lost acceptance) | U1 defines the retry-context reconciliation (`accepted_on_retry`, never fallback, never a replacement invitation), grounded in §8; scenarios at both the client (U1) and the tool surface (U3) |
+| F9 (stub with no owner) | `plugins/voice/tests/bridge_stub.py` named, owned by U1 alone, import contract stated |
+| F10 (adjective timeouts) | Normative "Timeout budget" table: every HTTP, subprocess, lock, and hook deadline is a number with a named on-expiry behaviour; hooks.json entries state `timeout: 5`; clock/deadline scenarios assigned |
+| F11 (token/identifier grammar untested) | U1 scenarios for base64url alphabet, padding, and length violations and for uppercase / non-UUID / wrong-version Core identifiers, each asserting no request follows; every guard mutation-checked once and recorded in the U5 acceptance note |
+| F12 (moving-branch requirement links) | Frontmatter `origin:`, the namespace note, and the unattended-decisions log all use the immutable commit permalink at `b49de1ba4d39cbd8a1e582d72bddca85bf528f8a` |
+
+## Cycle-2 doc-review disposition (2026-08-27)
+
+Where the two findings the cycle-2 focused re-review at
+[`2026-08-27-auralis-c3-adapter-plan-doc-review-cycle2.md`](../reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle2.md)
+recorded as partially closed were completed in this document. The ten findings that
+review recorded as closed are untouched; the cycle-1 table above stands as history. The
+cycle-3 focused re-review at
+[`2026-08-27-auralis-c3-adapter-plan-doc-review-cycle3.md`](../reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle3.md)
+then adjudicated these repairs — F3 closed, F5 still partially closed — and the cycle-3
+repair extends this same table with the final F5 row below.
+
+| Finding | Cycle-2 repair |
+|---|---|
+| F3 (the R122 test claimed an end-to-end proof it does not deliver) | New section "The joint AE36 test — executable home, owner, and procedure": the joint test executes in `infiquetra/auralis` — the only process space that can call the in-process `acceptFallback()` (`lib/src/core/bridge/turn_coordinator.dart:537` at the pinned revision) — owned by the C5 slice with a Dart harness standing in, following an eight-step procedure that starts with the real C3 rejection over the adapter's MCP pipes, submits no replacement, completes the turn, drives `acceptFallback()` in process, and closes on the `GET /v1/current` assertion that the same captured turn reads `fallback_accepted`; recorded as a named cross-repository dependency, with no bridge route added. The in-repository test is renamed `test_r122_adapter_boundary.py` (cycle-1 name `test_r122_end_to_end.py`), and its scenario, the R122 requirement row, U4, and the acceptance mapping now claim only the adapter-side half |
+| F5 (the Markdown table closed the cycle-1 examples, not the defect class) | U2's gate contract now states its completeness rule — every construct of base Markdown plus GitHub-flavored pipe tables and strikethrough is disposed of as a rejecting class, a structural non-class, or a named prose-collision non-class, with none left without a rule — adds the block-indentation rule (every line-anchored class matches after zero to three leading spaces; four or more, or a tab, is indented code, so no indentation depth passes the gate), and adds the previously missing classes: hard line break in both syntaxes (two trailing spaces, and the backslash form), raw HTML, backslash escape, and strikethrough. Every class keeps at least one rejecting scenario, every line-anchored class gains a three-space-indented rejecting variant plus the three-vs-four-space seam scenario, and the ordinary-punctuation accepting cases are retained and extended |
+| F5 (cycle 3: the rejecting rows still gave illustrative spellings — `1.`/`1)` plus space, `#` plus space — that a literal matcher could satisfy while missing `2.`, `12.`, a valid empty heading, or a tab) | Every rejecting row of the U2 class table now states a matching rule — the full marker set, the full separator set, and the permitted trailing context: the ordered-list marker is one to nine ASCII digits of any value followed by `.` or `)` and then a space, a tab, or the end of the line; the ATX heading is one to six `#` followed by a space, a tab, or the end of the line, so the valid empty heading rejects; and the sixteen remaining rows were audited to the same standard (fence runs of three or more characters, the complete horizontal-rule and pipe-row rules, all six raw-HTML opener forms, the enumerated backslash-escape punctuation set, autolinks with no required `//`, equal-length code-span runs, one-or-two-tilde strikethrough runs, and the rest as the table states). Every rejecting class gains a rule-not-spelling test scenario a literal-spelling implementation would fail — for ordered lists a non-`1` and a multi-digit marker, for ATX an empty and a tab-delimited heading — and every existing rejecting and accepting case is kept. The class table, block-indentation rule, and non-class list are declared the gate's self-contained normative grammar, chosen over pinning an external specification; the grammar-authority paragraph in U2 and the cycle-3 unattended-decisions entries record the choice and the why |

--- a/docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle2.md
+++ b/docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle2.md
@@ -1,0 +1,99 @@
+---
+date: 2026-08-27
+kind: doc-review
+cycle: 2
+target: docs/plans/2026-08-27-auralis-c3-adapter.md
+reviewed_revision: 961d0e437fe99eb2a4a2fed2bbd2e54b238b597c
+reviewed_plan_blob: c06db4dcfb71425358e3f5a57439bd3c5c03309b
+repair_revision: b4362a2ed227c646a4f076e29f089793e8da36de
+branch: orch/auralis-c3-adapter-docreview-c3-plan
+classification: implementation plan
+blocked: true
+---
+
+# Focused document re-review, cycle 2 — Auralis C3 Claude adapter implementation plan
+
+**Verdict: STILL BLOCKED / NOT READY TO DRIVE IMPLEMENTATION.** In this repository's plan for Auralis Claude adapter capability slice C3, ten cycle-1 findings are closed, but two priority-one (P1) findings are only partially closed: the requirement R122 rejection-to-fallback test stops at the adapter's local outcome instead of observing Core's actual fallback mark, and the requirement R121 Markdown recognizer still admits Markdown forms outside its claimed complete contract.
+
+## Applied fixes
+
+No fixes were applied in cycle 2. The operator required a focused re-review without rewriting or repairing the plan, so this review artifact is the only cycle-2 repository change.
+
+## Review result
+
+The repaired plan remains blocked by findings F3 and F5; all other cycle-1 findings are closed.
+
+| field | value |
+|---|---|
+| target | `docs/plans/2026-08-27-auralis-c3-adapter.md` |
+| review mode | focused cycle-2 re-review of findings F1 through F12; not a fresh review |
+| reviewed revision | `961d0e437fe99eb2a4a2fed2bbd2e54b238b597c`; target blob `c06db4dcfb71425358e3f5a57439bd3c5c03309b` |
+| repair revision | `b4362a2ed227c646a4f076e29f089793e8da36de` |
+| wire authority | `docs/bridge/bridge-v1.md` in `infiquetra/auralis` at accepted revision `695cd0ecfddf44e0d6e3386da318bd5fde4a1926` |
+| tracked wire snapshot | `docs/bridge-v1-from-c10.md`; blob `a706d6f30b09ef726fbf0940aba7a4fa76261063`; Secure Hash Algorithm 256-bit (SHA-256) `eb47d141e5c1b87bae0bd1c0799386a3aa8806635251db14fc806469b5db19eb` |
+| blocked | true — two P1 findings remain partially closed |
+| findings | 6 P1 closed, 2 P1 partially closed, 4 priority-two (P2) closed; no new findings |
+| applied fixes | none |
+| review artifact | `docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle2.md` |
+| override rationale | none |
+| linked issue / plan | `infiquetra/infiquetra-agent-plugins#46`; target plan above |
+
+## Readiness summary
+
+The repair makes the wire pin reproducible, names the fallback boundary between adapter capability slice C3 and audio capability slice C5 without changing the frozen five-route bridge, adds a real Model Context Protocol (MCP) process test, and supplies a real file-transaction mechanism. It also closes the settings custody, lost-response retry, shared-stub ownership, deadline, wire-grammar, and immutable-requirements-link findings.
+
+The plan still substitutes an adapter-local `fallback` value for the Core-side `fallback_accepted` state in its purported end-to-end requirement R122 test. Its Markdown class table also patches the examples named in cycle 1 without defining all Markdown forms that requirement R121 says the surface must reject.
+
+## Finding dispositions
+
+Each cycle-1 finding was checked against the repaired plan and the narrow repository evidence needed to judge that repair.
+
+| id | priority | status | evidence checked | disposition |
+|---|:---:|:---:|---|---|
+| F1 | P1 | closed | Plan lines 55–82; tracked snapshot and exact source revision; snapshot/source SHA-256 equality; clean `git archive` repository check | The source document, revision, digest, and tracked byte-identical snapshot are explicit. A clean checkout contains the target and `scripts/check_repo.py` passes without the old excluded-only convenience copy. |
+| F2 | P1 | closed | Plan lines 194–249 and 1013–1025; bridge contract lines 102–110 and 331–335 | The plan assigns named-reason rejection and completion without an accepted rendering to C3, and assigns fallback content, speech, and the visible `fallback_accepted` mark to Core and C5 through the existing in-process `acceptFallback()` API. It adds no bridge route and names acceptance example AE36 as the joint dependency. |
+| F3 | P1 | partially closed | Plan lines 887–931 and 1075–1077; bridge contract lines 202–209 and 331–335 | The new test launches the real prompt hook, the declared MCP process, and the real Stop hook, so it closes the fixture-only half. Its final assertion reads only the adapter record's `fallback` value; it neither drives C5's `acceptFallback()` path nor observes the captured Core turn in `fallback_accepted`, and the generic AE36 mapping supplies no executable joint procedure. |
+| F4 | P1 | closed | Key Technical Decision 11 at plan lines 508–539; implementation unit U2 tests at lines 746–788; local macOS lock probe | Every writer is routed through one `fcntl.flock`-guarded read-apply-atomic-replace transaction with a named 500 ms refusal. The deterministic two-writer interleaving scenario proves serialization and retention of both updates; a local probe confirmed separate opens contend on the target platform. |
+| F5 | P1 | partially closed | Plan lines 253–266 and 710–773 | The repair correctly makes the gate, not `text_cleanup.py`, own the recognizer and adds the four concrete classes cited in cycle 1. The claimed complete class table still omits core Markdown forms, including hard-line-break syntax and block constructs preceded by up to three spaces; as written, examples such as a three-space-indented list or blockquote have no rejecting rule. |
+| F6 | P1 | closed | Plan lines 819–868 and 984–989 | The test now launches `python3 <installed-root>/scripts/mcp_server.py` from an installed-root-shaped copy over real pipes and completes initialize, tools/list, rejected tools/call, and accepted tools/call. Packaging tests bind the declaration to those exact command and argument literals. |
+| F7 | P1 | closed | Plan lines 451–482, 583–592, and 674–679 | The two Herdr identity names extend the closed `SETTING_NAMES` tuple inside the sole environment reader. `settings.py` and `test_settings.py` belong only to U1, with absent, empty, and closed-set regressions assigned. |
+| F8 | P1 | closed | Bridge contract lines 317–322; plan lines 626–635, 670–673, and 856–861 | The byte-equivalent lost-response retry carries explicit context. A retry-only `duplicate_rendering` becomes `accepted_on_retry`, is recorded as authored, cannot become fallback, and does not invite replacement; client- and MCP-surface scenarios cover the path. |
+| F9 | P2 | closed | Plan lines 456–458 and 583–602 | `plugins/voice/tests/bridge_stub.py` is named, owned only by U1, and given an explicit sibling-suite import and request-capture contract. |
+| F10 | P2 | closed | Plan lines 541–569 and 881–883 | The normative table assigns numeric connect, overall-call, subprocess, lock, hook, and renewal deadlines, with behavior on every expiry and owner-level clock tests. The two new hooks carry literal `timeout: 5` declarations. |
+| F11 | P2 | closed | Plan lines 613–657 and 681–684 | Token length, alphabet, and padding violations and lowercase Version 4 universally unique identifier (UUID) violations are explicit fixtures. Each refuses the value, proves no downstream request, and must be mutation-checked before the guard is restored. |
+| F12 | P2 | closed | Plan lines 1–6, 46–51, and 1105–1108; moving-branch URL search | Every requirements reference uses the full immutable revision `b49de1ba4d39cbd8a1e582d72bddca85bf528f8a`; no `main` or `master` requirements URL remains. |
+
+## Remaining findings by priority
+
+Two P1 findings still prevent implementation dispatch.
+
+| id | priority | status | required disposition |
+|---|:---:|:---:|---|
+| F3 | P1 | partially closed | Specify the joint AE36 test that starts with the real C3 rejection, submits no replacement, lets the turn complete, drives C5's existing in-process `acceptFallback()` path, and observes that same Core turn as `fallback_accepted`. This must not add a bridge route. |
+| F5 | P1 | partially closed | Close the Markdown defect class rather than only the cycle-1 examples: state the complete syntax grammar the standard-library recognizer implements and assign rejecting cases for every class, including optional block indentation and hard-line-break syntax, while retaining the ordinary-punctuation negative cases. |
+
+## Repair-introduced findings
+
+No new finding was introduced by the repair. Findings F3 and F5 are the original cycle-1 defects with meaningful but incomplete repairs.
+
+## Verification evidence
+
+The wire-pin and repository claims were reproduced from tracked bytes, and the unchanged repository test suite remains green.
+
+| check | result |
+|---|---|
+| cycle-1 review and repaired plan read completely | pass |
+| repair commit scope | pass; only the plan and tracked bridge snapshot changed |
+| authoritative bridge revision available locally | pass; `695cd0ecfddf44e0d6e3386da318bd5fde4a1926` |
+| authoritative bridge bytes equal tracked snapshot | pass; matching SHA-256 `eb47d141e5c1b87bae0bd1c0799386a3aa8806635251db14fc806469b5db19eb` |
+| tracked snapshot present in reviewed revision | pass; blob `a706d6f30b09ef726fbf0940aba7a4fa76261063` |
+| `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_repo.py` in current checkout | pass |
+| same repository checker in a clean `git archive HEAD` | pass |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -q` | pass; 755 tests |
+| plan unchanged during cycle-2 review | pass; blob remains `c06db4dcfb71425358e3f5a57439bd3c5c03309b` |
+
+## Residual risk from limited evidence
+
+This was a focused plan re-review, not implementation or live acceptance. The Auralis bridge contract remains unmerged to `auralis` main, so acceptance example AE34 must still revalidate the real two-repository wire later; the tracked snapshot makes the implementation input reproducible but does not replace that joint proof.
+
+No formal idea-, issue-, or specification-phase rubric ran because the explicit target is a single implementation plan. No external-reviewer panel was requested or dispatched.

--- a/docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle3.md
+++ b/docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle3.md
@@ -1,0 +1,92 @@
+---
+date: 2026-08-27
+kind: doc-review
+cycle: 3
+target: docs/plans/2026-08-27-auralis-c3-adapter.md
+reviewed_revision: dadcf604dc2c47b55ebe4c615384d6370843c1bf
+reviewed_plan_blob: 666b3e99e0b57c84d638f0c43af5261c62e47130
+repair_revision: f24685b8f2e1b0e3877d11b8f48ab6b40bc471f7
+branch: orch/auralis-c3-adapter-docreview-c3-plan
+classification: implementation plan
+blocked: true
+---
+
+# Focused document re-review, cycle 3 — Auralis C3 Claude adapter implementation plan
+
+**Verdict: STILL BLOCKED / NOT READY TO DRIVE IMPLEMENTATION.** In this repository's plan for Auralis Claude adapter capability slice C3, the repair closes finding F3 by specifying the executable joint fallback test and correcting the local proof boundary, but finding F5 remains partially closed because the claimed complete Markdown contract still supplies construct labels and examples rather than a complete syntax grammar.
+
+## Applied fixes
+
+No fixes were applied in cycle 3. The operator required review-only adjudication of findings F3 and F5, so this review artifact is the only repository change.
+
+## Review result
+
+One priority-one (P1) finding remains; the plan is still blocked.
+
+| field | value |
+|---|---|
+| target | `docs/plans/2026-08-27-auralis-c3-adapter.md` |
+| review mode | focused cycle-3 re-review of findings F3 and F5 only |
+| reviewed revision | `dadcf604dc2c47b55ebe4c615384d6370843c1bf`; target blob `666b3e99e0b57c84d638f0c43af5261c62e47130` |
+| repair revision | `f24685b8f2e1b0e3877d11b8f48ab6b40bc471f7` |
+| repair scope | one file: the target plan; 241 insertions and 44 deletions |
+| blocked | true — F5 remains partially closed |
+| focused findings | F3 closed; F5 partially closed |
+| carried findings | F1, F2, F4, and F6 through F12 remain closed |
+| repair-introduced findings | none |
+| applied fixes | none |
+| review artifact | `docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle3.md` |
+| override rationale | none |
+| linked issue / plan | `infiquetra/infiquetra-agent-plugins#46`; target plan above |
+
+## Readiness summary
+
+The most defensible known-set choice is to close F3. The in-process Dart call cannot be driven from this repository, and the repair now names the only executable home, the owning audio capability slice C5, the stand-in harness, the eight process-and-repository steps, the captured identifier pair, and the closing Core assertion without adding a bridge route.
+
+The most defensible choice is to keep F5 partially closed. The repair now inventories all top-level base-Markdown constructs and the two named GitHub-flavored extensions, but it explicitly disclaims parser equivalence and still writes several rejecting classes as incomplete examples; a literal implementation can therefore admit valid syntax while every planned one-example-per-class test passes.
+
+## Finding dispositions
+
+Finding F3 is closed; finding F5 still blocks implementation.
+
+| id | priority | status | evidence checked | disposition |
+|---|:---:|:---:|---|---|
+| F3 | P1 | closed | Plan lines 157–163, 261–345, 1037–1091, and 1235–1241; frozen bridge contract lines 102–110, 202–209, and 331–335; `turn_coordinator.dart` line 537 and `bridge_server_test.dart` lines 391–431 at Auralis revision `695cd0ecfddf44e0d6e3386da318bd5fde4a1926` | The test has an executable home in `infiquetra/auralis`, owner C5, and eight steps. Step 3 fixes `(binding_id, turn_id)` as the join key for every later assertion, step 7 calls `acceptFallback()` with that pair, and step 8 reads the same turn as `fallback_accepted` over `GET /v1/current`; all wire activity stays on the frozen five operations. The local test is renamed `test_r122_adapter_boundary.py`, and the requirement row, implementation unit U4, and acceptance mapping now claim only the adapter-side half. |
+| F5 | P1 | partially closed | Plan lines 806–880 and 894–923; repair diff hunks for the class table and tests | The completeness rule closes the top-level construct inventory and adds the cycle-2 omissions, but it does not state an exact base-Markdown grammar or make each class's syntax exhaustive. For example, the ordered-list row names only `1.` and `1)` followed by a space, omitting other valid numeric markers and whitespace or empty-item forms; the hash-prefixed (ATX) heading row requires a following space, omitting a valid empty ATX heading and tab-delimited form. One rejecting example per class cannot detect those omissions, so a third unlisted form can still pass. |
+
+## Remaining findings by priority
+
+F5 remains a P1 implementation-readiness block.
+
+| id | priority | status | required disposition |
+|---|:---:|:---:|---|
+| F5 | P1 | partially closed | Pin the exact base-Markdown grammar and version, or state an equivalent self-contained grammar, then make every rejecting row cover that grammar's full syntax rather than illustrative spellings. At minimum, specify and test the complete ordered-list marker and separator grammar and the complete ATX-heading whitespace/end-of-line grammar; audit fences, emphasis delimiters, raw Hypertext Markup Language (HTML) forms, references, and the other rows against the same source, while retaining every named structural and prose-collision accepting case. |
+
+## Closed carryover verification
+
+The repair commit supports the author's claim that the other ten findings were not reopened.
+
+`git show f24685b` changes only the target plan. Its hunks add the F3 joint-test contract, rename and narrow the F3 test references, extend the F5 grammar and tests, and update the summary, evidence, risk, decisions, acceptance mapping, and disposition mirrors for those two findings; the requirement R22 row and shared-stub line change only the F3 test name, not the already-closed F2 or F9 mechanisms.
+
+## Verification evidence
+
+The frozen revision and repository gates were reproduced before delivery.
+
+| check | result |
+|---|---|
+| `HEAD` equals the operator-supplied reviewed revision | pass; `dadcf604dc2c47b55ebe4c615384d6370843c1bf` |
+| target at `HEAD` equals repair-commit target | pass; no diff between `f24685b` and `HEAD`; blob `666b3e99e0b57c84d638f0c43af5261c62e47130` |
+| repair changes only the target plan | pass |
+| Auralis `acceptFallback()` location and signature at the pinned revision | pass; `lib/src/core/bridge/turn_coordinator.dart:537` |
+| existing Core proof that `GET /v1/current` exposes `fallback_accepted` | pass; `test/core/bridge/bridge_server_test.dart:391–431` |
+| frozen wire remains five operations across four paths | pass; no sixth path appears in the plan or repair diff |
+| local R122 overclaim search | pass; remaining `test_r122_end_to_end.py` references are explicitly historical |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -q` | pass; 755 tests |
+| `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_repo.py` | pass |
+| `git diff --check` and review-artifact whitespace/newline checks | pass |
+
+## Residual risk from limited evidence
+
+This was a focused plan review, not implementation or live joint acceptance. Closing F3 means the cross-repository obligation is decision-complete; it does not claim that the future joint acceptance example AE36 test has already run.
+
+No formal idea-, issue-, or specification-phase rubric ran because the explicit target is a single implementation plan. No external-reviewer panel was requested or dispatched.

--- a/docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle4.md
+++ b/docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle4.md
@@ -1,0 +1,88 @@
+---
+date: 2026-08-27
+kind: doc-review
+cycle: 4
+target: docs/plans/2026-08-27-auralis-c3-adapter.md
+reviewed_revision: b4cc17bcd052cbe76cc0731ccb7ca477b9bfdcea
+reviewed_plan_blob: 9a65aaabe5d832721306f69702794e03e84ef0ee
+repair_revision: 0b020789cf7e0c7f766d93038f4302a18b76f8de
+branch: orch/auralis-c3-adapter-docreview-c3-plan
+classification: implementation plan
+blocked: false
+---
+
+# Focused document re-review, cycle 4 — Auralis C3 Claude adapter implementation plan
+
+**Verdict: READY TO DRIVE IMPLEMENTATION.** In this repository's plan for Auralis Claude adapter capability slice C3, the repair closes finding F5 by replacing illustrative Markdown spellings with a self-contained normative grammar and per-class tests that defeat the cycle-2 literal transcription; all twelve original findings are now closed.
+
+## Applied fixes
+
+No plan fixes were applied in cycle 4. The operator required review-only adjudication of finding F5, so this review artifact is the only repository change.
+
+## Review result
+
+No priority-zero or priority-one finding remains, so the plan is not blocked.
+
+| field | value |
+|---|---|
+| target | `docs/plans/2026-08-27-auralis-c3-adapter.md` |
+| review mode | focused cycle-4 re-review of finding F5 only |
+| reviewed revision | `b4cc17bcd052cbe76cc0731ccb7ca477b9bfdcea` |
+| reviewed plan blob | `9a65aaabe5d832721306f69702794e03e84ef0ee` |
+| repair revision | `0b020789cf7e0c7f766d93038f4302a18b76f8de` |
+| repair scope | one file: the target plan; 91 insertions and 18 deletions |
+| blocked | false |
+| focused finding | F5 closed |
+| carried findings | the other eleven findings remain closed and were not re-reviewed |
+| repair-introduced findings | none |
+| applied fixes | none |
+| review artifact | `docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review-cycle4.md` |
+| override rationale | none |
+| linked issue / plan | `infiquetra/infiquetra-agent-plugins#46`; target plan above |
+
+## Readiness summary
+
+Finding F5 is closed because an implementer no longer has to infer what the Markdown gate recognizes.
+
+Plan lines 848–865 make the table, indentation rule, and named non-classes the self-contained normative grammar. Lines 875–894 then state each rejecting class as a matching rule with its marker set, separators, context, and boundaries; the ordered-list rule covers one to nine decimal digits with either delimiter and a space, tab, or end of line, while the hash-prefixed heading rule covers one to six markers with all three trailing contexts.
+
+Plan lines 943–960 add a rule-not-spelling case for every rejecting class. Those cases include alternate values, delimiters, run lengths, whitespace, end-of-line forms, and opener shapes, so an implementation that merely transcribes the cycle-2 spellings cannot satisfy the planned suite; lines 961–965 retain the ordinary-punctuation and other named accepting cases.
+
+## Finding disposition
+
+The sole in-scope finding is closed.
+
+| finding | prior priority | status | evidence checked | adjudication |
+|---|:---:|:---:|---|---|
+| F5 — incomplete Markdown recognizer contract | priority one (P1) | closed | Repair diff; plan lines 824–910, 924–971, 1374–1392, and 1430 | The plan takes the permitted self-contained-grammar closure and states why that boundary is proportionate to requirement R121's cooperative resubmission flow. The rows are rules rather than spellings, and the added test tier would fail the former literal implementation: examples now cross numeric value and length, both list delimiters, space/tab/end-of-line context, heading emptiness, fence length, alternate horizontal-rule markers, raw Hypertext Markup Language opener families, delimiter-run length, and at least one off-spelling dimension for every other class. A literal implementation of the normative rows cannot admit an input those rows match; an implementation that hard-codes only finite test examples would violate the written contract rather than expose a missing plan decision. |
+
+## Remaining findings by priority
+
+No findings remain. All twelve findings from the original review are closed.
+
+## Closed carryover verification
+
+The repair did not touch the eleven findings already closed before this cycle.
+
+`git show 0b02078` changes only the target plan. Its hunks are confined to the F5 grammar authority, rejecting rules, rule-not-spelling scenarios, decision record, summary, and disposition mirror; no unchanged finding was re-reviewed or reopened, and the repair introduced no new finding.
+
+## Verification evidence
+
+The frozen plan bytes and repository gates were reproduced before delivery.
+
+| check | result |
+|---|---|
+| current reviewed revision | pass; `b4cc17bcd052cbe76cc0731ccb7ca477b9bfdcea` |
+| target at the reviewed revision equals the repair target | pass; no diff between `0b02078` and `HEAD`; blob `9a65aaabe5d832721306f69702794e03e84ef0ee` |
+| repair changes only the target plan | pass; 91 insertions and 18 deletions |
+| `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_repo.py` | pass |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -q` | pass; 755 tests |
+| `git diff --check` and review-artifact whitespace/newline checks | pass |
+
+## Residual risk from limited evidence
+
+The finite examples do not constitute parser conformance and could be gamed by a deliberately test-shaped implementation. That is not a plan-readiness defect here: the complete rows are normative, every class has an off-spelling guard and a required mutation check, and the consequence of an uncaught edge form in this private single-operator tool is a stray character spoken aloud rather than a security or safety failure.
+
+Implementation and code review must still compare each regular expression to its normative row. This cycle reviewed the plan only; it does not claim the future gate implementation already satisfies the grammar.
+
+No formal idea-, issue-, or specification-phase rubric ran because the explicit target is a single implementation plan. No external-reviewer panel was requested or dispatched.

--- a/docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review.md
+++ b/docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review.md
@@ -1,0 +1,194 @@
+---
+date: 2026-08-27
+kind: doc-review
+target: docs/plans/2026-08-27-auralis-c3-adapter.md
+reviewed_revision: 34760140a3620e0f4559dca4944f1c729c27697f
+branch: orch/auralis-c3-adapter-docreview-c3-plan
+classification: implementation plan
+blocked: true
+---
+
+# Document review — Auralis C3 Claude adapter implementation plan
+
+**Verdict: NOT READY / BLOCKED.** The plan preserves the central content-custody rules, but eight open priority-one (P1) findings would let implementation ship without a real rejection-to-fallback path, lose turn evidence between processes, accept Markdown that requirement R121 (the plain-spoken-text submission rule) requires it to reject, or pass helper tests while the declared Model Context Protocol (MCP) process does not run.
+
+## Applied fixes
+
+No fixes were applied. The operator required review-only treatment of the plan, so this artifact is the only repository change.
+
+## Review result
+
+This review is blocked by eight P1 findings; four priority-two (P2) findings add meaningful wire, unit-custody, and verification risk.
+
+| field | value |
+|-------|-------|
+| target | `docs/plans/2026-08-27-auralis-c3-adapter.md` |
+| reviewed revision | `34760140a3620e0f4559dca4944f1c729c27697f` on `orch/auralis-c3-adapter-docreview-c3-plan`; target blob `999de8ab157ca3e6288e6d2fae0a3c83367f7d62` |
+| wire authority reviewed | read-only local `docs/bridge-v1-from-c10.md` for Auralis Core capability slice C10, Secure Hash Algorithm 256-bit (SHA-256) `eb47d141e5c1b87bae0bd1c0799386a3aa8806635251db14fc806469b5db19eb` |
+| classification | single implementation plan; normal readiness-skeptic pass |
+| blocked | true — unresolved P1 findings remain |
+| findings | 0 priority-zero (P0), 8 P1, 4 P2, 0 priority-three (P3) |
+| applied fixes | none |
+| review artifact | `docs/reviews/2026-08-27-auralis-c3-adapter-plan-doc-review.md` |
+| override rationale | none |
+| linked issue / plan | `infiquetra/infiquetra-agent-plugins#46`; target plan above |
+
+The local bridge document was treated as the normative wire authority exactly as directed. The Voice 0.2.1 package behavior and exploration X1 (the PreToolUse payload-shape check) were accepted as established and were not re-derived.
+
+## Readiness summary
+
+The plan cannot safely drive implementation because the local fallback record is not a handoff to Auralis Core, and the five-route wire exposes no adapter operation that supplies fallback text or changes the turn to `fallback_accepted`. The plan also relies on a bridge document it calls committed even though that file is absent from the reviewed Git revision and locally excluded from Git.
+
+Several sharp constraints are otherwise stated correctly. Authored text is rejected rather than cleaned, accepted text is intended to cross the adapter unchanged, preferences are transmitted as instructions rather than applied, and a bound non-Auralis turn gets the negative origin case with no rendering expectation.
+
+All declared implementation file sets stay in this repository, and none plans an `infiquetra/auralis`, speech-provider, audio-capture, playback, or user-interface change. The declared unit file lists do not overlap, standard-library Python and `unittest` are explicit, and the hosted `Validate` workflow is acknowledged; findings F7 and F9 show where undeclared files or shared test custody would nevertheless become necessary.
+
+## Remaining findings by priority
+
+Every finding is open and requires a plan correction before implementation dispatch.
+
+| id | priority | status | summary |
+|----|:--------:|:------:|---------|
+| F1 | P1 | open | The wire authority is not committed or reproducibly pinned, so a clean checkout loses the document and fails the repository's Markdown-link check. |
+| F2 | P1 | open | An unreplaced R121 rejection is only labeled `fallback` in adapter-local JavaScript Object Notation (JSON); no planned handoff supplies requirement R22's fallback content or requirement R23's visible fallback marking in Core. |
+| F3 | P1 | open | No test proves requirement R122 (the unreplaced-rejection fallback rule) by running an actual rejected submission through completion and observing the resulting marked fallback path. |
+| F4 | P1 | open | Multiple processes update one whole-file turn record without a transaction, so atomic replacement can still lose submissions, rejection reasons, observations, or outcome. |
+| F5 | P1 | open | The R121 gate deliberately reuses an incomplete Markdown recognizer and therefore permits Markdown forms outside the Voice 0.2.1 cleanup subset. |
+| F6 | P1 | open | Tests call the MCP server loop in process instead of running the command Claude will launch, contrary to the repository's executable-entrypoint rule. |
+| F7 | P1 | open | Implementation unit U1 reads two new environment variables outside the package's sole settings reader while assigning neither `settings.py` nor its tests to a unit. |
+| F8 | P1 | open | The lost-response retry case can return `duplicate_rendering` after Core already accepted speech, but the plan does not define how the adapter records and reconciles that accepted turn. |
+| F9 | P2 | open | The shared independent-literals bridge stub is promised but has no named file or unit owner. |
+| F10 | P2 | open | Hypertext Transfer Protocol (HTTP) and hook timeouts are called “short” or “stated” without any numeric values. |
+| F11 | P2 | open | U1's malformed-wire scenarios do not prove the contract's full token and Core-identifier grammar. |
+| F12 | P2 | open | The requirements document is said to be pinned at `b49de1b`, but both recorded URLs point to mutable `main`. |
+
+### F1. The claimed committed wire pin does not exist in the reviewed revision
+
+The plan's most important evidence source disappears in a clean checkout.
+
+The plan calls `docs/bridge-v1-from-c10.md` a “verbatim working copy” that is “committed in this repository” and says adapter assumptions are pinned to that committed copy (plan lines 48–62). At the reviewed revision, `git show HEAD:docs/bridge-v1-from-c10.md` exits 128 because the file is not in Git; it is a read-only local file excluded by `.git/info/exclude`.
+
+This is not only a provenance wording error. The tracked plan links to the absent path, while `scripts/check_repo.py` lines 291–307 rejects missing local Markdown targets and the hosted `Validate` continuous integration (CI) workflow runs that checker after a clean checkout; the current local check passes only because the excluded file is present in this worktree.
+
+Required disposition: make the exact reviewed contract bytes available from a durable immutable pin that clean implementation and CI checkouts can resolve. The plan must then describe that real custody mechanism rather than call a local excluded file committed.
+
+### F2. The R121 rejection path never reaches an actual R22/R23 fallback
+
+Writing the word `fallback` to local adapter state does not make Core accept or mark a fallback.
+
+The plan says the Stop hook suppresses the legacy local speech path and only records outcome `fallback` when no authored rendering was accepted (plan lines 163–167, 292–305, and 629–634). It then explicitly excludes sourcing the full written response to Core (lines 697–699), even though R22 requires that response to become the fallback and R23 requires the fallback to be visibly distinguishable.
+
+The C10 contract exposes only authored submission at `POST /v1/rendering` (contract lines 102–110 and 213–265). It exposes `fallback_accepted` as Core state and assigns `acceptFallback()` to audio capability slice C5 (lines 202–209 and 331–336), but the plan names no mechanism that carries the Stop hook's `last_assistant_message` or completion signal to that mechanism.
+
+Required disposition: name the already-owned C10/C5 handoff that consumes the exact completed response and transitions the captured identifier pair to marked fallback. If no such handoff exists, the bridge or slice boundary must be resolved before C3 dispatch; a local outcome label cannot substitute for it.
+
+### F3. The R122 test plan joins two fixtures, not two production boundaries
+
+The described tests can pass while the real rejection-to-fallback handoff is broken.
+
+Implementation unit U3's acceptance example AE26 test rejects Markdown and then accepts a replacement (plan lines 554–575), so it never exercises R122's unreplaced case. Implementation unit U4 starts its Stop-hook scenario from “a prior gate rejection in the record” (lines 629–632), which can be constructed directly and does not prove that `submit_spoken_rendering` wrote what the real Stop hook later reads.
+
+Required disposition: add one scenario that calls the actual MCP tool with Markdown, observes the named rejection and no wire forwarding, supplies no replacement, executes the real completion boundary, and observes the same turn become marked fallback through the mechanism that closes F2. The test must fail if the submission record schema, session/identifier join, completion handoff, or fallback marker drifts.
+
+### F4. Atomic replace does not protect the shared turn record from lost updates
+
+The plan confuses a complete file write with a transaction across writers.
+
+The UserPromptSubmit hook creates the record, the long-lived MCP process appends submissions, the PreToolUse hook appends observations, and the Stop hook settles the outcome (plan lines 149–165, 499–502, 543–552, and 599–608). Those are separate processes performing read-modify-replace operations on one JSON file.
+
+The risk section says atomic write-replace and one writer per “field family” contain the race (lines 731–735), but two writers can read the same prior document and each replace it with a complete yet incomplete update. That interleaving can erase the named R121 rejection or an accepted disposition and cause the wrong R122 result.
+
+Required disposition: choose one standard-library transaction design for all record mutations, assign its file ownership, and add deterministic interleaving tests that fail on lost updates. Atomic replacement may remain the torn-write defense, but it is not the concurrency mechanism.
+
+### F5. The planned Markdown detector is known to be incomplete
+
+R121 cannot be proved by copying a recognizer whose documented scope is narrower than Markdown.
+
+The plan limits the gate to fences, hash-prefixed (ATX) headings, paired emphasis, inline code, inline links/images, lists, blockquotes, horizontal rules, and table pipes (plan lines 490–517). The source it proposes to reuse says it is a small line-and-regex cleanup pass and that fidelity beyond its tested classes is not a version-one goal (`plugins/voice/scripts/text_cleanup.py` lines 1–13).
+
+Setext headings, reference-style links, autolinks, and indented code blocks are concrete Markdown forms outside that list. A gate built literally from the plan would accept them as plain text even though R121 requires a rendering containing Markdown syntax to be rejected at submission.
+
+Required disposition: define the complete rejected syntax contract and tests at the agent-facing boundary, including negative cases for ordinary punctuation. The implementation must still return a named rejection and must never expose a cleanup or rewrite path.
+
+### F6. The declared MCP executable is never tested as Claude runs it
+
+In-process loop tests do not prove that the installed command starts, imports, frames, and answers over standard input/output.
+
+The plan declares `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/mcp_server.py` through `com.infiquetra.claude/mcp/servers.json` (plan lines 385–393 and 645–676). U3 instead drives an imported server loop over injected byte streams (lines 543–575), while U5 checks only that the path exists and says no behavior suite is added.
+
+`AGENTS.md` lines 63–66 requires an executable entrypoint to be run the way a user runs it because separate component tests have previously missed broken imports. Required disposition: assign a test that launches the exact declared argv from an installed-root-shaped directory and completes MCP initialize, tools/list, a rejected tools/call, and an accepted tools/call over real process pipes.
+
+### F7. Identity discovery violates the package's closed environment-reading contract
+
+The unit cannot follow both its file list and the existing Voice settings rule.
+
+U1 directs `adapter_identity.py` to read `HERDR_PANE_ID` and `HERDR_BIN_PATH` from the environment (plan lines 418–445), while Key Technical Decision 9 (KTD9) says `settings.py` and its closed `SETTING_NAMES` remain untouched (lines 362–373). The existing module says it is the whole package's sole environment reader and that nothing outside its eight-name tuple is read (`plugins/voice/scripts/settings.py` lines 1–7 and 79–90).
+
+Neither `plugins/voice/scripts/settings.py` nor `plugins/voice/tests/test_settings.py` belongs to any implementation unit. Required disposition: explicitly reconcile the C10-mandated identity context with the package rule, then give the chosen files and regression tests to exactly one unit without overlapping another unit's custody.
+
+### F8. Lost accepted responses have no defined local outcome
+
+The retry rule can turn a successful authored rendering into an apparent rejection unless the plan defines reconciliation.
+
+The C10 contract permits one byte-equivalent retry after a rendering response is lost and states that an earlier acceptance then returns `duplicate_rendering` (contract lines 317–322). The plan says every Core rejection, including `duplicate_rendering`, is relayed as `rejected_by_core` and recorded, while completion is authored only when the captured turn reached an accepted authored rendering (plan lines 543–575 and 292–305).
+
+No scenario loses the first accepted response, receives `duplicate_rendering` on the retry, and then checks both the agent result and the settled turn outcome. Required disposition: define how retry context and/or the exact `GET /v1/current` state establishes the local authored outcome for this case, and prove that it cannot become fallback or invite an unsafe replacement.
+
+### F9. The shared bridge stub has no file owner
+
+The test architecture promises one fixture that no unit is assigned to create.
+
+The plan says every wire literal is centralized in one module and one stub fixture (plan lines 57–66), and U3 says it uses the U1 stub (lines 543–552). U1's file list contains only production modules and two `test_*.py` files; no reusable stub module is named (lines 413–421).
+
+Required disposition: name the shared fixture path, its import contract, and its sole owning unit. Otherwise U3 must either create an undeclared file, import another test module as production test infrastructure, or duplicate the literals the plan says are centralized.
+
+### F10. Runtime deadlines remain choices for implementers
+
+The lease and prompt hot paths need numbers, not adjectives.
+
+U1 requires “stated short timeouts” for every HTTP call, and U4 adds hook entries with “stated timeouts,” but no connect, read, overall-call, UserPromptSubmit, or PreToolUse value appears (plan lines 432–445 and 583–608). Those choices affect whether the 5,000 ms renewal point is met and how long every prompt can stall during bridge trouble.
+
+Required disposition: state the numeric timeout budget for each operation and hook, plus the expected behavior when it expires, and add clock/deadline scenarios at the boundary that owns it.
+
+### F11. Strict wire validation is not fully mutation-provable
+
+The named malformed cases leave accepted contract violations that the plan calls fail-closed.
+
+The contract requires a 43-character unpadded base64url token and lowercase Version 4 universally unique identifiers for Core-assigned binding and turn identifiers (contract lines 25–40 and 311–315). U1 names token length, empty-token, type, and schema cases but no invalid base64url alphabet/padding case and no malformed, uppercase, or wrong-version Core identifier case (plan lines 432–464).
+
+Required disposition: add explicit malformed fixtures for those contract literals and assert that no presence or rendering request follows. The tests should also mutate each guard once so a relaxed validator is observed failing before restoration.
+
+### F12. The requirements pin is a moving branch URL
+
+The plan's requirement source cannot be reconstructed from the links it records.
+
+Frontmatter and the namespace note link to `.../blob/main/docs/brainstorms/2026-08-26-auralis-v1-requirements.md` while saying the document is pinned at `b49de1b` (plan lines 1–6 and 41–46). The unattended-decisions log repeats that the URL is pinned even though `main` can move (lines 774–776).
+
+Required disposition: replace the moving links with an immutable commit permalink and preserve the exact source revision in the acceptance evidence. This does not require an `infiquetra/auralis` edit.
+
+## Unresolved work question
+
+One cross-slice answer is required before implementation can proceed: which already-owned C10/C5 mechanism receives the Stop hook's exact full written response and changes the captured `(binding_id, turn_id)` to `fallback_accepted` after an R121 rejection receives no replacement? The reviewed five-route contract names no such adapter handoff, and the plan must not invent one or silently substitute a local JSON label.
+
+## Verification evidence
+
+The current worktree's repository checker passes, but that result is not reproducible from the reviewed commit because the excluded bridge file masks the broken tracked link.
+
+| check | result |
+|-------|--------|
+| target and contract read completely | pass |
+| target tracked and unchanged during review | pass; blob `999de8ab157ca3e6288e6d2fae0a3c83367f7d62` |
+| contract available in reviewed Git revision | fail; `git show HEAD:docs/bridge-v1-from-c10.md` exits 128 |
+| local contract integrity for this review | pass; read-only file, SHA-256 `eb47d141e5c1b87bae0bd1c0799386a3aa8806635251db14fc806469b5db19eb` |
+| `PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_repo.py` in the populated worktree | pass; limited by the excluded local file above |
+| the same repository checker against a clean `git archive HEAD` | fail as predicted; three broken-link errors for `../bridge-v1-from-c10.md` |
+| `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -q` | pass; 755 tests |
+| review-artifact whitespace and repository `git diff --check` | pass |
+
+## Residual risk from limited evidence
+
+No external or live Auralis source was consulted; the operator-designated local C10 document was the sole wire authority. The review therefore does not claim that the local bytes match the current Auralis run branch beyond the supplied statement.
+
+The current plan's Claude plugin lifecycle claims were not re-researched. F6 requires the implementation to prove the declared process in the installed shape, which is the relevant readiness closure for this repository.
+
+No formal idea-, issue-, or specification-phase rubric ran because the explicit target is a single implementation plan. No external-reviewer panel was requested or dispatched.

--- a/plugins/voice/.claude-plugin/plugin.json
+++ b/plugins/voice/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "voice",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A spoken conversational loop for one explicitly bound, Herdr-managed Claude Code session. Claude installs this package root so the portable core travels with the client extension; every Claude-specific behaviour is declared out of com.infiquetra.claude/.",
   "author": {
     "name": "Infiquetra",
@@ -15,5 +15,6 @@
     "conversational-loop"
   ],
   "hooks": "./com.infiquetra.claude/hooks/hooks.json",
+  "mcpServers": "./com.infiquetra.claude/mcp/servers.json",
   "skills": "./skills/"
 }

--- a/plugins/voice/README.md
+++ b/plugins/voice/README.md
@@ -20,7 +20,7 @@ the run-wide implementation plan is
 | Path | What it is |
 |---|---|
 | [`plugin.json`](plugin.json) | Agent Plugins 1.0 manifest — the portable, vendor-neutral one |
-| [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) | Claude Code packaging manifest. A different specification, required by the Claude CLI to sit at the installed package root. Holds no behaviour: it declares the hooks path into `com.infiquetra.claude/` and the portable skills directory |
+| [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) | Claude Code packaging manifest. A different specification, required by the Claude CLI to sit at the installed package root. Holds no behaviour: it declares the hooks and MCP server paths into `com.infiquetra.claude/` and the portable skills directory |
 | [`scripts/providers.py`](scripts/providers.py) | Provider declaration contract: closed egress set, declarations, named refusals |
 | [`scripts/settings.py`](scripts/settings.py) | The one settings reader: stated names, split defaults, absent never means empty |
 | [`scripts/process.py`](scripts/process.py) | Subprocess discipline: closed stdin and a deadline on every child |
@@ -32,10 +32,16 @@ the run-wide implementation plan is
 | [`scripts/deliver.py`](scripts/deliver.py) | Delivery path: transcript into the bound agent's input box unsubmitted, or a named audible refusal that holds it |
 | [`scripts/preflight.py`](scripts/preflight.py) | Preflight the declared providers, the stop keybinding, and the executables; report by name, never install or repair |
 | [`scripts/pane.py`](scripts/pane.py) | The Voice pane: the one long-running operator surface and listen-path sequencer |
-| [`scripts/voice_cli.py`](scripts/voice_cli.py) | The one command surface: `pane`, `bind`, `preflight`, `toggle`, `stop` |
+| [`scripts/voice_cli.py`](scripts/voice_cli.py) | The one command surface: `pane`, `bind`, `preflight`, `toggle`, `stop`, `policy` |
+| [`scripts/bridge_client.py`](scripts/bridge_client.py) | Bridge client for Auralis loopback HTTP bridge: discovery, presence, and rendering submission |
+| [`scripts/adapter_identity.py`](scripts/adapter_identity.py) | Three-part adapter identity resolver (`agent_session_id`, `pane_id`, `terminal_id`) |
+| [`scripts/rendering_gate.py`](scripts/rendering_gate.py) | Plain-spoken-text rendering gate: rejects Markdown/fences with named reasons (R121, R20) |
+| [`scripts/voice_policy.py`](scripts/voice_policy.py) | Voice policy and preferences store: renders instructions, consumes Brief Next Turn override (R25, R107) |
+| [`scripts/turn_record.py`](scripts/turn_record.py) | Current turn record store: locked read-apply-write transactions (`fcntl.flock`) for turn state (KTD11) |
+| [`scripts/mcp_server.py`](scripts/mcp_server.py) | Model Context Protocol (MCP) stdio server: `submit_spoken_rendering` tool and presence renewal loop (R21, KTD2, KTD8) |
 | [`skills/voice/`](skills/voice/SKILL.md) | Agent Skill: documents the CLI and the in-pane keys; adds no second command surface |
 | [`tests/`](tests/) | `unittest` suites for the scripts above, the Stop hook, and the skill entrypoint |
-| [`com.infiquetra.claude/`](com.infiquetra.claude/plugin.json) | Claude client extension directory: manifest, hook descriptor, and the Stop hook |
+| [`com.infiquetra.claude/`](com.infiquetra.claude/plugin.json) | Claude client extension directory: manifest, hook descriptor, MCP server declaration, and hooks |
 
 Claude-specific files — hooks and the client extension — never live in this
 portable core; they belong under the `com.infiquetra.claude/` client
@@ -113,6 +119,8 @@ non-sensitive.
 | `VOICE_PLAYBACK_BIN` | `/usr/bin/afplay` | Playback executable, supplied by the operator, never discovered |
 | `VOICE_STATE_DIR` | `~/.local/state/voice` | Machine-local runtime state directory |
 | `VOICE_RETENTION` | none — must be stated | Retention posture; version one accepts exactly `ephemeral` |
+| `HERDR_PANE_ID` | none — refused by name when unset | Current Herdr pane identifier (`w1:p1` or integer) for Auralis bridge adapter identity |
+| `HERDR_BIN_PATH` | none — refused by name when unset | Path to Herdr executable for resolving session and terminal identity |
 
 Retention behaviour is a stated setting rather than a silent default: the
 empty case — audio deleted after success and failure, no transcript log, no
@@ -178,6 +186,47 @@ anything are different claims, and they came apart here: the binding was
 documented before any `voice` existed on `PATH`. A probe that reported that as
 healthy would have been worse than no probe, because it retires your own
 suspicion.
+
+## Auralis bridge adapter
+
+The package also provides the Claude Code adapter for the Auralis V1
+conversational loop (capability slice C3), specified in
+[`docs/plans/2026-08-27-auralis-c3-adapter.md`](../../docs/plans/2026-08-27-auralis-c3-adapter.md).
+Auralis Core (repository `infiquetra/auralis`) exposes a loopback HTTP bridge
+governed by the five-route Auralis Bridge Contract v1 (`GET /v1/health`,
+`PUT /v1/presence`, `DELETE /v1/presence`, `GET /v1/current`, `POST /v1/rendering`).
+
+### Adapter architecture and lifecycle
+
+1. **Long-lived MCP process ([`scripts/mcp_server.py`](scripts/mcp_server.py))**:
+   The stdio Model Context Protocol (MCP) server declared in
+   [`com.infiquetra.claude/mcp/servers.json`](com.infiquetra.claude/mcp/servers.json)
+   persists for the Claude session. It runs a background presence thread that registers
+   and renews presence (`PUT /v1/presence`) on the contract lease cadence and sends
+   `DELETE /v1/presence` on clean shutdown (KTD2). It exposes the `submit_spoken_rendering`
+   tool through which the agent submits its authored spoken rendering.
+2. **Plain-spoken-text rendering gate ([`scripts/rendering_gate.py`](scripts/rendering_gate.py))**:
+   Submissions are locally validated before reaching the wire (KTD1; R121, R20). Markdown
+   formatting or fenced code blocks are rejected with named reasons (`fenced_code_block`,
+   `markdown_formatting`) and never reformatted or cleaned. Accepted plain text is
+   forwarded byte-identical to `POST /v1/rendering` using the prompt-time captured turn
+   identifiers.
+3. **Turn origin and policy injection ([`com.infiquetra.claude/hooks/user_prompt_submit_hook.py`](com.infiquetra.claude/hooks/user_prompt_submit_hook.py))**:
+   At prompt submission, the hook queries `GET /v1/current`, matches adapter identity,
+   captures `(binding_id, turn_id)` into [`scripts/turn_record.py`](scripts/turn_record.py),
+   and injects explicit context telling the agent whether the turn originated via voice,
+   that a spoken rendering is expected, and the operator's current voice policy instructions
+   rendered by [`scripts/voice_policy.py`](scripts/voice_policy.py) (including any armed
+   one-shot Brief Next Turn override, consumed on transmission; R106, R107).
+4. **PreToolUse observation ([`com.infiquetra.claude/hooks/pre_tool_use_hook.py`](com.infiquetra.claude/hooks/pre_tool_use_hook.py))**:
+   Observes tool use on voice-originated turns and appends observations to the current turn
+   record (KTD7). It is observe-only and never emits permission decisions.
+5. **Completion reconciliation ([`com.infiquetra.claude/hooks/stop_hook.py`](com.infiquetra.claude/hooks/stop_hook.py))**:
+   When the turn completes, the Stop hook reconciles the turn record: if wire-bound and an
+   authored rendering was accepted, outcome is recorded as `authored`; if the voice turn
+   completed without an accepted rendering, outcome is recorded as `fallback` (KTD6; R22,
+   R23, R122). While wire-bound, the legacy local speak path is suppressed so Auralis retains
+   sole speech custody.
 
 ## Subprocess discipline
 

--- a/plugins/voice/com.infiquetra.claude/hooks/hooks.json
+++ b/plugins/voice/com.infiquetra.claude/hooks/hooks.json
@@ -1,5 +1,27 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/com.infiquetra.claude/hooks/user_prompt_submit_hook.py\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/com.infiquetra.claude/hooks/pre_tool_use_hook.py\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/voice/com.infiquetra.claude/hooks/pre_tool_use_hook.py
+++ b/plugins/voice/com.infiquetra.claude/hooks/pre_tool_use_hook.py
@@ -1,0 +1,94 @@
+"""The Claude Code ``PreToolUse`` hook for the voice package (KTD7; X1).
+
+This hook observes tool invocations during an Auralis-originated voice turn:
+1. Reads the hook payload from standard input once (``session_id``, ``tool_name``,
+   ``tool_input``, ``tool_use_id``).
+2. Verifies that the single current-turn record exists for ``session_id`` and is
+   marked as an Auralis-originated turn (KTD7).
+3. If an allow-list is configured in the voice policy store, only tool names
+   present in the list are recorded; an empty allow-list records all tools (KTD7).
+4. Records the observation into the current turn record via ``turn_record.record_tool_observation``.
+5. Always exits 0 with no standard output on every path: observe-only, never
+   emits a permission decision, and never mutates the permission flow (KTD7).
+
+A hook must never break a turn, so every path — including malformed input,
+unavailability, and unexpected errors — exits 0.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_PACKAGE_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_PACKAGE_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_SCRIPTS))
+
+import turn_record  # noqa: E402
+import voice_policy  # noqa: E402
+
+
+def _read_payload() -> dict | None:
+    """Read the hook payload from stdin exactly once; ``None`` unless a JSON object."""
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def main() -> int:
+    try:
+        payload = _read_payload()
+        if payload is None:
+            return 0
+        session_id = payload.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            return 0
+        tool_name = payload.get("tool_name")
+        if not isinstance(tool_name, str) or not tool_name:
+            return 0
+        tool_input = payload.get("tool_input")
+        tool_use_id = payload.get("tool_use_id")
+        if not isinstance(tool_use_id, str) or not tool_use_id:
+            return 0
+
+        # Check that the active turn record is an Auralis-originated turn for this session (KTD7)
+        rec = turn_record.read_turn_record()
+        if rec is None or rec.session_id != session_id:
+            return 0
+        if rec.origin != turn_record.ORIGIN_AURALIS:
+            return 0
+
+        # Check policy tool allow-list (KTD7)
+        policy = voice_policy.read_policy()
+        if policy.tool_allowlist and tool_name not in policy.tool_allowlist:
+            return 0
+
+        # Record tool observation into the single turn record (KTD7, KTD11)
+        try:
+            turn_record.record_tool_observation(
+                session_id=session_id,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                tool_use_id=tool_use_id,
+            )
+        except Exception:
+            # On lock busy or error, drop observation and exit 0
+            return 0
+
+    except Exception:
+        # A hook must never break a turn: any failure exits 0 silently.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/voice/com.infiquetra.claude/hooks/stop_hook.py
+++ b/plugins/voice/com.infiquetra.claude/hooks/stop_hook.py
@@ -1,28 +1,26 @@
-"""The Claude Code ``Stop`` hook for the voice package.
+"""The Claude Code ``Stop`` hook for the voice package (R22, R23, R122; KTD6).
 
-Claude runs ``Stop`` hooks synchronously, so a hook that does the speaking
-itself would stall every turn settle by the length of the speech. This hook
-therefore detaches (KTD2): it reads the hook payload from standard input
-once, compares the payload's ``session_id`` against the sticky binding with
-a pure local file read, and — only when this session is the bound one —
-writes the response text to a unique payload file and starts the speak
-script as a fully detached child. If that spawn fails, it removes the
-payload it just wrote, so a failed hook never leaves an orphaned file
-behind; the speak child owns the payload on every path once it starts. It
-then exits 0 immediately. It never blocks on, waits for, or reads back from
-the child; the harness timeout in ``hooks.json`` is a backstop, not a
-budget.
+Claude runs ``Stop`` hooks synchronously.
 
-Only the bound session may speak (R3): unbound, mismatched, absent, or
-unreadable binding, or an empty ``last_assistant_message``, reads as
-silence — no spawn, no payload file, no sound. The response text comes
-only from the payload's ``last_assistant_message``; this hook never reads
-the screen or the transcript file. A hook must never break a turn, so
-every path — including malformed input and unexpected failure — exits 0.
+When this session is wire-bound to an active Auralis bridge (KTD6):
+1. Resolves adapter identity and queries the bridge via ``GET /v1/current``.
+2. When the active binding epoch matches this session's adapter identity:
+   - Suppresses the legacy local speak path (Auralis owns speech custody);
+   - Reconciles the turn record: if the captured turn reached an accepted
+     authored rendering, records outcome ``authored``; otherwise records
+     outcome ``fallback`` (R22, R23, R122; KTD6);
+   - Exits 0 immediately without spawning a detached speak child.
 
-The hook does not import the speak script, clean Markdown, or call the
-speech provider: it hands the text off by argv and file (KTD1/KTD2) and
-the speak path owns the rest.
+On any bridge doubt (discovery failure, transport error, no active binding epoch,
+or session mismatch), falls through to the legacy 0.2.1 standalone voice loop:
+- Compares ``session_id`` against the local sticky binding;
+- Only when bound, writes the response text to a unique payload file and
+  spawns ``speak.py`` as a fully detached child (KTD2);
+- If the spawn fails, cleans up the payload file;
+- Exits 0 immediately.
+
+A hook must never break a turn, so every path — including malformed input and
+unexpected errors — exits 0.
 """
 
 from __future__ import annotations
@@ -36,9 +34,12 @@ _PACKAGE_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
 if str(_PACKAGE_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_PACKAGE_SCRIPTS))
 
+import adapter_identity  # noqa: E402
 import binding  # noqa: E402
+import bridge_client  # noqa: E402
 import process  # noqa: E402
 import settings  # noqa: E402
+import turn_record  # noqa: E402
 
 #: The speak script the detached child runs, resolved from this hook file
 #: to the portable package root. The hook spawns it by argv and never
@@ -69,6 +70,46 @@ def main() -> int:
         session_id = payload.get("session_id")
         if not isinstance(session_id, str) or not session_id:
             return 0
+
+        # KTD6: Check if this session is wire-bound to an active Auralis bridge
+        is_wire_bound = False
+        try:
+            identity = adapter_identity.resolve_adapter_identity()
+            if adapter_identity.matches_session(identity, session_id):
+                # Check bridge snapshot with internal 1,000 ms budget (timeout budget table)
+                client = bridge_client.BridgeClient()
+                snapshot = client.get_current()
+                if (
+                    snapshot.binding is not None
+                    and snapshot.binding.identity == identity
+                ):
+                    is_wire_bound = True
+        except Exception:
+            # Any bridge doubt -> fall through to legacy path
+            is_wire_bound = False
+
+        if is_wire_bound:
+            # Wire-bound: reconcile turn record outcome and suppress local speech
+            try:
+                rec = turn_record.read_turn_record()
+                if rec is not None and rec.session_id == session_id:
+                    has_accepted = any(
+                        sub.get("disposition") == "accepted"
+                        for sub in rec.submissions
+                        if isinstance(sub, dict)
+                    )
+                    outcome = (
+                        turn_record.OUTCOME_AUTHORED
+                        if has_accepted
+                        else turn_record.OUTCOME_FALLBACK
+                    )
+                    turn_record.settle_outcome(session_id=session_id, outcome=outcome)
+            except Exception:
+                # On busy or error, leave outcome unsettled; still suppress speech
+                pass
+            return 0
+
+        # Legacy 0.2.1 speak path
         record = binding.read_binding()
         if record is None or record.session_id != session_id:
             return 0
@@ -83,9 +124,7 @@ def main() -> int:
             )
         except Exception:
             # The spawn failed, so no child will consume this payload: remove
-            # it so failed hooks do not accumulate orphaned files. The removal
-            # is best-effort — a failure there still reads as silence through
-            # the outer guard.
+            # it so failed hooks do not accumulate orphaned files.
             payload_path.unlink(missing_ok=True)
             return 0
     except Exception:

--- a/plugins/voice/com.infiquetra.claude/hooks/user_prompt_submit_hook.py
+++ b/plugins/voice/com.infiquetra.claude/hooks/user_prompt_submit_hook.py
@@ -1,0 +1,167 @@
+"""The Claude Code ``UserPromptSubmit`` hook for the voice package (R106, R107; KTD3, KTD4, KTD5).
+
+This hook runs on every user prompt submission in Claude Code:
+1. Reads the hook payload from standard input once to obtain ``session_id``.
+2. Resolves the three-part adapter identity (``adapter_identity.resolve_adapter_identity``)
+   and verifies that ``session_id`` matches ``agent_session_id`` (§5).
+3. Reads the active bridge state via ``GET /v1/current`` (KTD3, §6.4).
+4. Matches the binding epoch against this session's adapter identity.
+5. If the session is wire-bound:
+   - On an Auralis-originated turn (open turn matching this binding):
+     captures ``(binding_id, turn_id)`` into the single current-turn record
+     (KTD4, KTD11), consumes the armed Brief Next Turn one-shot override on
+     transmission (KTD5, R107), and injects context via
+     ``hookSpecificOutput.additionalContext`` containing the origin statement,
+     the rendering expectation, the submission tool pointer, the plain text
+     rule, and the rendered policy instructions (R106, R107).
+   - On a bound turn that did not originate via Auralis (no open turn):
+     injects the explicit negative signal ("This turn did not originate through
+     Auralis voice. No spoken rendering is expected.") and transmits no policy
+     (KTD3, R106, R107).
+6. When unbound, bridge unavailable, identity unresolvable, or on session
+   mismatch: emits no output and remains silent (KTD3).
+
+A hook must never break a turn, so every path — including malformed input,
+unavailability, and unexpected errors — exits 0.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_PACKAGE_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_PACKAGE_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_SCRIPTS))
+
+import adapter_identity  # noqa: E402
+import bridge_client  # noqa: E402
+import turn_record  # noqa: E402
+import voice_policy  # noqa: E402
+
+
+def _read_payload() -> dict | None:
+    """Read the hook payload from stdin exactly once; ``None`` unless a JSON object."""
+    try:
+        raw = sys.stdin.read()
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def main() -> int:
+    try:
+        payload = _read_payload()
+        if payload is None:
+            return 0
+        session_id = payload.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            return 0
+
+        # 1. Resolve adapter identity (§5)
+        try:
+            identity = adapter_identity.resolve_adapter_identity()
+        except Exception:
+            # Identity resolution refusal / missing setting -> silent exit
+            return 0
+
+        if not adapter_identity.matches_session(identity, session_id):
+            return 0
+
+        # 2. Query bridge GET /v1/current (§6.4)
+        try:
+            client = bridge_client.BridgeClient()
+            snapshot = client.get_current()
+        except Exception:
+            # Bridge unavailable / discovery failed / transport error -> silent exit
+            return 0
+
+        # 3. Check binding epoch match (§6.4, §8, KTD3)
+        if snapshot.binding is None or snapshot.binding.identity != identity:
+            return 0
+
+        # 4. Determine turn origin under the active binding
+        is_originated = (
+            snapshot.turn is not None
+            and snapshot.turn.state == "open"
+            and snapshot.turn.binding_id == snapshot.binding.binding_id
+        )
+
+        if is_originated:
+            assert snapshot.turn is not None
+            # Initialize turn record with captured identifiers (KTD4, KTD11)
+            try:
+                turn_record.init_turn(
+                    session_id=session_id,
+                    binding_id=snapshot.binding.binding_id,
+                    turn_id=snapshot.turn.turn_id,
+                    origin=turn_record.ORIGIN_AURALIS,
+                )
+            except turn_record.TurnRecordBusy:
+                # Timeout budget table: emit no injection and exit 0
+                return 0
+            except Exception:
+                return 0
+
+            # Consume brief_next_turn one-shot override on transmission (KTD5, R107)
+            was_brief_armed = voice_policy.consume_brief_next_turn()
+            policy_instructions = voice_policy.render_instructions(brief=was_brief_armed)
+
+            context_lines = [
+                "This turn originated through Auralis voice.",
+                "A spoken rendering is expected for this turn.",
+                "Submit your spoken rendering via the submit_spoken_rendering tool.",
+                "The rendering surface accepts plain spoken text only. Do not include Markdown formatting or fenced code blocks.",
+            ]
+            if policy_instructions:
+                context_lines.append(policy_instructions)
+            context_text = "\n\n".join(context_lines)
+
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context_text,
+                }
+            }
+            sys.stdout.write(json.dumps(output) + "\n")
+            return 0
+        else:
+            # Bound, but non-originated turn (KTD3, R106)
+            try:
+                turn_record.init_turn(
+                    session_id=session_id,
+                    binding_id=snapshot.binding.binding_id,
+                    turn_id=None,
+                    origin=turn_record.ORIGIN_NOT_ORIGINATED,
+                )
+            except Exception:
+                pass
+
+            context_text = (
+                "This turn did not originate through Auralis voice. "
+                "No spoken rendering is expected."
+            )
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "UserPromptSubmit",
+                    "additionalContext": context_text,
+                }
+            }
+            sys.stdout.write(json.dumps(output) + "\n")
+            return 0
+
+    except Exception:
+        # A hook must never break a turn: any failure exits 0 with no output.
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/voice/com.infiquetra.claude/mcp/servers.json
+++ b/plugins/voice/com.infiquetra.claude/mcp/servers.json
@@ -1,0 +1,8 @@
+{
+  "voice": {
+    "command": "python3",
+    "args": [
+      "${CLAUDE_PLUGIN_ROOT}/scripts/mcp_server.py"
+    ]
+  }
+}

--- a/plugins/voice/com.infiquetra.claude/plugin.json
+++ b/plugins/voice/com.infiquetra.claude/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "voice",
-  "version": "0.2.1",
-  "description": "Claude client extension for the voice package: the Stop hook that lets the one explicitly bound session speak its completed response through the portable voice loop.",
+  "version": "0.3.0",
+  "description": "Claude client extension for the voice package: hooks and Model Context Protocol (MCP) server for Auralis bridge integration and the spoken conversational loop.",
   "author": {
     "name": "Infiquetra",
     "email": "hello@infiquetra.com"

--- a/plugins/voice/plugin.json
+++ b/plugins/voice/plugin.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "voice",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Portable voice package: a spoken conversational loop for one explicitly bound, Herdr-managed Claude Code session. The bound session speaks its completed response, the operator answers by voice, and the transcript lands editable and unsubmitted in that same session's input box. The portable core carries the provider declaration contract, the stated settings surface, and the subprocess discipline; Claude-specific files live under the com.infiquetra.claude client extension directory."
 }

--- a/plugins/voice/scripts/adapter_identity.py
+++ b/plugins/voice/scripts/adapter_identity.py
@@ -1,0 +1,196 @@
+"""Complete adapter identity resolver (portable core; §5).
+
+This module implements the C3 adapter identity discovery rule defined in
+Section 5 of the Auralis Bridge Contract v1:
+
+1. Reads ``HERDR_PANE_ID`` from its process environment via ``settings.py``.
+2. Executes the ``HERDR_BIN_PATH`` executable with arguments ``agent``, ``list``
+   under the package subprocess discipline (``process.run``) with a 2,000 ms
+   deadline.
+3. Verifies that the JSON envelope contains ``result.type == "agent_list"``.
+4. Finds exactly one record in ``result.agents`` where ``pane_id == HERDR_PANE_ID``.
+5. Copies that record's non-empty ``agent_session.value`` as ``agent_session_id``,
+   that record's ``pane_id`` as ``pane_id``, and that record's ``terminal_id`` as
+   ``terminal_id``.
+6. Any Claude hook or agent request carrying Claude's session identifier must
+   match ``agent_session_id``.
+7. The adapter must never copy identity from ``GET /v1/current``.
+
+A missing environment value, missing executable, command or envelope failure,
+zero or multiple matches, a missing component, or a session mismatch means the
+adapter registers and submits nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import process
+import settings
+
+__all__ = [
+    "AdapterIdentity",
+    "IdentityRefusal",
+    "HERDR_TIMEOUT_SECONDS",
+    "resolve_adapter_identity",
+    "matches_session",
+]
+
+#: The normative Herdr subprocess deadline from the timeout budget table (2,000 ms).
+HERDR_TIMEOUT_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class AdapterIdentity:
+    """The three-part complete adapter identity (§5)."""
+
+    agent_session_id: str
+    pane_id: str
+    terminal_id: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "agent_session_id": self.agent_session_id,
+            "pane_id": self.pane_id,
+            "terminal_id": self.terminal_id,
+        }
+
+    def to_payload(self) -> dict[str, str]:
+        return self.to_dict()
+
+
+class IdentityRefusal(Exception):
+    """A named refusal for identity resolution (§5)."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"adapter identity refused: {reason}")
+
+
+def matches_session(identity: AdapterIdentity, session_id: str) -> bool:
+    """Return whether a Claude session id matches the adapter's agent_session_id (§5)."""
+    if not isinstance(session_id, str):
+        return False
+    return identity.agent_session_id == session_id
+
+
+def _extract_component(record: dict, key: str) -> str:
+    """Extract a non-empty string component from a record dict."""
+    val = record.get(key)
+    if not isinstance(val, str):
+        raise IdentityRefusal(
+            f"record field {key!r} must be a string, got {type(val).__name__}"
+        )
+    val = val.strip()
+    if not val:
+        raise IdentityRefusal(f"record field {key!r} is empty")
+    return val
+
+
+def resolve_adapter_identity(
+    *,
+    run_process: Callable = process.run,
+    pane_id_resolver: Callable[[], str] = settings.herdr_pane_id,
+    bin_path_resolver: Callable[[], str] = settings.herdr_bin_path,
+) -> AdapterIdentity:
+    """Resolve the three-part adapter identity from Herdr (§5).
+
+    Reads ``HERDR_PANE_ID`` and ``HERDR_BIN_PATH`` through ``settings.py``,
+    runs ``herdr agent list``, parses the envelope, matches the pane, and
+    constructs the validated ``AdapterIdentity``.
+
+    Any failure produces an ``IdentityRefusal`` named refusal.
+    """
+    try:
+        target_pane_id = pane_id_resolver()
+    except settings.SettingsRefusal as refusal:
+        raise IdentityRefusal(
+            f"cannot resolve pane id: {refusal.name} {refusal.reason}"
+        ) from refusal
+
+    try:
+        bin_path = bin_path_resolver()
+    except settings.SettingsRefusal as refusal:
+        raise IdentityRefusal(
+            f"cannot resolve Herdr executable: {refusal.name} {refusal.reason}"
+        ) from refusal
+
+    command = [bin_path, "agent", "list"]
+    try:
+        completed = run_process(
+            command,
+            timeout=HERDR_TIMEOUT_SECONDS,
+            check=True,
+        )
+    except subprocess.TimeoutExpired as expired:
+        raise IdentityRefusal(
+            f"Herdr command timed out after {HERDR_TIMEOUT_SECONDS}s: {expired}"
+        ) from expired
+    except (subprocess.CalledProcessError, FileNotFoundError, PermissionError, OSError) as err:
+        raise IdentityRefusal(f"Herdr command failed: {err}") from err
+
+    stdout_text = completed.stdout if hasattr(completed, "stdout") else str(completed)
+    try:
+        envelope = json.loads(stdout_text)
+    except (json.JSONDecodeError, TypeError) as err:
+        raise IdentityRefusal(f"Herdr output is not valid JSON: {err}") from err
+
+    if not isinstance(envelope, dict):
+        raise IdentityRefusal("Herdr output envelope is not a JSON object")
+
+    result = envelope.get("result")
+    if not isinstance(result, dict):
+        raise IdentityRefusal(
+            f"Herdr envelope 'result' is not a JSON object, got {type(result).__name__}"
+        )
+
+    if result.get("type") != "agent_list":
+        raise IdentityRefusal(
+            f"Herdr envelope result.type is {result.get('type')!r}, expected 'agent_list'"
+        )
+
+    agents = result.get("agents")
+    if not isinstance(agents, list):
+        raise IdentityRefusal("Herdr envelope result.agents is not a list")
+
+    matching = [
+        agent
+        for agent in agents
+        if isinstance(agent, dict) and agent.get("pane_id") == target_pane_id
+    ]
+
+    if not matching:
+        raise IdentityRefusal(f"no agent matching pane_id {target_pane_id!r}")
+    if len(matching) > 1:
+        raise IdentityRefusal(
+            f"multiple ({len(matching)}) agents matching pane_id {target_pane_id!r}"
+        )
+
+    record = matching[0]
+
+    agent_session = record.get("agent_session")
+    if not isinstance(agent_session, dict):
+        raise IdentityRefusal(
+            f"record 'agent_session' must be an object, got {type(agent_session).__name__}"
+        )
+
+    agent_session_id = agent_session.get("value")
+    if not isinstance(agent_session_id, str):
+        raise IdentityRefusal(
+            f"record agent_session.value must be a string, got {type(agent_session_id).__name__}"
+        )
+    agent_session_id = agent_session_id.strip()
+    if not agent_session_id:
+        raise IdentityRefusal("record agent_session.value is empty")
+
+    pane_id = _extract_component(record, "pane_id")
+    terminal_id = _extract_component(record, "terminal_id")
+
+    return AdapterIdentity(
+        agent_session_id=agent_session_id,
+        pane_id=pane_id,
+        terminal_id=terminal_id,
+    )

--- a/plugins/voice/scripts/bridge_client.py
+++ b/plugins/voice/scripts/bridge_client.py
@@ -1,0 +1,705 @@
+"""Bridge wire client for the Auralis Local Bridge v1 (portable core; §2–§8).
+
+Implements the five frozen routes, discovery, authentication, timeout budget,
+identifier grammar validation, transport error mapping, and retry/lost-response
+reconciliation for the Auralis Bridge Contract v1.
+
+Standard library only: ``http.client``, ``json``, ``time``, ``os``, ``re``.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import re
+import socket
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from adapter_identity import AdapterIdentity
+
+__all__ = [
+    "BridgeConnection",
+    "HealthResponse",
+    "PresenceResponse",
+    "PresenceDeleteResponse",
+    "BindingEpoch",
+    "TurnSnapshot",
+    "CurrentSnapshot",
+    "RenderingResponse",
+    "BridgeError",
+    "BridgeUnavailable",
+    "BridgeUnauthorized",
+    "BridgeTransportError",
+    "DEFAULT_BRIDGE_FILE",
+    "CONNECT_TIMEOUT_SECONDS",
+    "HEALTH_TIMEOUT_SECONDS",
+    "CURRENT_TIMEOUT_SECONDS",
+    "PRESENCE_TIMEOUT_SECONDS",
+    "RENDERING_TIMEOUT_SECONDS",
+    "read_discovery",
+    "BridgeClient",
+]
+
+DEFAULT_BRIDGE_FILE = Path("~/Library/Application Support/Auralis/bridge.json")
+
+# Timeout budget table constants (seconds)
+CONNECT_TIMEOUT_SECONDS = 0.250
+HEALTH_TIMEOUT_SECONDS = 1.000
+CURRENT_TIMEOUT_SECONDS = 1.000
+PRESENCE_TIMEOUT_SECONDS = 2.000
+RENDERING_TIMEOUT_SECONDS = 2.000
+
+_TOKEN_REGEX = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_UUID_V4_REGEX = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+_VALID_TURN_STATES = {"open", "authored_accepted", "fallback_accepted", "canceled"}
+_VALID_REJECTION_REASONS = {
+    "no_binding",
+    "binding_not_current",
+    "adapter_not_bound",
+    "turn_not_current",
+    "turn_canceled",
+    "fallback_already_began",
+    "duplicate_rendering",
+    "empty_rendering",
+}
+_VALID_ERROR_CODES = {
+    "invalid_json",
+    "invalid_request",
+    "unsupported_schema",
+    "unauthorized",
+    "not_found",
+    "method_not_allowed",
+    "body_too_large",
+    "unsupported_media_type",
+    "internal_error",
+}
+
+
+class BridgeError(Exception):
+    """Base exception for all bridge operations."""
+
+
+class BridgeUnavailable(BridgeError):
+    """The bridge is unavailable (discovery failed, connection refused, or unreadable)."""
+
+
+class BridgeUnauthorized(BridgeError):
+    """The bridge returned 401 Unauthorized (credentials invalid or rotated)."""
+
+
+class BridgeTransportError(BridgeError):
+    """A transport or contract-level protocol error occurred."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.error_code = error_code
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class BridgeConnection:
+    """Connection parameters discovered from bridge.json (§2)."""
+
+    host: str
+    port: int
+    token: str
+    schema: int = 1
+
+
+@dataclass(frozen=True)
+class HealthResponse:
+    """Response from GET /v1/health (§6.1)."""
+
+    service: str
+    status: str
+    schema: int = 1
+
+
+@dataclass(frozen=True)
+class PresenceResponse:
+    """Response from PUT /v1/presence (§6.2)."""
+
+    disposition: str
+    lease_ms: int
+    renew_after_ms: int
+    schema: int = 1
+
+
+@dataclass(frozen=True)
+class PresenceDeleteResponse:
+    """Response from DELETE /v1/presence (§6.3)."""
+
+    disposition: str
+    schema: int = 1
+
+
+@dataclass(frozen=True)
+class BindingEpoch:
+    """An active binding epoch from GET /v1/current (§6.4)."""
+
+    binding_id: str
+    identity: AdapterIdentity
+
+
+@dataclass(frozen=True)
+class TurnSnapshot:
+    """An active turn snapshot from GET /v1/current (§6.4)."""
+
+    turn_id: str
+    binding_id: str
+    state: str
+
+
+@dataclass(frozen=True)
+class CurrentSnapshot:
+    """Response from GET /v1/current (§6.4)."""
+
+    binding: BindingEpoch | None
+    turn: TurnSnapshot | None
+    schema: int = 1
+
+
+@dataclass(frozen=True)
+class RenderingResponse:
+    """Response from POST /v1/rendering (§6.5)."""
+
+    disposition: str  # "accepted" or "rejected"
+    binding_id: str
+    turn_id: str
+    reason: str | None = None
+    detail: str | None = None
+
+
+def read_discovery(bridge_file: Path | str | None = None) -> BridgeConnection:
+    """Read and strictly validate the discovery bridge.json file (§2).
+
+    Must have file mode 0600, exact 4 keys (schema, host, port, token),
+    schema=1, host='127.0.0.1', valid TCP port, and 43-character unpadded
+    base64url token. Any deviation raises BridgeUnavailable.
+    """
+    path = Path(bridge_file).expanduser() if bridge_file is not None else DEFAULT_BRIDGE_FILE.expanduser()
+
+    if not path.exists():
+        raise BridgeUnavailable(f"bridge.json does not exist: {path}")
+
+    try:
+        st = path.stat()
+    except OSError as err:
+        raise BridgeUnavailable(f"cannot stat bridge.json: {err}") from err
+
+    # Permissions check: mode 0600 (owner read/write only)
+    if (st.st_mode & 0o777) != 0o600:
+        raise BridgeUnavailable(
+            f"bridge.json file mode is {oct(st.st_mode & 0o777)}, expected 0600"
+        )
+
+    try:
+        content = path.read_text(encoding="utf-8")
+        data = json.loads(content)
+    except Exception as err:
+        raise BridgeUnavailable(f"cannot read or parse bridge.json: {err}") from err
+
+    if not isinstance(data, dict):
+        raise BridgeUnavailable("bridge.json content is not a JSON object")
+
+    expected_keys = {"schema", "host", "port", "token"}
+    if set(data.keys()) != expected_keys:
+        raise BridgeUnavailable(
+            f"bridge.json keys {set(data.keys())} do not match exact required keys {expected_keys}"
+        )
+
+    schema_val = data.get("schema")
+    if type(schema_val) is not int or schema_val != 1:
+        raise BridgeUnavailable(f"bridge.json schema must be integer 1, got {schema_val!r}")
+
+    host_val = data.get("host")
+    if host_val != "127.0.0.1":
+        raise BridgeUnavailable(f"bridge.json host must be '127.0.0.1', got {host_val!r}")
+
+    port_val = data.get("port")
+    if type(port_val) is not int or not (1 <= port_val <= 65535):
+        raise BridgeUnavailable(f"bridge.json port must be integer 1..65535, got {port_val!r}")
+
+    token_val = data.get("token")
+    if not isinstance(token_val, str) or not _TOKEN_REGEX.fullmatch(token_val):
+        raise BridgeUnavailable(
+            "bridge.json token must be exactly 43 unpadded base64url characters"
+        )
+
+    return BridgeConnection(
+        host=host_val,
+        port=port_val,
+        token=token_val,
+        schema=1,
+    )
+
+
+def _validate_uuid_v4(val: Any, field_name: str) -> str:
+    """Validate that val is a lowercase UUIDv4 string (§8)."""
+    if not isinstance(val, str):
+        raise BridgeUnavailable(f"{field_name} must be a string, got {type(val).__name__}")
+    if val != val.lower():
+        raise BridgeUnavailable(f"{field_name} must be lowercase UUIDv4, got {val!r}")
+    if not _UUID_V4_REGEX.fullmatch(val):
+        raise BridgeUnavailable(f"{field_name} is not a valid UUIDv4 string, got {val!r}")
+    return val
+
+
+class BridgeClient:
+    """The HTTP client for Auralis Local Bridge v1 (§4–§8)."""
+
+    def __init__(
+        self,
+        bridge_file: Path | str | None = None,
+        connection: BridgeConnection | None = None,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.bridge_file = bridge_file
+        self._connection = connection
+        self.clock = clock
+
+    def get_connection(self) -> BridgeConnection:
+        """Resolve or return the cached BridgeConnection."""
+        if self._connection is None:
+            self._connection = read_discovery(self.bridge_file)
+        return self._connection
+
+    def reset_connection(self) -> None:
+        """Clear cached connection to force re-discovery."""
+        self._connection = None
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body_dict: dict[str, Any] | None,
+        timeout_budget: float,
+        conn: BridgeConnection,
+    ) -> tuple[int, dict[str, Any]]:
+        """Perform one HTTP request under monotonic clock deadline discipline."""
+        start_time = self.clock()
+        deadline = start_time + timeout_budget
+
+        def remaining() -> float:
+            rem = deadline - self.clock()
+            if rem <= 0:
+                raise BridgeTransportError(
+                    f"operation timed out on deadline ({timeout_budget}s budget)",
+                    error_code="transport_error",
+                )
+            return rem
+
+        headers = {
+            "Authorization": f"Bearer {conn.token}",
+        }
+
+        body_bytes = b""
+        if body_dict is not None:
+            headers["Content-Type"] = "application/json; charset=utf-8"
+            body_bytes = json.dumps(body_dict).encode("utf-8")
+            headers["Content-Length"] = str(len(body_bytes))
+
+        # Use connect timeout for initial socket connection if within remaining budget
+        initial_timeout = min(CONNECT_TIMEOUT_SECONDS, remaining())
+
+        try:
+            http_conn = http.client.HTTPConnection(
+                conn.host,
+                conn.port,
+                timeout=initial_timeout,
+            )
+            # Connect explicitly
+            http_conn.connect()
+            # Reset timeout to remaining total deadline
+            http_conn.sock.settimeout(remaining())
+
+            http_conn.request(method, path, body=body_bytes if body_bytes else None, headers=headers)
+
+            http_conn.sock.settimeout(remaining())
+            response = http_conn.getresponse()
+            status = response.status
+            raw_resp_body = response.read()
+            http_conn.close()
+        except (socket.timeout, TimeoutError) as err:
+            raise BridgeTransportError(
+                f"operation timed out on deadline ({timeout_budget}s): {err}",
+                error_code="transport_error",
+            ) from err
+        except (ConnectionRefusedError, ConnectionResetError, BrokenPipeError, socket.error, OSError) as err:
+            raise BridgeTransportError(
+                f"transport error during {method} {path}: {err}",
+                error_code="transport_error",
+            ) from err
+
+        try:
+            resp_json = json.loads(raw_resp_body.decode("utf-8"))
+        except Exception as err:
+            raise BridgeTransportError(
+                f"malformed JSON in response from {method} {path} (status {status}): {err}",
+                status_code=status,
+                error_code="invalid_json",
+            ) from err
+
+        if not isinstance(resp_json, dict):
+            raise BridgeTransportError(
+                f"response from {method} {path} is not a JSON object",
+                status_code=status,
+            )
+
+        return status, resp_json
+
+    def get_health(self) -> HealthResponse:
+        """Call GET /v1/health (§6.1)."""
+        conn = self.get_connection()
+        status, data = self._request(
+            "GET",
+            "/v1/health",
+            None,
+            HEALTH_TIMEOUT_SECONDS,
+            conn,
+        )
+        if status == 401:
+            self.reset_connection()
+            raise BridgeUnauthorized("unauthorized health check")
+        if status != 200:
+            err_code = data.get("error", "unknown_error")
+            raise BridgeTransportError(
+                f"health check returned status {status}: {err_code}",
+                status_code=status,
+                error_code=err_code,
+            )
+
+        service = data.get("service")
+        st = data.get("status")
+        if not isinstance(service, str) or not isinstance(st, str):
+            raise BridgeTransportError("health check missing required string fields")
+
+        return HealthResponse(service=service, status=st, schema=data.get("schema", 1))
+
+    def put_presence(self, identity: AdapterIdentity) -> PresenceResponse:
+        """Call PUT /v1/presence (§6.2)."""
+        conn = self.get_connection()
+        body = {
+            "schema": 1,
+            "identity": identity.to_dict(),
+        }
+        status, data = self._request(
+            "PUT",
+            "/v1/presence",
+            body,
+            PRESENCE_TIMEOUT_SECONDS,
+            conn,
+        )
+        if status == 401:
+            self.reset_connection()
+            raise BridgeUnauthorized("unauthorized presence registration")
+        if status != 200:
+            err_code = data.get("error", "unknown_error")
+            raise BridgeTransportError(
+                f"presence PUT returned status {status}: {err_code}",
+                status_code=status,
+                error_code=err_code,
+            )
+
+        disposition = data.get("disposition")
+        lease_ms = data.get("lease_ms")
+        renew_after_ms = data.get("renew_after_ms")
+
+        if not isinstance(disposition, str) or type(lease_ms) is not int or type(renew_after_ms) is not int:
+            raise BridgeTransportError("presence response missing or invalid required fields")
+
+        return PresenceResponse(
+            disposition=disposition,
+            lease_ms=lease_ms,
+            renew_after_ms=renew_after_ms,
+            schema=data.get("schema", 1),
+        )
+
+    def delete_presence(self, identity: AdapterIdentity) -> PresenceDeleteResponse:
+        """Call DELETE /v1/presence (§6.3)."""
+        conn = self.get_connection()
+        body = {
+            "schema": 1,
+            "identity": identity.to_dict(),
+        }
+        status, data = self._request(
+            "DELETE",
+            "/v1/presence",
+            body,
+            PRESENCE_TIMEOUT_SECONDS,
+            conn,
+        )
+        if status == 401:
+            self.reset_connection()
+            raise BridgeUnauthorized("unauthorized presence deletion")
+        if status != 200:
+            err_code = data.get("error", "unknown_error")
+            raise BridgeTransportError(
+                f"presence DELETE returned status {status}: {err_code}",
+                status_code=status,
+                error_code=err_code,
+            )
+
+        disposition = data.get("disposition")
+        if not isinstance(disposition, str):
+            raise BridgeTransportError("presence DELETE response missing disposition")
+
+        return PresenceDeleteResponse(disposition=disposition, schema=data.get("schema", 1))
+
+    def get_current(self) -> CurrentSnapshot:
+        """Call GET /v1/current and validate identifier grammar (§6.4, §8)."""
+        conn = self.get_connection()
+        status, data = self._request(
+            "GET",
+            "/v1/current",
+            None,
+            CURRENT_TIMEOUT_SECONDS,
+            conn,
+        )
+        if status == 401:
+            self.reset_connection()
+            raise BridgeUnauthorized("unauthorized current snapshot read")
+        if status != 200:
+            err_code = data.get("error", "unknown_error")
+            raise BridgeTransportError(
+                f"current GET returned status {status}: {err_code}",
+                status_code=status,
+                error_code=err_code,
+            )
+
+        binding_raw = data.get("binding")
+        turn_raw = data.get("turn")
+
+        binding_epoch: BindingEpoch | None = None
+        if binding_raw is not None:
+            if not isinstance(binding_raw, dict):
+                raise BridgeUnavailable("binding in current snapshot is not an object")
+            b_id = _validate_uuid_v4(binding_raw.get("binding_id"), "binding_id")
+            id_dict = binding_raw.get("identity")
+            if not isinstance(id_dict, dict):
+                raise BridgeUnavailable("identity in binding snapshot is not an object")
+            sess_id = id_dict.get("agent_session_id")
+            p_id = id_dict.get("pane_id")
+            t_id = id_dict.get("terminal_id")
+            if not isinstance(sess_id, str) or not isinstance(p_id, str) or not isinstance(t_id, str):
+                raise BridgeUnavailable("identity in binding snapshot has missing or non-string components")
+            binding_epoch = BindingEpoch(
+                binding_id=b_id,
+                identity=AdapterIdentity(
+                    agent_session_id=sess_id,
+                    pane_id=p_id,
+                    terminal_id=t_id,
+                ),
+            )
+
+        turn_snapshot: TurnSnapshot | None = None
+        if turn_raw is not None:
+            if binding_epoch is None:
+                raise BridgeUnavailable("turn is present when binding is null in current snapshot")
+            if not isinstance(turn_raw, dict):
+                raise BridgeUnavailable("turn in current snapshot is not an object")
+            t_id = _validate_uuid_v4(turn_raw.get("turn_id"), "turn_id")
+            t_b_id = _validate_uuid_v4(turn_raw.get("binding_id"), "turn.binding_id")
+            state = turn_raw.get("state")
+            if state not in _VALID_TURN_STATES:
+                raise BridgeUnavailable(f"turn state {state!r} is not one of {_VALID_TURN_STATES}")
+            turn_snapshot = TurnSnapshot(
+                turn_id=t_id,
+                binding_id=t_b_id,
+                state=state,
+            )
+
+        return CurrentSnapshot(
+            binding=binding_epoch,
+            turn=turn_snapshot,
+            schema=data.get("schema", 1),
+        )
+
+    def submit_rendering(
+        self,
+        identity: AdapterIdentity,
+        binding_id: str,
+        turn_id: str,
+        text: str,
+    ) -> RenderingResponse:
+        """Call POST /v1/rendering with retry & lost-response reconciliation (§6.5, §8)."""
+        conn = self.get_connection()
+        body = {
+            "schema": 1,
+            "identity": identity.to_dict(),
+            "binding_id": binding_id,
+            "turn_id": turn_id,
+            "text": text,
+        }
+
+        # Attempt 1
+        server_error_500 = False
+        lost_response = False
+        status = 0
+        data: dict[str, Any] = {}
+
+        try:
+            status, data = self._request(
+                "POST",
+                "/v1/rendering",
+                body,
+                RENDERING_TIMEOUT_SECONDS,
+                conn,
+            )
+        except BridgeTransportError as err:
+            if err.status_code == 500:
+                server_error_500 = True
+            elif err.status_code is not None:
+                # Received an HTTP response with a status code (e.g. 4xx client error, invalid JSON).
+                # Section 8: 4xx Client Errors must not be retried without correcting the request or contract violation.
+                raise
+            else:
+                # No response status received: transport error / network failure before response -> lost response
+                lost_response = True
+
+        if not (server_error_500 or lost_response):
+            if status == 200:
+                return self._parse_rendering_200(data, is_retry=False)
+            if status == 401:
+                self.reset_connection()
+                raise BridgeUnauthorized("unauthorized rendering submission")
+            if status == 500:
+                server_error_500 = True
+            else:
+                # 4xx client error or other status (§8: must not be retried)
+                err_code = data.get("error", "unknown_error")
+                raise BridgeTransportError(
+                    f"rendering submission rejected: status {status}, code {err_code}",
+                    status_code=status,
+                    error_code=err_code,
+                )
+
+        # Retry logic per §8
+        if server_error_500:
+            # Confirm health first per §8
+            try:
+                health = self.get_health()
+                if health.status != "ok":
+                    raise BridgeTransportError(
+                        f"500 Internal Error and health check reported status {health.status!r}",
+                        status_code=500,
+                        error_code="internal_error",
+                    )
+            except Exception as health_err:
+                raise BridgeTransportError(
+                    f"500 Internal Error and health check failed: {health_err}",
+                    status_code=500,
+                    error_code="internal_error",
+                ) from health_err
+
+            # One byte-identical retry
+            try:
+                status, data = self._request(
+                    "POST",
+                    "/v1/rendering",
+                    body,
+                    RENDERING_TIMEOUT_SECONDS,
+                    conn,
+                )
+            except BridgeTransportError as retry_err:
+                raise BridgeTransportError(
+                    f"rendering retry after 500 failed: {retry_err}",
+                    status_code=retry_err.status_code or 500,
+                    error_code=retry_err.error_code or "internal_error",
+                ) from retry_err
+
+            if status == 200:
+                return self._parse_rendering_200(data, is_retry=False)
+            if status == 401:
+                self.reset_connection()
+                raise BridgeUnauthorized("unauthorized rendering submission on retry")
+            err_code = data.get("error", "unknown_error")
+            raise BridgeTransportError(
+                f"rendering retry after 500 failed with status {status}: {err_code}",
+                status_code=status,
+                error_code=err_code,
+            )
+
+        if lost_response:
+            # Single byte-equivalent retry for lost rendering response (§8; F8)
+            try:
+                status, data = self._request(
+                    "POST",
+                    "/v1/rendering",
+                    body,
+                    RENDERING_TIMEOUT_SECONDS,
+                    conn,
+                )
+            except BridgeTransportError as retry_err:
+                raise BridgeTransportError(
+                    f"rendering submission failed and retry also failed: {retry_err}",
+                    status_code=retry_err.status_code,
+                    error_code=retry_err.error_code or "transport_error",
+                ) from retry_err
+
+            if status == 200:
+                return self._parse_rendering_200(data, is_retry=True)
+            if status == 401:
+                self.reset_connection()
+                raise BridgeUnauthorized("unauthorized rendering submission on retry")
+            err_code = data.get("error", "unknown_error")
+            raise BridgeTransportError(
+                f"rendering retry after lost response failed with status {status}: {err_code}",
+                status_code=status,
+                error_code=err_code,
+            )
+
+        raise BridgeTransportError("unexpected rendering submission state")
+
+    def _parse_rendering_200(self, data: dict[str, Any], *, is_retry: bool) -> RenderingResponse:
+        b_id = data.get("binding_id")
+        t_id = data.get("turn_id")
+        disp = data.get("disposition")
+        reason = data.get("reason")
+
+        if not isinstance(b_id, str) or not isinstance(t_id, str) or not isinstance(disp, str):
+            raise BridgeTransportError("rendering response missing required fields")
+
+        if disp == "accepted":
+            return RenderingResponse(
+                disposition="accepted",
+                binding_id=b_id,
+                turn_id=t_id,
+                detail="accepted",
+            )
+        elif disp == "rejected":
+            if reason not in _VALID_REJECTION_REASONS:
+                raise BridgeTransportError(f"unknown rendering rejection reason: {reason!r}")
+
+            # Lost-response reconciliation (F8 / §8):
+            if is_retry and reason == "duplicate_rendering":
+                return RenderingResponse(
+                    disposition="accepted",
+                    binding_id=b_id,
+                    turn_id=t_id,
+                    detail="accepted_on_retry",
+                )
+
+            return RenderingResponse(
+                disposition="rejected",
+                binding_id=b_id,
+                turn_id=t_id,
+                reason=reason,
+            )
+        else:
+            raise BridgeTransportError(f"unknown rendering disposition: {disp!r}")

--- a/plugins/voice/scripts/mcp_server.py
+++ b/plugins/voice/scripts/mcp_server.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""MCP stdio server exposing submit_spoken_rendering and presence lifecycle (U3; R20, R21, R121, R122; KTD1, KTD2, KTD4, KTD8, KTD11).
+
+This module implements the adapter's long-lived Model Context Protocol (MCP)
+stdio server in the Claude Code process space:
+1. Exposes the single `submit_spoken_rendering` tool with a closed `{text: string}`
+   input schema over newline-delimited JSON-RPC 2.0 stdio framing (KTD8);
+2. Evaluates candidate rendering text against the R121 plain-spoken-text gate
+   before anything reaches the wire (KTD1);
+3. Forwards plain text byte-identical to `POST /v1/rendering` using the
+   prompt-time captured identifier pair from the turn record (R20, KTD4);
+4. Relays Core's adjudication vocabulary verbatim, including lost-response
+   reconciliation (KTD1, §8);
+5. Writes all submissions and dispositions to the turn record through
+   `turn_record.mutate` (KTD11);
+6. Runs the background presence registration and renewal lifecycle over
+   `PUT /v1/presence` and `DELETE /v1/presence` (KTD2).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+_PACKAGE_SCRIPTS = Path(__file__).resolve().parent
+if str(_PACKAGE_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_PACKAGE_SCRIPTS))
+
+import adapter_identity
+import bridge_client
+import rendering_gate
+import turn_record
+from adapter_identity import AdapterIdentity, IdentityRefusal, resolve_adapter_identity
+from bridge_client import (
+    BridgeClient,
+    BridgeError,
+    BridgeTransportError,
+    BridgeUnauthorized,
+    BridgeUnavailable,
+    RenderingResponse,
+)
+from turn_record import (
+    TurnRecord,
+    TurnRecordBusy,
+    TurnRecordSessionMismatch,
+    mutate,
+    read_turn_record,
+    record_submission,
+)
+
+__all__ = [
+    "MCPServer",
+    "PresenceWorker",
+    "main",
+    "run_server",
+]
+
+
+class PresenceWorker:
+    """Background worker managing presence registration, lease renewal, and deletion (KTD2; §6.2, §6.3)."""
+
+    def __init__(
+        self,
+        bridge_client_instance: BridgeClient | None = None,
+        identity_resolver: Callable[[], AdapterIdentity] = resolve_adapter_identity,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.bridge_client = bridge_client_instance or BridgeClient()
+        self.identity_resolver = identity_resolver
+        self.clock = clock
+        self.sleep = sleep
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self.registered_identity: AdapterIdentity | None = None
+        self.registration_count = 0
+        self.renewal_count = 0
+
+    def start(self) -> PresenceWorker:
+        """Start the presence background thread."""
+        if self._thread is None:
+            self._stop_event.clear()
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        return self
+
+    def stop(self, timeout: float = 2.0) -> None:
+        """Signal the presence loop to stop and perform best-effort DELETE /v1/presence."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+        else:
+            self.delete_presence()
+
+    def tick(self) -> bool:
+        """Perform one synchronous registration/renewal iteration (for testing)."""
+        try:
+            identity = self.identity_resolver()
+        except IdentityRefusal:
+            self.registered_identity = None
+            self.bridge_client.reset_connection()
+            return False
+
+        try:
+            resp = self.bridge_client.put_presence(identity)
+            if self.registered_identity != identity:
+                self.registered_identity = identity
+                self.registration_count += 1
+            else:
+                self.renewal_count += 1
+            return True
+        except BridgeUnauthorized:
+            self.registered_identity = None
+            self.bridge_client.reset_connection()
+            return False
+        except (BridgeUnavailable, BridgeTransportError, BridgeError, OSError):
+            self.registered_identity = None
+            self.bridge_client.reset_connection()
+            return False
+        except Exception:
+            self.registered_identity = None
+            self.bridge_client.reset_connection()
+            return False
+
+    def delete_presence(self) -> bool:
+        """Send best-effort DELETE /v1/presence on shutdown."""
+        if self.registered_identity is not None:
+            try:
+                self.bridge_client.delete_presence(self.registered_identity)
+                self.registered_identity = None
+                return True
+            except Exception:
+                return False
+        return False
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                identity = self.identity_resolver()
+            except IdentityRefusal:
+                self.registered_identity = None
+                self.bridge_client.reset_connection()
+                if self._stop_event.wait(1.0):
+                    break
+                continue
+
+            try:
+                resp = self.bridge_client.put_presence(identity)
+                if self.registered_identity != identity:
+                    self.registered_identity = identity
+                    self.registration_count += 1
+                else:
+                    self.renewal_count += 1
+
+                renew_seconds = max(0.05, resp.renew_after_ms / 1000.0)
+                if self._stop_event.wait(renew_seconds):
+                    break
+            except BridgeUnauthorized:
+                self.registered_identity = None
+                self.bridge_client.reset_connection()
+                if self._stop_event.wait(1.0):
+                    break
+            except (BridgeUnavailable, BridgeTransportError, BridgeError, OSError):
+                self.registered_identity = None
+                self.bridge_client.reset_connection()
+                if self._stop_event.wait(1.0):
+                    break
+            except Exception:
+                self.registered_identity = None
+                self.bridge_client.reset_connection()
+                if self._stop_event.wait(1.0):
+                    break
+
+        self.delete_presence()
+
+
+class MCPServer:
+    """MCP stdio server exposing submit_spoken_rendering (KTD8)."""
+
+    def __init__(
+        self,
+        *,
+        stdin: io.TextIOBase | Any = sys.stdin,
+        stdout: io.TextIOBase | Any = sys.stdout,
+        bridge_client_instance: BridgeClient | None = None,
+        identity_resolver: Callable[[], AdapterIdentity] = resolve_adapter_identity,
+        turn_record_path: Path | None = None,
+        turn_record_reader: Callable[..., TurnRecord | None] | None = None,
+        presence_worker: PresenceWorker | None = None,
+        enable_presence: bool = True,
+    ) -> None:
+        self.stdin = stdin
+        self.stdout = stdout
+        self.bridge_client = bridge_client_instance or BridgeClient()
+        self.identity_resolver = identity_resolver
+        self.turn_record_path = turn_record_path
+        if turn_record_reader is not None:
+            self.turn_record_reader = turn_record_reader
+        else:
+            self.turn_record_reader = lambda: read_turn_record(self.turn_record_path)
+        self.enable_presence = enable_presence
+        if presence_worker is not None:
+            self.presence_worker = presence_worker
+        elif enable_presence:
+            self.presence_worker = PresenceWorker(
+                bridge_client_instance=self.bridge_client,
+                identity_resolver=self.identity_resolver,
+            )
+        else:
+            self.presence_worker = None
+
+    def _execute_submit_spoken_rendering(self, text: str) -> dict[str, Any]:
+        # 1. Resolve identity (§5)
+        try:
+            identity = self.identity_resolver()
+        except IdentityRefusal:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"disposition": "unavailable", "reason": "not_bound"},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+
+        # 2. Read turn record (KTD4)
+        record = self.turn_record_reader()
+        if (
+            record is None
+            or record.binding_id is None
+            or record.turn_id is None
+            or record.session_id != identity.agent_session_id
+        ):
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"disposition": "unavailable", "reason": "no_current_turn"},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+
+        # 3. Gate candidate text (R121, KTD1)
+        verdict = rendering_gate.evaluate(text)
+        if not verdict.is_plain:
+            detail = verdict.detail
+            try:
+                record_submission(
+                    session_id=record.session_id,
+                    text=text,
+                    disposition="rejected_content",
+                    reason=verdict.reason,
+                    detail=detail,
+                    path=self.turn_record_path,
+                )
+            except TurnRecordBusy:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {"disposition": "unavailable", "reason": "turn_record_busy"},
+                                sort_keys=True,
+                            ),
+                        }
+                    ],
+                    "isError": False,
+                }
+            except Exception:
+                pass
+
+            payload: dict[str, Any] = {
+                "disposition": "rejected_content",
+                "reason": verdict.reason,
+            }
+            if detail is not None:
+                payload["detail"] = detail
+
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(payload, sort_keys=True),
+                    }
+                ],
+                "isError": False,
+            }
+
+        # 4. Forward plain text byte-identical to Core (§6.5, R20)
+        try:
+            resp = self.bridge_client.submit_rendering(
+                identity=identity,
+                binding_id=record.binding_id,
+                turn_id=record.turn_id,
+                text=text,
+            )
+        except BridgeUnavailable:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"disposition": "unavailable", "reason": "bridge_unavailable"},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+        except BridgeUnauthorized:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"disposition": "unavailable", "reason": "bridge_unavailable"},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+        except (BridgeTransportError, BridgeError, OSError):
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"disposition": "unavailable", "reason": "transport_error"},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+        except Exception:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"disposition": "unavailable", "reason": "transport_error"},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+
+        if resp.disposition == "accepted":
+            detail_str = resp.detail or "accepted"
+            try:
+                record_submission(
+                    session_id=record.session_id,
+                    text=text,
+                    disposition="accepted",
+                    detail={"detail": detail_str} if detail_str != "accepted" else None,
+                    path=self.turn_record_path,
+                )
+            except Exception:
+                pass
+
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"detail": detail_str, "disposition": "accepted"},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+
+        elif resp.disposition == "rejected":
+            try:
+                record_submission(
+                    session_id=record.session_id,
+                    text=text,
+                    disposition="rejected_by_core",
+                    reason=resp.reason,
+                    path=self.turn_record_path,
+                )
+            except Exception:
+                pass
+
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"disposition": "rejected_by_core", "reason": resp.reason},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+
+        else:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {"disposition": "unavailable", "reason": "transport_error"},
+                            sort_keys=True,
+                        ),
+                    }
+                ],
+                "isError": False,
+            }
+
+    def handle_line(self, line: str) -> str | None:
+        """Handle one input line of JSON-RPC 2.0 framing."""
+        raw = line.strip()
+        if not raw:
+            return None
+
+        try:
+            req = json.loads(raw)
+        except Exception:
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error"},
+            })
+
+        if not isinstance(req, dict):
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request"},
+            })
+
+        method = req.get("method")
+        req_id = req.get("id")
+        params = req.get("params")
+        is_notification = "id" not in req
+
+        if method == "initialize":
+            client_version = params.get("protocolVersion") if isinstance(params, dict) else None
+            supported_versions = {"2024-11-05", "2024-10-07", "latest"}
+            protocol_version = client_version if client_version in supported_versions else "2024-11-05"
+            result = {
+                "protocolVersion": protocol_version,
+                "capabilities": {
+                    "tools": {},
+                },
+                "serverInfo": {
+                    "name": "auralis-voice",
+                    "version": "0.3.0",
+                },
+            }
+            return json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result})
+
+        elif method == "notifications/initialized":
+            return None
+
+        elif method == "ping":
+            return json.dumps({"jsonrpc": "2.0", "id": req_id, "result": {}})
+
+        elif method == "tools/list":
+            result = {
+                "tools": [
+                    {
+                        "name": "submit_spoken_rendering",
+                        "description": (
+                            "Submit an authored spoken rendering for the current Auralis voice turn. "
+                            "Accepts plain spoken text only; Markdown formatting and fenced code blocks are rejected."
+                        ),
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "text": {
+                                    "type": "string",
+                                    "description": "The plain spoken text to be rendered as speech.",
+                                },
+                            },
+                            "required": ["text"],
+                            "additionalProperties": False,
+                        },
+                    }
+                ]
+            }
+            return json.dumps({"jsonrpc": "2.0", "id": req_id, "result": result})
+
+        elif method == "tools/call":
+            if not isinstance(params, dict):
+                return json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": "Invalid params: params must be an object"},
+                })
+            tool_name = params.get("name")
+            arguments = params.get("arguments")
+            if tool_name != "submit_spoken_rendering":
+                return json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32601, "message": f"Tool not found: {tool_name!r}"},
+                })
+            if not isinstance(arguments, dict) or "text" not in arguments or not isinstance(arguments["text"], str):
+                return json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": "Invalid params: arguments.text string required"},
+                })
+
+            tool_result = self._execute_submit_spoken_rendering(arguments["text"])
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": tool_result,
+            })
+
+        else:
+            if is_notification:
+                return None
+            return json.dumps({
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method not found: {method!r}"},
+            })
+
+    def serve(self) -> int:
+        """Run the server loop on self.stdin and self.stdout until EOF."""
+        if self.enable_presence and self.presence_worker:
+            self.presence_worker.start()
+
+        try:
+            while True:
+                line = self.stdin.readline()
+                if not line:
+                    break
+                response_line = self.handle_line(line)
+                if response_line is not None:
+                    self.stdout.write(response_line + "\n")
+                    self.stdout.flush()
+        except (KeyboardInterrupt, BrokenPipeError):
+            pass
+        finally:
+            if self.presence_worker:
+                self.presence_worker.stop()
+
+        return 0
+
+
+def run_server(
+    stdin: io.TextIOBase | Any = sys.stdin,
+    stdout: io.TextIOBase | Any = sys.stdout,
+    *,
+    bridge_client_instance: BridgeClient | None = None,
+    identity_resolver: Callable[[], AdapterIdentity] = resolve_adapter_identity,
+    enable_presence: bool = True,
+) -> int:
+    """Run the MCP server instance."""
+    server = MCPServer(
+        stdin=stdin,
+        stdout=stdout,
+        bridge_client_instance=bridge_client_instance,
+        identity_resolver=identity_resolver,
+        enable_presence=enable_presence,
+    )
+    return server.serve()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entrypoint for `python3 scripts/mcp_server.py`."""
+    return run_server()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/voice/scripts/rendering_gate.py
+++ b/plugins/voice/scripts/rendering_gate.py
@@ -1,0 +1,294 @@
+"""Plain-spoken-text rendering gate (R121, R20; KTD1).
+
+This module is the adapter-facing enforcement boundary for requirement R121:
+the agent-facing surface accepts plain spoken text only. Any Markdown
+formatting or fenced code block is rejected at submission with a named
+reason; text is never silently cleaned, shortened, or reformatted (R20).
+
+The class table, block-indentation rule, and stated non-class list below are
+the gate's self-contained normative grammar. Every construct in base Markdown
+plus GitHub-flavored pipe tables and strikethrough is disposed of in exactly
+one of three ways:
+1. A rejecting class in the table below;
+2. A structural non-class: blank lines and ordinary paragraph breaks;
+3. A prose-collision non-class: HTML entity references (&name;) which collide
+   with ordinary prose like 'AT&T;' are accepted as plain.
+
+Precedence for rejection reasons (KTD1):
+- Any fence yields 'fenced_code_block';
+- Otherwise any other detected class yields 'markdown_formatting', with the
+  detected classes and first offending line named in the detail.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+__all__ = [
+    "REASON_FENCED_CODE_BLOCK",
+    "REASON_MARKDOWN_FORMATTING",
+    "VERDICT_PLAIN",
+    "VERDICT_REJECTED",
+    "CLASS_FENCED_CODE_BLOCK",
+    "CLASS_INDENTED_CODE_BLOCK",
+    "CLASS_ATX_HEADING",
+    "CLASS_SETEXT_HEADING",
+    "CLASS_LIST_MARKER",
+    "CLASS_BLOCKQUOTE",
+    "CLASS_HORIZONTAL_RULE",
+    "CLASS_TABLE_PIPE_ROW",
+    "CLASS_LINK_REFERENCE_DEFINITION",
+    "CLASS_HARD_LINE_BREAK",
+    "CLASS_RAW_HTML",
+    "CLASS_BACKSLASH_ESCAPE",
+    "CLASS_EMPHASIS_STRONG",
+    "CLASS_STRIKETHROUGH",
+    "CLASS_INLINE_CODE_SPAN",
+    "CLASS_INLINE_LINK_IMAGE",
+    "CLASS_REFERENCE_LINK",
+    "CLASS_AUTOLINK",
+    "GateVerdict",
+    "evaluate",
+    "gate",
+    "check_rendering",
+]
+
+REASON_FENCED_CODE_BLOCK = "fenced_code_block"
+REASON_MARKDOWN_FORMATTING = "markdown_formatting"
+
+VERDICT_PLAIN = "plain"
+VERDICT_REJECTED = "rejected"
+
+CLASS_FENCED_CODE_BLOCK = "fenced_code_block"
+CLASS_INDENTED_CODE_BLOCK = "indented_code_block"
+CLASS_ATX_HEADING = "atx_heading"
+CLASS_SETEXT_HEADING = "setext_heading"
+CLASS_LIST_MARKER = "list_marker"
+CLASS_BLOCKQUOTE = "blockquote"
+CLASS_HORIZONTAL_RULE = "horizontal_rule"
+CLASS_TABLE_PIPE_ROW = "table_pipe_row"
+CLASS_LINK_REFERENCE_DEFINITION = "link_reference_definition"
+CLASS_HARD_LINE_BREAK = "hard_line_break"
+CLASS_RAW_HTML = "raw_html"
+CLASS_BACKSLASH_ESCAPE = "backslash_escape"
+CLASS_EMPHASIS_STRONG = "emphasis_strong"
+CLASS_STRIKETHROUGH = "strikethrough"
+CLASS_INLINE_CODE_SPAN = "inline_code_span"
+CLASS_INLINE_LINK_IMAGE = "inline_link_image"
+CLASS_REFERENCE_LINK = "reference_link"
+CLASS_AUTOLINK = "autolink"
+
+# 1. Fenced code block: 0-3 leading spaces, 3+ backticks or 3+ tildes
+_FENCE_PATTERN = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})")
+
+# 3. ATX heading: 0-3 leading spaces, 1-6 hashes, then space/tab or end of line
+_ATX_HEADING_PATTERN = re.compile(r"^[ ]{0,3}#{1,6}([ \t]|$)")
+
+# 4. Setext underline: 0-3 leading spaces, 1+ '=' or 1+ '-', optional spaces/tabs to EOL
+_SETEXT_UNDERLINE_PATTERN = re.compile(r"^[ ]{0,3}(?:={1,}|-{1,})[ \t]*$")
+
+# 5. List marker: 0-3 leading spaces, bullet (-+*) or 1-9 digits with . or ), then space/tab/EOL
+_LIST_MARKER_PATTERN = re.compile(r"^[ ]{0,3}(?:[-+*]|\d{1,9}[.)])([ \t]|$)")
+
+# 6. Blockquote marker: 0-3 leading spaces, >
+_BLOCKQUOTE_PATTERN = re.compile(r"^[ ]{0,3}>")
+
+# 7. Horizontal rule: 0-3 leading spaces, 3+ of -, _, or *, spaces/tabs allowed
+_HORIZONTAL_RULE_PATTERN = re.compile(
+    r"^[ ]{0,3}(?:(?:-[ \t]*){3,}|(?:_[ \t]*){3,}|(?:\*[ \t]*){3,})$"
+)
+
+# 9. Link-reference definition: 0-3 leading spaces, [label]:
+_LINK_REF_DEF_PATTERN = re.compile(r"^[ ]{0,3}\[(?:\\\]|[^\]])+\]:")
+
+# 11. Raw HTML: < followed by letter, /letter, !--, !letter, ?, or ![CDATA[
+_RAW_HTML_PATTERN = re.compile(r"<(?=[A-Za-z]|/[A-Za-z]|!--|![A-Za-z]|\?|!\[CDATA\[)")
+
+# 12. Backslash escape: backslash before any of the 32 ASCII punctuation characters
+# ASCII 33-47, 58-64, 91-96, 123-126
+_BACKSLASH_ESCAPE_PATTERN = re.compile(r"\\[!\"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~]")
+
+# 13. Emphasis / strong: *...* or _..._ (word edge guarded)
+_EMPHASIS_STAR_PATTERN = re.compile(r"(?<!\*)\*{1,}(?=\S)(?:.*?\S)?\*{1,}(?!\*)")
+_EMPHASIS_UNDERSCORE_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])_{1,}(?=\S)(?:.*?\S)?_{1,}(?![A-Za-z0-9_])"
+)
+
+# 14. Strikethrough: 1 or 2 tildes
+_STRIKETHROUGH_PATTERN = re.compile(
+    r"(?<!~)(?P<tilde>~{1,2})(?=\S)(?:.*?\S)?(?P=tilde)(?!~)"
+)
+
+# 15. Inline code span: 1+ backticks matched by equal run
+_INLINE_CODE_PATTERN = re.compile(r"(?<!`)(?P<ticks>`{1,})(?:.*?(?<!`))(?P=ticks)(?!`)")
+
+# 16. Inline link / image: [text](url) or ![alt](url)
+_INLINE_LINK_IMAGE_PATTERN = re.compile(r"!?\[[^\]]*\]\([^)]*\)")
+
+# 17. Reference link: [text][ref] or [text][]
+_REFERENCE_LINK_PATTERN = re.compile(r"!?\[[^\]]*\]\[[^\]]*\]")
+
+# 18. Autolink: <scheme:...> or <user@domain>
+_AUTOLINK_PATTERN = re.compile(
+    r"<(?:[A-Za-z][A-Za-z0-9+.\-]{1,31}:[^<>\s]*|[^<>\s@]+@[^<>\s@]+)>"
+)
+
+
+@dataclass(frozen=True)
+class GateVerdict:
+    """The outcome of evaluating candidate spoken text against R121."""
+
+    is_plain: bool
+    verdict: str
+    reason: str | None = None
+    detail: dict[str, object] | None = None
+    detected_classes: list[str] = field(default_factory=list)
+    first_offending_line: int | None = None
+
+
+@dataclass(frozen=True)
+class _Violation:
+    class_name: str
+    line_number: int
+
+
+def evaluate(text: str) -> GateVerdict:
+    """Evaluate candidate rendering text against the R121 normative grammar.
+
+    Returns a GateVerdict indicating whether the text is plain spoken text or
+    rejected, with reason, detected classes, and first offending line number.
+    This module exposes no text transformation or cleaning function (R20).
+    """
+    if not text:
+        return GateVerdict(
+            is_plain=True,
+            verdict=VERDICT_PLAIN,
+            reason=None,
+            detail=None,
+            detected_classes=[],
+            first_offending_line=None,
+        )
+
+    lines = text.splitlines()
+    violations: list[_Violation] = []
+
+    for i, line in enumerate(lines):
+        line_no = i + 1
+
+        # 1. Fenced code block
+        if _FENCE_PATTERN.match(line):
+            violations.append(_Violation(CLASS_FENCED_CODE_BLOCK, line_no))
+
+        # 2. Indented code block: non-blank line with >=4 leading spaces or a tab in leading whitespace
+        if line.strip() != "":
+            if line.startswith("    ") or bool(re.match(r"^[ ]*\t", line)):
+                violations.append(_Violation(CLASS_INDENTED_CODE_BLOCK, line_no))
+
+        # 3. ATX heading
+        if _ATX_HEADING_PATTERN.match(line):
+            violations.append(_Violation(CLASS_ATX_HEADING, line_no))
+
+        # 4. Setext heading: preceding non-blank line followed by underline line
+        if i < len(lines) - 1 and line.strip() != "":
+            next_line = lines[i + 1]
+            if _SETEXT_UNDERLINE_PATTERN.match(next_line):
+                violations.append(_Violation(CLASS_SETEXT_HEADING, line_no))
+
+        # 5. List marker
+        if _LIST_MARKER_PATTERN.match(line):
+            violations.append(_Violation(CLASS_LIST_MARKER, line_no))
+
+        # 6. Blockquote marker
+        if _BLOCKQUOTE_PATTERN.match(line):
+            violations.append(_Violation(CLASS_BLOCKQUOTE, line_no))
+
+        # 7. Horizontal rule
+        if _HORIZONTAL_RULE_PATTERN.match(line):
+            violations.append(_Violation(CLASS_HORIZONTAL_RULE, line_no))
+
+        # 8. Table pipe row
+        if "|" in line:
+            violations.append(_Violation(CLASS_TABLE_PIPE_ROW, line_no))
+
+        # 9. Link-reference definition
+        if _LINK_REF_DEF_PATTERN.match(line):
+            violations.append(_Violation(CLASS_LINK_REFERENCE_DEFINITION, line_no))
+
+        # 10. Hard line break: non-final line ending in \ or in 2+ spaces before non-blank line
+        if i < len(lines) - 1:
+            if line.endswith("\\"):
+                violations.append(_Violation(CLASS_HARD_LINE_BREAK, line_no))
+            elif line.endswith("  ") and lines[i + 1].strip() != "":
+                violations.append(_Violation(CLASS_HARD_LINE_BREAK, line_no))
+
+        # 11. Raw HTML
+        if _RAW_HTML_PATTERN.search(line):
+            violations.append(_Violation(CLASS_RAW_HTML, line_no))
+
+        # 12. Backslash escape
+        if _BACKSLASH_ESCAPE_PATTERN.search(line):
+            violations.append(_Violation(CLASS_BACKSLASH_ESCAPE, line_no))
+
+        # 13. Emphasis / strong
+        if _EMPHASIS_STAR_PATTERN.search(line) or _EMPHASIS_UNDERSCORE_PATTERN.search(line):
+            violations.append(_Violation(CLASS_EMPHASIS_STRONG, line_no))
+
+        # 14. Strikethrough
+        if _STRIKETHROUGH_PATTERN.search(line):
+            violations.append(_Violation(CLASS_STRIKETHROUGH, line_no))
+
+        # 15. Inline code span
+        if _INLINE_CODE_PATTERN.search(line):
+            violations.append(_Violation(CLASS_INLINE_CODE_SPAN, line_no))
+
+        # 16. Inline link / image
+        if _INLINE_LINK_IMAGE_PATTERN.search(line):
+            violations.append(_Violation(CLASS_INLINE_LINK_IMAGE, line_no))
+
+        # 17. Reference link
+        if _REFERENCE_LINK_PATTERN.search(line):
+            violations.append(_Violation(CLASS_REFERENCE_LINK, line_no))
+
+        # 18. Autolink
+        if _AUTOLINK_PATTERN.search(line):
+            violations.append(_Violation(CLASS_AUTOLINK, line_no))
+
+    if not violations:
+        return GateVerdict(
+            is_plain=True,
+            verdict=VERDICT_PLAIN,
+            reason=None,
+            detail=None,
+            detected_classes=[],
+            first_offending_line=None,
+        )
+
+    # Sort violations to determine first offending line
+    violations.sort(key=lambda v: v.line_number)
+    detected_classes = list(dict.fromkeys(v.class_name for v in violations))
+    first_offending_line = violations[0].line_number
+
+    # Precedence: any fence yields 'fenced_code_block'; otherwise 'markdown_formatting'
+    if CLASS_FENCED_CODE_BLOCK in detected_classes:
+        reason = REASON_FENCED_CODE_BLOCK
+    else:
+        reason = REASON_MARKDOWN_FORMATTING
+
+    detail: dict[str, object] = {
+        "detected_classes": detected_classes,
+        "first_offending_line": first_offending_line,
+    }
+
+    return GateVerdict(
+        is_plain=False,
+        verdict=VERDICT_REJECTED,
+        reason=reason,
+        detail=detail,
+        detected_classes=detected_classes,
+        first_offending_line=first_offending_line,
+    )
+
+
+gate = evaluate
+check_rendering = evaluate

--- a/plugins/voice/scripts/settings.py
+++ b/plugins/voice/scripts/settings.py
@@ -42,6 +42,8 @@ __all__ = [
     "PLAYBACK_BIN",
     "STATE_DIR",
     "RETENTION",
+    "HERDR_PANE_ID",
+    "HERDR_BIN_PATH",
     "forge_base_url",
     "forge_voice_id",
     "hermes_base_url",
@@ -50,6 +52,8 @@ __all__ = [
     "playback_bin",
     "state_dir",
     "retention",
+    "herdr_pane_id",
+    "herdr_bin_path",
 ]
 
 
@@ -75,6 +79,8 @@ CAPTURE_BIN = "VOICE_CAPTURE_BIN"
 PLAYBACK_BIN = "VOICE_PLAYBACK_BIN"
 STATE_DIR = "VOICE_STATE_DIR"
 RETENTION = "VOICE_RETENTION"
+HERDR_PANE_ID = "HERDR_PANE_ID"
+HERDR_BIN_PATH = "HERDR_BIN_PATH"
 
 #: The closed set of settings this package reads. Nothing outside this tuple
 #: is ever read from the environment, and no member may carry a secret.
@@ -87,6 +93,8 @@ SETTING_NAMES = (
     PLAYBACK_BIN,
     STATE_DIR,
     RETENTION,
+    HERDR_PANE_ID,
+    HERDR_BIN_PATH,
 )
 
 DEFAULT_HERMES_BASE_URL = "http://127.0.0.1:8765"
@@ -174,3 +182,13 @@ def retention() -> str:
             f"{RETENTION_EPHEMERAL!r} and refuses other postures by name",
         )
     return value
+
+
+def herdr_pane_id() -> str:
+    """Herdr pane identifier for the current process session. No default."""
+    return _stated(HERDR_PANE_ID, None)
+
+
+def herdr_bin_path() -> str:
+    """Path to the Herdr CLI executable. No default."""
+    return _stated(HERDR_BIN_PATH, None)

--- a/plugins/voice/scripts/turn_record.py
+++ b/plugins/voice/scripts/turn_record.py
@@ -1,0 +1,438 @@
+"""Per-turn state and mutation record (R23, R122; KTD11).
+
+This module manages the single current-turn JSON state file under the state
+directory (``turn_record.json``).
+
+Four processes mutate this record:
+1. UserPromptSubmit hook creates it at turn origin;
+2. MCP server appends submitted renderings and dispositions;
+3. PreToolUse hook appends tool-use observations;
+4. Stop hook settles the final outcome ('authored' vs 'fallback').
+
+To prevent lost updates, all mutations are serialized through the single
+`mutate(fn)` entrypoint (KTD11):
+- An exclusive advisory lock via fcntl.flock on a sidecar lock file
+  (``turn_record.json.lock``);
+- Acquisition deadline of 500 ms (monotonic clock) retried at 10 ms intervals;
+- An expired deadline raises TurnRecordBusy ('turn_record_busy'), never a
+  blind write;
+- The entire read-modify-replace sequence is executed inside the lock;
+- Atomic replace (write temp and os.replace) provides the torn-write defense
+  for concurrent readers.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Callable
+
+import settings
+
+__all__ = [
+    "TurnRecord",
+    "TurnRecordReport",
+    "TurnRecordBusy",
+    "TurnRecordSessionMismatch",
+    "TURN_RECORD_FILENAME",
+    "TURN_RECORD_LOCK_FILENAME",
+    "STATUS_RECORD",
+    "STATUS_ABSENT",
+    "STATUS_CORRUPT",
+    "OUTCOME_AUTHORED",
+    "OUTCOME_FALLBACK",
+    "ORIGIN_AURALIS",
+    "ORIGIN_NOT_ORIGINATED",
+    "read_turn_record",
+    "read_turn_record_report",
+    "mutate",
+    "init_turn",
+    "record_submission",
+    "record_tool_observation",
+    "settle_outcome",
+]
+
+TURN_RECORD_FILENAME = "turn_record.json"
+TURN_RECORD_LOCK_FILENAME = "turn_record.json.lock"
+
+STATUS_RECORD = "record"
+STATUS_ABSENT = "absent"
+STATUS_CORRUPT = "corrupt"
+
+OUTCOME_AUTHORED = "authored"
+OUTCOME_FALLBACK = "fallback"
+
+ORIGIN_AURALIS = "auralis"
+ORIGIN_NOT_ORIGINATED = "not_originated"
+
+
+class TurnRecordBusy(Exception):
+    """Raised when lock acquisition exceeds the 500 ms deadline."""
+
+
+class TurnRecordSessionMismatch(Exception):
+    """Raised when a mutation is attempted on a record with a different session_id."""
+
+
+@dataclass(frozen=True)
+class TurnRecord:
+    """The state of the current voice turn."""
+
+    session_id: str
+    binding_id: str | None = None
+    turn_id: str | None = None
+    origin: str = ORIGIN_AURALIS
+    submissions: list[dict[str, object]] = field(default_factory=list)
+    tool_observations: list[dict[str, object]] = field(default_factory=list)
+    outcome: str | None = None
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "binding_id": self.binding_id,
+            "turn_id": self.turn_id,
+            "origin": self.origin,
+            "submissions": self.submissions,
+            "tool_observations": self.tool_observations,
+            "outcome": self.outcome,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, object]) -> TurnRecord:
+        session_id = payload["session_id"]
+        if not isinstance(session_id, str):
+            raise ValueError("session_id must be a string")
+        binding_id = payload.get("binding_id")
+        if binding_id is not None and not isinstance(binding_id, str):
+            raise ValueError("binding_id must be a string or None")
+        turn_id = payload.get("turn_id")
+        if turn_id is not None and not isinstance(turn_id, str):
+            raise ValueError("turn_id must be a string or None")
+        origin = payload.get("origin", ORIGIN_AURALIS)
+        if not isinstance(origin, str):
+            raise ValueError("origin must be a string")
+        submissions = payload.get("submissions", [])
+        if not isinstance(submissions, list):
+            raise ValueError("submissions must be a list")
+        tool_observations = payload.get("tool_observations", [])
+        if not isinstance(tool_observations, list):
+            raise ValueError("tool_observations must be a list")
+        outcome = payload.get("outcome")
+        if outcome is not None and not isinstance(outcome, str):
+            raise ValueError("outcome must be a string or None")
+        created_at = payload.get("created_at", "")
+        if not isinstance(created_at, str):
+            created_at = datetime.now(UTC).isoformat()
+        updated_at = payload.get("updated_at", "")
+        if not isinstance(updated_at, str):
+            updated_at = datetime.now(UTC).isoformat()
+
+        return cls(
+            session_id=session_id,
+            binding_id=binding_id,
+            turn_id=turn_id,
+            origin=origin,
+            submissions=submissions,
+            tool_observations=tool_observations,
+            outcome=outcome,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+
+@dataclass(frozen=True)
+class TurnRecordReport:
+    """The result of reading the turn record state."""
+
+    record: TurnRecord | None
+    status: str
+
+
+def _turn_record_path(path: Path | None = None) -> Path:
+    if path is not None:
+        return path
+    return settings.state_dir() / TURN_RECORD_FILENAME
+
+
+def _lock_path(lock_path: Path | None, record_path: Path) -> Path:
+    if lock_path is not None:
+        return lock_path
+    return record_path.parent / (record_path.name + ".lock")
+
+
+def _read_record_from_path(target: Path) -> TurnRecord | None:
+    if not target.exists():
+        return None
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            return None
+        return TurnRecord.from_payload(payload)
+    except (OSError, ValueError, TypeError, KeyError):
+        return None
+
+
+def read_turn_record_report(path: Path | None = None) -> TurnRecordReport:
+    """Read the turn record once, reporting status as record, absent, or corrupt."""
+    target = _turn_record_path(path)
+    if not target.exists():
+        return TurnRecordReport(record=None, status=STATUS_ABSENT)
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            return TurnRecordReport(record=None, status=STATUS_CORRUPT)
+        record = TurnRecord.from_payload(payload)
+        return TurnRecordReport(record=record, status=STATUS_RECORD)
+    except (OSError, ValueError, TypeError, KeyError):
+        return TurnRecordReport(record=None, status=STATUS_CORRUPT)
+
+
+def read_turn_record(path: Path | None = None) -> TurnRecord | None:
+    """Return the current turn record, or None if absent or corrupt."""
+    return read_turn_record_report(path).record
+
+
+def mutate(
+    fn: Callable[[TurnRecord | None], TurnRecord | None],
+    *,
+    path: Path | None = None,
+    lock_path: Path | None = None,
+    timeout_seconds: float = 0.5,
+    retry_interval: float = 0.01,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> TurnRecord | None:
+    """Execute a mutation on the turn record inside an exclusive flock transaction (KTD11).
+
+    Acquires an exclusive advisory lock on the sidecar lock file within
+    timeout_seconds (default 500 ms). If lock acquisition fails, raises
+    TurnRecordBusy ('turn_record_busy'). Inside the critical section, reads the
+    current record, applies fn(current), and if the result is not None, writes
+    it atomically via temporary file and os.replace.
+    """
+    target = _turn_record_path(path)
+    lock_file = _lock_path(lock_path, target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    lock_fd = os.open(lock_file, os.O_RDWR | os.O_CREAT, 0o600)
+    acquired = False
+    start_time = clock()
+    deadline = start_time + timeout_seconds
+
+    try:
+        while True:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+                break
+            except (BlockingIOError, OSError):
+                if clock() >= deadline:
+                    break
+                sleep(retry_interval)
+
+        if not acquired:
+            raise TurnRecordBusy(
+                f"turn_record_busy: lock acquisition exceeded {timeout_seconds:.3f}s budget"
+            )
+
+        current = _read_record_from_path(target)
+        new_record = fn(current)
+
+        if new_record is not None:
+            fd, temporary = tempfile.mkstemp(
+                dir=target.parent, prefix=".turn_record-", suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                    handle.write(
+                        json.dumps(new_record.to_payload(), indent=2, sort_keys=True)
+                    )
+                    handle.write("\n")
+                os.replace(temporary, target)
+            except BaseException:
+                try:
+                    os.unlink(temporary)
+                except OSError:
+                    pass
+                raise
+        return new_record
+    finally:
+        if acquired:
+            try:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+        try:
+            os.close(lock_fd)
+        except OSError:
+            pass
+
+
+def init_turn(
+    session_id: str,
+    binding_id: str | None = None,
+    turn_id: str | None = None,
+    origin: str = ORIGIN_AURALIS,
+    *,
+    path: Path | None = None,
+    lock_path: Path | None = None,
+    **kwargs,
+) -> TurnRecord:
+    """Initialize a new turn record, replacing any previous turn's record."""
+    now = datetime.now(UTC).isoformat()
+
+    def _init(_current: TurnRecord | None) -> TurnRecord:
+        return TurnRecord(
+            session_id=session_id,
+            binding_id=binding_id,
+            turn_id=turn_id,
+            origin=origin,
+            submissions=[],
+            tool_observations=[],
+            outcome=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+    result = mutate(_init, path=path, lock_path=lock_path, **kwargs)
+    assert result is not None
+    return result
+
+
+def record_submission(
+    session_id: str,
+    text: str,
+    disposition: str,
+    reason: str | None = None,
+    detail: dict[str, object] | None = None,
+    *,
+    path: Path | None = None,
+    lock_path: Path | None = None,
+    **kwargs,
+) -> TurnRecord:
+    """Append a rendering submission and disposition to the current turn record."""
+    now = datetime.now(UTC).isoformat()
+
+    def _append(current: TurnRecord | None) -> TurnRecord:
+        if current is None:
+            raise TurnRecordSessionMismatch("no active turn record")
+        if current.session_id != session_id:
+            raise TurnRecordSessionMismatch(
+                f"session_id mismatch: current is {current.session_id!r}, caller is {session_id!r}"
+            )
+        sub: dict[str, object] = {
+            "text": text,
+            "disposition": disposition,
+            "reason": reason,
+            "detail": detail,
+            "timestamp": now,
+        }
+        new_subs = list(current.submissions)
+        new_subs.append(sub)
+        return TurnRecord(
+            session_id=current.session_id,
+            binding_id=current.binding_id,
+            turn_id=current.turn_id,
+            origin=current.origin,
+            submissions=new_subs,
+            tool_observations=current.tool_observations,
+            outcome=current.outcome,
+            created_at=current.created_at,
+            updated_at=now,
+        )
+
+    result = mutate(_append, path=path, lock_path=lock_path, **kwargs)
+    assert result is not None
+    return result
+
+
+def record_tool_observation(
+    session_id: str,
+    tool_name: str,
+    tool_input: object,
+    tool_use_id: str,
+    *,
+    path: Path | None = None,
+    lock_path: Path | None = None,
+    **kwargs,
+) -> TurnRecord:
+    """Append a tool-use observation to the current turn record."""
+    now = datetime.now(UTC).isoformat()
+
+    def _append(current: TurnRecord | None) -> TurnRecord:
+        if current is None:
+            raise TurnRecordSessionMismatch("no active turn record")
+        if current.session_id != session_id:
+            raise TurnRecordSessionMismatch(
+                f"session_id mismatch: current is {current.session_id!r}, caller is {session_id!r}"
+            )
+        obs: dict[str, object] = {
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_use_id": tool_use_id,
+            "timestamp": now,
+        }
+        new_obs = list(current.tool_observations)
+        new_obs.append(obs)
+        return TurnRecord(
+            session_id=current.session_id,
+            binding_id=current.binding_id,
+            turn_id=current.turn_id,
+            origin=current.origin,
+            submissions=current.submissions,
+            tool_observations=new_obs,
+            outcome=current.outcome,
+            created_at=current.created_at,
+            updated_at=now,
+        )
+
+    result = mutate(_append, path=path, lock_path=lock_path, **kwargs)
+    assert result is not None
+    return result
+
+
+def settle_outcome(
+    session_id: str,
+    outcome: str,
+    *,
+    path: Path | None = None,
+    lock_path: Path | None = None,
+    **kwargs,
+) -> TurnRecord:
+    """Settle the outcome of the turn ('authored' or 'fallback'). Settles once."""
+    now = datetime.now(UTC).isoformat()
+
+    def _settle(current: TurnRecord | None) -> TurnRecord:
+        if current is None:
+            raise TurnRecordSessionMismatch("no active turn record")
+        if current.session_id != session_id:
+            raise TurnRecordSessionMismatch(
+                f"session_id mismatch: current is {current.session_id!r}, caller is {session_id!r}"
+            )
+        if current.outcome is not None:
+            return current
+        return TurnRecord(
+            session_id=current.session_id,
+            binding_id=current.binding_id,
+            turn_id=current.turn_id,
+            origin=current.origin,
+            submissions=current.submissions,
+            tool_observations=current.tool_observations,
+            outcome=outcome,
+            created_at=current.created_at,
+            updated_at=now,
+        )
+
+    result = mutate(_settle, path=path, lock_path=lock_path, **kwargs)
+    assert result is not None
+    return result

--- a/plugins/voice/scripts/voice_cli.py
+++ b/plugins/voice/scripts/voice_cli.py
@@ -15,6 +15,7 @@ Commands:
   sequencer (KTD16).
 - ``stop`` — stop playback immediately; the command the operator's
   Herdr-wide stop keybinding invokes (R8 support).
+- ``policy`` — inspect or configure voice policy (``show``, ``brief-next-turn``).
 
 This CLI is the only command surface the package ships; the Agent Skill
 documents it rather than adding a second one. The heavy modules are
@@ -153,6 +154,20 @@ def _stop() -> int:
     return 0
 
 
+def _policy(policy_args: argparse.Namespace) -> int:
+    import voice_policy
+
+    if policy_args.policy_command == "show":
+        policy = voice_policy.read_policy()
+        print(json.dumps(policy.to_payload(), indent=2, sort_keys=True))
+        return 0
+    if policy_args.policy_command == "brief-next-turn":
+        voice_policy.arm_brief_next_turn()
+        print("armed brief next turn override")
+        return 0
+    return 1
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         prog="voice_cli.py",
@@ -172,6 +187,16 @@ def main(argv: list[str] | None = None) -> int:
         "toggle", help="one recording toggle press: start, or stop and deliver"
     )
     subparsers.add_parser("stop", help="stop playback immediately")
+    policy_parser = subparsers.add_parser(
+        "policy", help="inspect or configure voice policy"
+    )
+    policy_subparsers = policy_parser.add_subparsers(
+        dest="policy_command", required=True
+    )
+    policy_subparsers.add_parser("show", help="show current voice policy")
+    policy_subparsers.add_parser(
+        "brief-next-turn", help="arm brief next turn override"
+    )
     arguments = parser.parse_args(argv)
     if arguments.command == "pane":
         return _pane()
@@ -183,6 +208,8 @@ def main(argv: list[str] | None = None) -> int:
         return _toggle()
     if arguments.command == "stop":
         return _stop()
+    if arguments.command == "policy":
+        return _policy(arguments)
     parser.error(f"unknown command {arguments.command!r}")
     return 2  # Unreached; parser.error exits.
 

--- a/plugins/voice/scripts/voice_policy.py
+++ b/plugins/voice/scripts/voice_policy.py
@@ -1,0 +1,205 @@
+"""Voice policy and operator preferences store (R25, R107; KTD5).
+
+This module manages the operator's voice policy and preferences:
+- Stated preference instruction lines carried to the agent (R107);
+- An armed one-shot 'Brief Next Turn' override (R107), consumed on transmission;
+- A tool allow-list selecting which tools to record in PreToolUse observations (KTD7);
+- Renders instructions without ever applying content transformations or
+  making content decisions in the adapter (R25).
+
+Storage follows the binding.py pattern: atomic write-replace, with absent and
+corrupt states reported by name.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+import settings
+
+__all__ = [
+    "VoicePolicy",
+    "PolicyReport",
+    "POLICY_FILENAME",
+    "STATUS_OK",
+    "STATUS_ABSENT",
+    "STATUS_CORRUPT",
+    "read_policy",
+    "read_policy_report",
+    "write_policy",
+    "arm_brief_next_turn",
+    "consume_brief_next_turn",
+    "render_instructions",
+]
+
+POLICY_FILENAME = "policy.json"
+
+STATUS_OK = "ok"
+STATUS_ABSENT = "absent"
+STATUS_CORRUPT = "corrupt"
+
+BRIEF_INSTRUCTION = "Brief Next Turn override active: keep the spoken rendering concise and brief."
+
+
+@dataclass(frozen=True)
+class VoicePolicy:
+    """The stored voice policy and preferences."""
+
+    preferences: tuple[str, ...] = ()
+    brief_next_turn: bool = False
+    tool_allowlist: tuple[str, ...] = ()
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "preferences": list(self.preferences),
+            "brief_next_turn": self.brief_next_turn,
+            "tool_allowlist": list(self.tool_allowlist),
+        }
+
+
+@dataclass(frozen=True)
+class PolicyReport:
+    """The result of reading the policy store."""
+
+    policy: VoicePolicy
+    status: str
+
+
+def _policy_path(path: Path | None = None) -> Path:
+    if path is not None:
+        return path
+    return settings.state_dir() / POLICY_FILENAME
+
+
+def write_policy(
+    preferences: Sequence[str] | None = None,
+    brief_next_turn: bool = False,
+    tool_allowlist: Sequence[str] | None = None,
+    *,
+    path: Path | None = None,
+) -> VoicePolicy:
+    """Write the policy record atomically, replacing any previous record."""
+    clean_prefs = (
+        tuple(p.strip() for p in preferences if isinstance(p, str) and p.strip())
+        if preferences is not None
+        else ()
+    )
+    clean_tools = (
+        tuple(t.strip() for t in tool_allowlist if isinstance(t, str) and t.strip())
+        if tool_allowlist is not None
+        else ()
+    )
+    policy = VoicePolicy(
+        preferences=clean_prefs,
+        brief_next_turn=bool(brief_next_turn),
+        tool_allowlist=clean_tools,
+    )
+    target = _policy_path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(
+        dir=target.parent, prefix=".policy-", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(policy.to_payload(), indent=2, sort_keys=True))
+            handle.write("\n")
+        os.replace(temporary, target)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+    return policy
+
+
+def read_policy_report(path: Path | None = None) -> PolicyReport:
+    """Read the policy store, reporting status as ok, absent, or corrupt."""
+    target = _policy_path(path)
+    if not target.exists():
+        return PolicyReport(policy=VoicePolicy(), status=STATUS_ABSENT)
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            return PolicyReport(policy=VoicePolicy(), status=STATUS_CORRUPT)
+        prefs_raw = payload.get("preferences", [])
+        if not isinstance(prefs_raw, list) or not all(isinstance(p, str) for p in prefs_raw):
+            return PolicyReport(policy=VoicePolicy(), status=STATUS_CORRUPT)
+        brief_raw = payload.get("brief_next_turn", False)
+        if not isinstance(brief_raw, bool):
+            return PolicyReport(policy=VoicePolicy(), status=STATUS_CORRUPT)
+        tools_raw = payload.get("tool_allowlist", [])
+        if not isinstance(tools_raw, list) or not all(isinstance(t, str) for t in tools_raw):
+            return PolicyReport(policy=VoicePolicy(), status=STATUS_CORRUPT)
+        policy = VoicePolicy(
+            preferences=tuple(prefs_raw),
+            brief_next_turn=brief_raw,
+            tool_allowlist=tuple(tools_raw),
+        )
+        return PolicyReport(policy=policy, status=STATUS_OK)
+    except (OSError, ValueError):
+        return PolicyReport(policy=VoicePolicy(), status=STATUS_CORRUPT)
+
+
+def read_policy(path: Path | None = None) -> VoicePolicy:
+    """Return the current policy, or a default policy if absent or corrupt."""
+    return read_policy_report(path).policy
+
+
+def arm_brief_next_turn(*, path: Path | None = None) -> VoicePolicy:
+    """Arm the Brief Next Turn one-shot override atomically."""
+    current = read_policy(path)
+    return write_policy(
+        preferences=current.preferences,
+        brief_next_turn=True,
+        tool_allowlist=current.tool_allowlist,
+        path=path,
+    )
+
+
+def consume_brief_next_turn(*, path: Path | None = None) -> bool:
+    """Consume the Brief Next Turn override if armed.
+
+    Returns True if the override was armed and has now been disarmed,
+    or False if it was not armed.
+    """
+    current = read_policy(path)
+    if not current.brief_next_turn:
+        return False
+    write_policy(
+        preferences=current.preferences,
+        brief_next_turn=False,
+        tool_allowlist=current.tool_allowlist,
+        path=path,
+    )
+    return True
+
+
+def render_instructions(
+    policy: VoicePolicy | None = None,
+    *,
+    brief: bool | None = None,
+    path: Path | None = None,
+) -> str:
+    """Render the operator policy and preferences into instruction text.
+
+    Preferences are rendered verbatim and never applied to alter or transform
+    content (R25). If brief is True (or armed in policy when brief is None),
+    the brief directive is included.
+    """
+    if policy is None:
+        policy = read_policy(path)
+    is_brief = policy.brief_next_turn if brief is None else bool(brief)
+
+    lines: list[str] = []
+    if is_brief:
+        lines.append(BRIEF_INSTRUCTION)
+    for pref in policy.preferences:
+        lines.append(pref)
+
+    return "\n".join(lines)

--- a/plugins/voice/tests/bridge_stub.py
+++ b/plugins/voice/tests/bridge_stub.py
@@ -1,0 +1,568 @@
+"""Independent-literals bridge HTTP server stub for tests (KTD9; §6, §7).
+
+This module is the single shared stub fixture for all bridge-facing tests:
+U1 client tests, U3 server tests, U4 hook tests, and the U4 adapter-boundary
+scenario. Wire literals live here and in ``bridge_client.py`` only.
+
+Runs a stdlib ``http.server.HTTPServer`` on loopback (127.0.0.1) with an
+ephemeral port, speaks the exact literals of ``docs/bridge-v1-from-c10.md``,
+records incoming requests, and allows fault injection (custom statuses, dropped
+connections, clock/timing simulation).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import socket
+import threading
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+__all__ = [
+    "BridgeStub",
+    "CapturedRequest",
+    "DEFAULT_STUB_TOKEN",
+]
+
+#: A valid 43-character unpadded base64url token for tests.
+DEFAULT_STUB_TOKEN = "test_token_43_chars_base64url_alphabet_0123"
+
+_UUID_V4_REGEX = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+@dataclass
+class CapturedRequest:
+    """A record of one HTTP request received by the bridge stub."""
+
+    method: str
+    path: str
+    headers: dict[str, str]
+    body: dict[str, Any] | None
+    raw_body: bytes
+
+
+class _BridgeHTTPRequestHandler(BaseHTTPRequestHandler):
+    server: _StubHTTPServer  # type: ignore[assignment]
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Suppress standard logging to keep test output clean
+        pass
+
+    def _send_json(
+        self,
+        status: int,
+        payload: dict[str, Any],
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        body_bytes = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body_bytes)))
+        if headers:
+            for k, v in headers.items():
+                self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(body_bytes)
+
+    def _send_transport_error(
+        self,
+        status: int,
+        error_code: str,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._send_json(status, {"schema": 1, "error": error_code}, headers=headers)
+
+    def do_GET(self) -> None:
+        self._handle_request("GET")
+
+    def do_PUT(self) -> None:
+        self._handle_request("PUT")
+
+    def do_DELETE(self) -> None:
+        self._handle_request("DELETE")
+
+    def do_POST(self) -> None:
+        self._handle_request("POST")
+
+    def _handle_request(self, method: str) -> None:
+        parsed_url = urlparse(self.path)
+        path = parsed_url.path
+        raw_query = parsed_url.query
+
+        content_length_str = self.headers.get("Content-Length", "0")
+        try:
+            content_length = int(content_length_str)
+        except ValueError:
+            content_length = 0
+
+        raw_body = self.rfile.read(content_length) if content_length > 0 else b""
+
+        # Record captured request
+        body_json: dict[str, Any] | None = None
+        if raw_body:
+            try:
+                body_json = json.loads(raw_body.decode("utf-8"))
+            except Exception:
+                body_json = None
+
+        captured = CapturedRequest(
+            method=method,
+            path=self.path,
+            headers=dict(self.headers),
+            body=body_json,
+            raw_body=raw_body,
+        )
+        self.server.stub.requests.append(captured)
+
+        # Check explicit path error override
+        if path in self.server.stub.path_status_overrides:
+            status, error_code = self.server.stub.path_status_overrides[path]
+            if status == 200:
+                self._send_json(200, {"schema": 1, "status": "ok"})
+            else:
+                self._send_transport_error(status, error_code)
+            return
+
+        # Check one-shot rendering 500 error simulation (§8; F08)
+        if path == "/v1/rendering" and method == "POST" and self.server.stub.rendering_500_count > 0:
+            self.server.stub.rendering_500_count -= 1
+            self._send_transport_error(500, "internal_error")
+            return
+
+        # Processing precedence (§7):
+        # 1. Path matching: non-existent path -> 404 not_found
+        valid_paths = {"/v1/health", "/v1/current", "/v1/presence", "/v1/rendering"}
+        if path not in valid_paths:
+            self._send_transport_error(404, "not_found")
+            return
+
+        # 2. Method matching: disallowed method -> 405 method_not_allowed with Allow header
+        allowed_methods = {
+            "/v1/health": ["GET"],
+            "/v1/current": ["GET"],
+            "/v1/presence": ["PUT", "DELETE"],
+            "/v1/rendering": ["POST"],
+        }
+        if method not in allowed_methods[path]:
+            allow_header = ", ".join(allowed_methods[path])
+            self._send_transport_error(405, "method_not_allowed", headers={"Allow": allow_header})
+            return
+
+        # 3. Authentication: Missing or invalid Bearer token -> 401 unauthorized
+        auth_header = self.headers.get("Authorization", "")
+        parts = auth_header.split()
+        if len(parts) != 2 or parts[0].lower() != "bearer" or parts[1] != self.server.stub.token:
+            self._send_transport_error(401, "unauthorized")
+            return
+
+        # 4. HTTP version and query string
+        if raw_query:
+            self._send_transport_error(400, "invalid_request")
+            return
+
+        # 5. GET-body prohibition / Media type
+        if method == "GET":
+            if content_length > 0 or raw_body:
+                self._send_transport_error(400, "invalid_request")
+                return
+        else:
+            content_type = self.headers.get("Content-Type", "")
+            media_type = content_type.split(";")[0].strip().lower()
+            if media_type != "application/json":
+                self._send_transport_error(415, "unsupported_media_type")
+                return
+
+        # 6. Body size cap (> 1 MiB -> 413 body_too_large)
+        if len(raw_body) > 1048576:
+            self._send_transport_error(413, "body_too_large")
+            return
+
+        # For body-bearing requests, validate JSON decoding and schema
+        if method in {"PUT", "DELETE", "POST"}:
+            if not raw_body:
+                self._send_transport_error(400, "invalid_json")
+                return
+            try:
+                payload = json.loads(raw_body.decode("utf-8"))
+            except Exception:
+                self._send_transport_error(400, "invalid_json")
+                return
+
+            if not isinstance(payload, dict):
+                self._send_transport_error(400, "invalid_json")
+                return
+
+            # 8. Schema validation
+            schema_val = payload.get("schema")
+            if type(schema_val) is not int:
+                self._send_transport_error(400, "invalid_request")
+                return
+            if schema_val != 1:
+                self._send_transport_error(400, "unsupported_schema")
+                return
+
+            # Execute Endpoint
+            if path == "/v1/presence" and method == "PUT":
+                self._handle_put_presence(payload)
+                return
+            elif path == "/v1/presence" and method == "DELETE":
+                self._handle_delete_presence(payload)
+                return
+            elif path == "/v1/rendering" and method == "POST":
+                self._handle_post_rendering(payload)
+                return
+
+        elif method == "GET":
+            if path == "/v1/health":
+                self._handle_get_health()
+                return
+            elif path == "/v1/current":
+                self._handle_get_current()
+                return
+
+    def _validate_identity_dict(self, identity: Any) -> bool:
+        if not isinstance(identity, dict):
+            return False
+        expected_keys = {"agent_session_id", "pane_id", "terminal_id"}
+        if set(identity.keys()) != expected_keys:
+            return False
+        for k in expected_keys:
+            v = identity.get(k)
+            if not isinstance(v, str) or not v.strip():
+                return False
+        return True
+
+    def _handle_get_health(self) -> None:
+        self._send_json(
+            200,
+            {
+                "schema": 1,
+                "service": "auralis-bridge",
+                "status": self.server.stub.health_status,
+            },
+        )
+
+    def _handle_put_presence(self, payload: dict[str, Any]) -> None:
+        if set(payload.keys()) != {"schema", "identity"}:
+            self._send_transport_error(400, "invalid_request")
+            return
+        identity = payload.get("identity")
+        if not self._validate_identity_dict(identity):
+            self._send_transport_error(400, "invalid_request")
+            return
+
+        self._send_json(
+            200,
+            {
+                "schema": 1,
+                "disposition": self.server.stub.presence_disposition,
+                "lease_ms": self.server.stub.lease_ms,
+                "renew_after_ms": self.server.stub.renew_after_ms,
+            },
+        )
+
+    def _handle_delete_presence(self, payload: dict[str, Any]) -> None:
+        if set(payload.keys()) != {"schema", "identity"}:
+            self._send_transport_error(400, "invalid_request")
+            return
+        identity = payload.get("identity")
+        if not self._validate_identity_dict(identity):
+            self._send_transport_error(400, "invalid_request")
+            return
+
+        self._send_json(
+            200,
+            {
+                "schema": 1,
+                "disposition": self.server.stub.presence_delete_disposition,
+            },
+        )
+
+    def _handle_get_current(self) -> None:
+        binding = self.server.stub.current_binding
+        turn = self.server.stub.current_turn
+        self._send_json(
+            200,
+            {
+                "schema": 1,
+                "binding": binding,
+                "turn": turn,
+            },
+        )
+
+    def _handle_post_rendering(self, payload: dict[str, Any]) -> None:
+        expected_keys = {"schema", "identity", "binding_id", "turn_id", "text"}
+        if set(payload.keys()) != expected_keys:
+            self._send_transport_error(400, "invalid_request")
+            return
+
+        identity = payload.get("identity")
+        if not self._validate_identity_dict(identity):
+            self._send_transport_error(400, "invalid_request")
+            return
+
+        binding_id = payload.get("binding_id")
+        turn_id = payload.get("turn_id")
+        text = payload.get("text")
+
+        if not isinstance(binding_id, str) or not isinstance(turn_id, str) or not isinstance(text, str):
+            self._send_transport_error(400, "invalid_request")
+            return
+
+        # Adjudication order (§6.5):
+        stub = self.server.stub
+
+        # 1. no_binding
+        if stub.current_binding is None:
+            self._send_json(
+                200,
+                {
+                    "schema": 1,
+                    "binding_id": binding_id,
+                    "turn_id": turn_id,
+                    "disposition": "rejected",
+                    "reason": "no_binding",
+                },
+            )
+            return
+
+        # 2. binding_not_current
+        if binding_id != stub.current_binding.get("binding_id"):
+            self._send_json(
+                200,
+                {
+                    "schema": 1,
+                    "binding_id": binding_id,
+                    "turn_id": turn_id,
+                    "disposition": "rejected",
+                    "reason": "binding_not_current",
+                },
+            )
+            return
+
+        # 3. adapter_not_bound
+        if identity != stub.current_binding.get("identity"):
+            self._send_json(
+                200,
+                {
+                    "schema": 1,
+                    "binding_id": binding_id,
+                    "turn_id": turn_id,
+                    "disposition": "rejected",
+                    "reason": "adapter_not_bound",
+                },
+            )
+            return
+
+        # 4. turn_not_current
+        if stub.current_turn is None or turn_id != stub.current_turn.get("turn_id"):
+            self._send_json(
+                200,
+                {
+                    "schema": 1,
+                    "binding_id": binding_id,
+                    "turn_id": turn_id,
+                    "disposition": "rejected",
+                    "reason": "turn_not_current",
+                },
+            )
+            return
+
+        # 5. turn_canceled
+        if stub.current_turn.get("state") == "canceled":
+            self._send_json(
+                200,
+                {
+                    "schema": 1,
+                    "binding_id": binding_id,
+                    "turn_id": turn_id,
+                    "disposition": "rejected",
+                    "reason": "turn_canceled",
+                },
+            )
+            return
+
+        # 6. fallback_already_began
+        if stub.current_turn.get("state") == "fallback_accepted":
+            self._send_json(
+                200,
+                {
+                    "schema": 1,
+                    "binding_id": binding_id,
+                    "turn_id": turn_id,
+                    "disposition": "rejected",
+                    "reason": "fallback_already_began",
+                },
+            )
+            return
+
+        # 7. duplicate_rendering
+        if stub.current_turn.get("state") == "authored_accepted":
+            self._send_json(
+                200,
+                {
+                    "schema": 1,
+                    "binding_id": binding_id,
+                    "turn_id": turn_id,
+                    "disposition": "rejected",
+                    "reason": "duplicate_rendering",
+                },
+            )
+            return
+
+        # 8. empty_rendering
+        if not text.strip():
+            self._send_json(
+                200,
+                {
+                    "schema": 1,
+                    "binding_id": binding_id,
+                    "turn_id": turn_id,
+                    "disposition": "rejected",
+                    "reason": "empty_rendering",
+                },
+            )
+            return
+
+        # 9. Accepted
+        stub.current_turn["state"] = "authored_accepted"
+        if stub.drop_rendering_responses_count > 0:
+            stub.drop_rendering_responses_count -= 1
+            self.close_connection = True
+            return
+
+        self._send_json(
+            200,
+            {
+                "schema": 1,
+                "binding_id": binding_id,
+                "turn_id": turn_id,
+                "disposition": "accepted",
+            },
+        )
+
+
+class _StubHTTPServer(HTTPServer):
+    def __init__(self, server_address: tuple[str, int], stub: BridgeStub) -> None:
+        self.stub = stub
+        super().__init__(server_address, _BridgeHTTPRequestHandler)
+
+
+class BridgeStub:
+    """The test stub HTTP server implementing the Auralis Bridge Contract v1."""
+
+    def __init__(
+        self,
+        token: str = DEFAULT_STUB_TOKEN,
+        *,
+        host: str = "127.0.0.1",
+    ) -> None:
+        self.token = token
+        self.host = host
+        self.port = 0
+        self.health_status = "ok"
+        self.presence_disposition = "present"
+        self.lease_ms = 15000
+        self.renew_after_ms = 5000
+        self.presence_delete_disposition = "absent"
+        self.current_binding: dict[str, Any] | None = None
+        self.current_turn: dict[str, Any] | None = None
+        self.drop_rendering_responses_count = 0
+        self.rendering_500_count = 0
+        self.path_status_overrides: dict[str, tuple[int, str]] = {}
+        self.requests: list[CapturedRequest] = []
+
+        self._server: _StubHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> BridgeStub:
+        """Start the stub HTTP server on a background thread."""
+        self._server = _StubHTTPServer((self.host, 0), self)
+        self.port = self._server.server_port
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, daemon=True
+        )
+        self._thread.start()
+        return self
+
+    def stop(self) -> None:
+        """Shut down the stub HTTP server."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    def __enter__(self) -> BridgeStub:
+        return self.start()
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.stop()
+
+    def set_binding(self, binding_id: str, identity: dict[str, str]) -> None:
+        self.current_binding = {
+            "binding_id": binding_id,
+            "identity": dict(identity),
+        }
+
+    def clear_binding(self) -> None:
+        self.current_binding = None
+        self.current_turn = None
+
+    def set_turn(self, turn_id: str, binding_id: str, state: str = "open") -> None:
+        self.current_turn = {
+            "turn_id": turn_id,
+            "binding_id": binding_id,
+            "state": state,
+        }
+
+    def clear_turn(self) -> None:
+        self.current_turn = None
+
+    def drop_next_rendering_response(self) -> None:
+        self.drop_rendering_responses_count += 1
+
+    def fail_next_rendering_500(self, count: int = 1) -> None:
+        self.rendering_500_count += count
+
+    def write_discovery_file(
+        self,
+        dest_path_or_dir: Path | str,
+        *,
+        mode: int = 0o600,
+        schema: int = 1,
+        host: str | None = None,
+        port: int | None = None,
+        token: str | None = None,
+        extra_keys: dict[str, Any] | None = None,
+    ) -> Path:
+        """Write a discovery bridge.json file pointing to this stub."""
+        target = Path(dest_path_or_dir)
+        if target.is_dir() or target.suffix != ".json":
+            file_path = target / "bridge.json"
+        else:
+            file_path = target
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        payload: dict[str, Any] = {
+            "schema": schema,
+            "host": host if host is not None else self.host,
+            "port": port if port is not None else self.port,
+            "token": token if token is not None else self.token,
+        }
+        if extra_keys:
+            payload.update(extra_keys)
+
+        file_path.write_text(json.dumps(payload), encoding="utf-8")
+        os.chmod(file_path, mode)
+        return file_path

--- a/plugins/voice/tests/test_adapter_identity.py
+++ b/plugins/voice/tests/test_adapter_identity.py
@@ -1,0 +1,295 @@
+"""Tests for the adapter identity resolver (KTD9; §5).
+
+Exercises the Section 5 identity discovery rule across happy paths, env var
+failures, executable failures, timeouts, envelope malformations, zero/multiple
+pane matches, and component-level corruptions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import adapter_identity  # noqa: E402
+import settings  # noqa: E402
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+
+
+def _valid_herdr_envelope(
+    *,
+    pane_id: str = "w1:p1",
+    terminal_id: str = "term-1",
+    session_id: str = "session-abc-123",
+) -> str:
+    return json.dumps(
+        {
+            "result": {
+                "type": "agent_list",
+                "agents": [
+                    {
+                        "pane_id": pane_id,
+                        "terminal_id": terminal_id,
+                        "agent_session": {"value": session_id},
+                    }
+                ],
+            }
+        }
+    )
+
+
+class AdapterIdentityTests(unittest.TestCase):
+    """Happy path and structure tests for AdapterIdentity."""
+
+    def test_happy_path_resolves_three_components_exactly(self) -> None:
+        raw_json = _valid_herdr_envelope(
+            pane_id="w1:p2",
+            terminal_id="t-99",
+            session_id="session-xyz-789",
+        )
+        fake_run = mock.Mock(return_value=_FakeCompletedProcess(raw_json))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p2",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            identity = adapter_identity.resolve_adapter_identity(run_process=fake_run)
+
+        self.assertEqual(identity.agent_session_id, "session-xyz-789")
+        self.assertEqual(identity.pane_id, "w1:p2")
+        self.assertEqual(identity.terminal_id, "t-99")
+        self.assertEqual(
+            identity.to_dict(),
+            {
+                "agent_session_id": "session-xyz-789",
+                "pane_id": "w1:p2",
+                "terminal_id": "t-99",
+            },
+        )
+        fake_run.assert_called_once_with(
+            ["/bin/herdr", "agent", "list"],
+            timeout=adapter_identity.HERDR_TIMEOUT_SECONDS,
+            check=True,
+        )
+
+    def test_matches_session_verification(self) -> None:
+        identity = adapter_identity.AdapterIdentity(
+            agent_session_id="session-1",
+            pane_id="p1",
+            terminal_id="t1",
+        )
+        self.assertTrue(adapter_identity.matches_session(identity, "session-1"))
+        self.assertFalse(adapter_identity.matches_session(identity, "session-2"))
+        self.assertFalse(adapter_identity.matches_session(identity, 123))  # type: ignore[arg-type]
+
+
+class IdentityRefusalTests(unittest.TestCase):
+    """Named refusals on missing/corrupt environment or command failure."""
+
+    def test_refusal_when_pane_id_unset(self) -> None:
+        env = {settings.HERDR_BIN_PATH: "/bin/herdr"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity()
+            self.assertIn("HERDR_PANE_ID", caught.exception.reason)
+
+    def test_refusal_when_bin_path_unset(self) -> None:
+        env = {settings.HERDR_PANE_ID: "w1:p1"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity()
+            self.assertIn("HERDR_BIN_PATH", caught.exception.reason)
+
+    def test_refusal_when_bin_path_empty(self) -> None:
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity()
+            self.assertIn("HERDR_BIN_PATH", caught.exception.reason)
+
+    def test_refusal_when_executable_not_found_or_fails(self) -> None:
+        fake_run = mock.Mock(side_effect=FileNotFoundError("no such file"))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/nonexistent",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("Herdr command failed", caught.exception.reason)
+
+    def test_refusal_when_command_times_out(self) -> None:
+        fake_run = mock.Mock(
+            side_effect=subprocess.TimeoutExpired(
+                cmd=["/bin/herdr", "agent", "list"], timeout=2.0
+            )
+        )
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("timed out", caught.exception.reason)
+
+    def test_refusal_when_output_is_not_json(self) -> None:
+        fake_run = mock.Mock(return_value=_FakeCompletedProcess("not json at all"))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("not valid JSON", caught.exception.reason)
+
+    def test_refusal_when_output_is_not_dict(self) -> None:
+        fake_run = mock.Mock(return_value=_FakeCompletedProcess('["agent_list"]'))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("not a JSON object", caught.exception.reason)
+
+    def test_refusal_when_envelope_result_is_missing_or_not_dict(self) -> None:
+        payload = json.dumps({"type": "agent_list"})
+        fake_run = mock.Mock(return_value=_FakeCompletedProcess(payload))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("not a JSON object", caught.exception.reason)
+
+    def test_refusal_when_envelope_type_is_wrong(self) -> None:
+        payload = json.dumps({"result": {"type": "other_list", "agents": []}})
+        fake_run = mock.Mock(return_value=_FakeCompletedProcess(payload))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("expected 'agent_list'", caught.exception.reason)
+
+    def test_refusal_when_agents_is_not_list(self) -> None:
+        payload = json.dumps({"result": {"type": "agent_list", "agents": {}}})
+        fake_run = mock.Mock(return_value=_FakeCompletedProcess(payload))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("not a list", caught.exception.reason)
+
+    def test_refusal_when_zero_pane_matches(self) -> None:
+        payload = json.dumps(
+            {
+                "result": {
+                    "type": "agent_list",
+                    "agents": [
+                        {
+                            "pane_id": "other_pane",
+                            "terminal_id": "t1",
+                            "agent_session": {"value": "s1"},
+                        }
+                    ],
+                }
+            }
+        )
+        fake_run = mock.Mock(return_value=_FakeCompletedProcess(payload))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("no agent matching pane_id 'w1:p1'", caught.exception.reason)
+
+    def test_refusal_when_multiple_pane_matches(self) -> None:
+        payload = json.dumps(
+            {
+                "result": {
+                    "type": "agent_list",
+                    "agents": [
+                        {
+                            "pane_id": "w1:p1",
+                            "terminal_id": "t1",
+                            "agent_session": {"value": "s1"},
+                        },
+                        {
+                            "pane_id": "w1:p1",
+                            "terminal_id": "t2",
+                            "agent_session": {"value": "s2"},
+                        },
+                    ],
+                }
+            }
+        )
+        fake_run = mock.Mock(return_value=_FakeCompletedProcess(payload))
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(adapter_identity.IdentityRefusal) as caught:
+                adapter_identity.resolve_adapter_identity(run_process=fake_run)
+            self.assertIn("multiple (2) agents matching pane_id", caught.exception.reason)
+
+    def test_refusal_when_component_is_missing_or_empty(self) -> None:
+        corrupted_cases = [
+            ("agent_session is missing", {"pane_id": "w1:p1", "terminal_id": "t1"}),
+            ("agent_session is not dict", {"pane_id": "w1:p1", "terminal_id": "t1", "agent_session": "s1"}),
+            ("agent_session value is missing", {"pane_id": "w1:p1", "terminal_id": "t1", "agent_session": {}}),
+            ("agent_session value is empty", {"pane_id": "w1:p1", "terminal_id": "t1", "agent_session": {"value": ""}}),
+            ("terminal_id is missing", {"pane_id": "w1:p1", "agent_session": {"value": "s1"}}),
+            ("terminal_id is empty", {"pane_id": "w1:p1", "terminal_id": "   ", "agent_session": {"value": "s1"}}),
+            ("pane_id is empty in record", {"pane_id": "", "terminal_id": "t1", "agent_session": {"value": "s1"}}),
+        ]
+        env = {
+            settings.HERDR_PANE_ID: "w1:p1",
+            settings.HERDR_BIN_PATH: "/bin/herdr",
+        }
+        for desc, record in corrupted_cases:
+            with self.subTest(case=desc):
+                # When pane_id is empty in record, test target_pane_id="" matching
+                test_env = dict(env)
+                if record.get("pane_id") == "":
+                    test_env[settings.HERDR_PANE_ID] = ""
+                    # Handled by settings refusal or empty component
+                    with mock.patch.dict(os.environ, test_env, clear=True):
+                        with self.assertRaises(adapter_identity.IdentityRefusal):
+                            adapter_identity.resolve_adapter_identity()
+                    continue
+
+                payload = json.dumps({"result": {"type": "agent_list", "agents": [record]}})
+                fake_run = mock.Mock(return_value=_FakeCompletedProcess(payload))
+                with mock.patch.dict(os.environ, test_env, clear=True):
+                    with self.assertRaises(adapter_identity.IdentityRefusal):
+                        adapter_identity.resolve_adapter_identity(run_process=fake_run)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_bridge_client.py
+++ b/plugins/voice/tests/test_bridge_client.py
@@ -1,0 +1,577 @@
+"""Tests for the bridge wire client (KTD9; §2–§8).
+
+Exercises discovery validation, token grammar, Core-identifier grammar, auth,
+the five routes, transport errors, deadlines, retry after 500, and lost-response
+reconciliation against the independent bridge_stub.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import bridge_client  # noqa: E402
+from adapter_identity import AdapterIdentity  # noqa: E402
+from bridge_client import (  # noqa: E402
+    CONNECT_TIMEOUT_SECONDS,
+    CURRENT_TIMEOUT_SECONDS,
+    HEALTH_TIMEOUT_SECONDS,
+    PRESENCE_TIMEOUT_SECONDS,
+    RENDERING_TIMEOUT_SECONDS,
+    BridgeClient,
+    BridgeConnection,
+    BridgeTransportError,
+    BridgeUnauthorized,
+    BridgeUnavailable,
+    read_discovery,
+)
+from bridge_stub import DEFAULT_STUB_TOKEN, BridgeStub  # noqa: E402
+
+VALID_UUID_1 = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+VALID_UUID_2 = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+UUID_V1 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+
+class DiscoveryValidationTests(unittest.TestCase):
+    """Discovery file validation tests (§2)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.bridge_path = Path(self.temp_dir.name) / "bridge.json"
+
+    def _write_file(self, content: str | dict, mode: int = 0o600) -> Path:
+        if isinstance(content, dict):
+            raw = json.dumps(content)
+        else:
+            raw = content
+        self.bridge_path.write_text(raw, encoding="utf-8")
+        os.chmod(self.bridge_path, mode)
+        return self.bridge_path
+
+    def test_valid_discovery_file_parses(self) -> None:
+        self._write_file(
+            {
+                "schema": 1,
+                "host": "127.0.0.1",
+                "port": 49152,
+                "token": DEFAULT_STUB_TOKEN,
+            }
+        )
+        conn = read_discovery(self.bridge_path)
+        self.assertEqual(conn.schema, 1)
+        self.assertEqual(conn.host, "127.0.0.1")
+        self.assertEqual(conn.port, 49152)
+        self.assertEqual(conn.token, DEFAULT_STUB_TOKEN)
+
+    def test_missing_file_raises_unavailable(self) -> None:
+        non_existent = Path(self.temp_dir.name) / "missing_bridge.json"
+        with self.assertRaises(BridgeUnavailable) as caught:
+            read_discovery(non_existent)
+        self.assertIn("does not exist", str(caught.exception))
+
+    def test_invalid_mode_raises_unavailable(self) -> None:
+        # File mode 0644 (world/group readable) must fail
+        self._write_file(
+            {
+                "schema": 1,
+                "host": "127.0.0.1",
+                "port": 49152,
+                "token": DEFAULT_STUB_TOKEN,
+            },
+            mode=0o644,
+        )
+        with self.assertRaises(BridgeUnavailable) as caught:
+            read_discovery(self.bridge_path)
+        self.assertIn("file mode", str(caught.exception))
+
+    def test_malformed_json_raises_unavailable(self) -> None:
+        self._write_file("{ not json }")
+        with self.assertRaises(BridgeUnavailable):
+            read_discovery(self.bridge_path)
+
+    def test_non_dict_json_raises_unavailable(self) -> None:
+        self._write_file("[1, 2, 3]")
+        with self.assertRaises(BridgeUnavailable):
+            read_discovery(self.bridge_path)
+
+    def test_extra_keys_raise_unavailable(self) -> None:
+        self._write_file(
+            {
+                "schema": 1,
+                "host": "127.0.0.1",
+                "port": 49152,
+                "token": DEFAULT_STUB_TOKEN,
+                "extra_key": "unsupported",
+            }
+        )
+        with self.assertRaises(BridgeUnavailable) as caught:
+            read_discovery(self.bridge_path)
+        self.assertIn("extra_key", str(caught.exception))
+
+    def test_missing_keys_raise_unavailable(self) -> None:
+        self._write_file(
+            {
+                "schema": 1,
+                "host": "127.0.0.1",
+                "port": 49152,
+            }
+        )
+        with self.assertRaises(BridgeUnavailable) as caught:
+            read_discovery(self.bridge_path)
+        self.assertIn("keys", str(caught.exception))
+
+    def test_wrong_member_types_raise_unavailable(self) -> None:
+        cases = [
+            ("schema is string", {"schema": "1", "host": "127.0.0.1", "port": 49152, "token": DEFAULT_STUB_TOKEN}),
+            ("schema is bool", {"schema": True, "host": "127.0.0.1", "port": 49152, "token": DEFAULT_STUB_TOKEN}),
+            ("schema is 2", {"schema": 2, "host": "127.0.0.1", "port": 49152, "token": DEFAULT_STUB_TOKEN}),
+            ("host is not 127.0.0.1", {"schema": 1, "host": "localhost", "port": 49152, "token": DEFAULT_STUB_TOKEN}),
+            ("port is string", {"schema": 1, "host": "127.0.0.1", "port": "49152", "token": DEFAULT_STUB_TOKEN}),
+            ("port out of range", {"schema": 1, "host": "127.0.0.1", "port": 70000, "token": DEFAULT_STUB_TOKEN}),
+            ("token is int", {"schema": 1, "host": "127.0.0.1", "port": 49152, "token": 12345}),
+        ]
+        for name, payload in cases:
+            with self.subTest(case=name):
+                self._write_file(payload)
+                with self.assertRaises(BridgeUnavailable):
+                    read_discovery(self.bridge_path)
+
+
+class TokenGrammarTests(unittest.TestCase):
+    """Token grammar validation tests (§2, §3)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.bridge_path = Path(self.temp_dir.name) / "bridge.json"
+
+    def test_token_grammar_violations_refuse_and_make_no_wire_requests(self) -> None:
+        violations = [
+            ("42 chars (too short)", "a" * 42),
+            ("44 chars (too long)", "a" * 44),
+            ("43 chars with '+' (invalid char)", "a" * 42 + "+"),
+            ("43 chars with '/' (invalid char)", "a" * 42 + "/"),
+            ("padded with '='", "a" * 42 + "="),
+            ("empty token", ""),
+        ]
+
+        with BridgeStub() as stub:
+            for name, token in violations:
+                with self.subTest(violation=name):
+                    stub.requests.clear()
+                    stub.write_discovery_file(
+                        self.bridge_path,
+                        token=token,
+                    )
+                    client = BridgeClient(bridge_file=self.bridge_path)
+                    with self.assertRaises(BridgeUnavailable):
+                        client.get_health()
+
+                    identity = AdapterIdentity("s1", "p1", "t1")
+                    with self.assertRaises(BridgeUnavailable):
+                        client.put_presence(identity)
+
+                    with self.assertRaises(BridgeUnavailable):
+                        client.submit_rendering(identity, VALID_UUID_1, VALID_UUID_2, "hello")
+
+                    # Assert no request ever reached the stub on grammar violation
+                    self.assertEqual(len(stub.requests), 0)
+
+
+class CoreIdentifierGrammarTests(unittest.TestCase):
+    """Core identifier UUIDv4 grammar validation tests (§8)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.bridge_path = Path(self.temp_dir.name) / "bridge.json"
+
+    def test_malformed_uppercase_or_wrong_version_identifier_refuses_snapshot(self) -> None:
+        invalid_ids = [
+            ("uppercase UUID", "F47AC10B-58CC-4372-A567-0E02B2C3D479"),
+            ("not a UUID", "opaque-binding-id-1234"),
+            ("UUID v1 (wrong version)", UUID_V1),
+        ]
+
+        identity = AdapterIdentity("session-1", "p1", "t1")
+
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            for name, bad_id in invalid_ids:
+                with self.subTest(invalid_binding_id=name):
+                    stub.set_binding(bad_id, identity.to_dict())
+                    stub.set_turn(VALID_UUID_2, bad_id, "open")
+                    with self.assertRaises(BridgeUnavailable) as caught:
+                        client.get_current()
+                    self.assertIn("UUIDv4", str(caught.exception))
+
+                with self.subTest(invalid_turn_id=name):
+                    stub.set_binding(VALID_UUID_1, identity.to_dict())
+                    stub.set_turn(bad_id, VALID_UUID_1, "open")
+                    with self.assertRaises(BridgeUnavailable) as caught:
+                        client.get_current()
+                    self.assertIn("UUIDv4", str(caught.exception))
+
+
+class RoutesAndAuthTests(unittest.TestCase):
+    """Tests for the five frozen routes, Auth, and response parsing (§3, §6)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.bridge_path = Path(self.temp_dir.name) / "bridge.json"
+
+    def test_auth_header_and_401_unauthorized(self) -> None:
+        with BridgeStub(token=DEFAULT_STUB_TOKEN) as stub:
+            stub.write_discovery_file(self.bridge_path)
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            # Health check succeeds with correct token
+            resp = client.get_health()
+            self.assertEqual(resp.status, "ok")
+            self.assertEqual(len(stub.requests), 1)
+            self.assertEqual(
+                stub.requests[0].headers.get("Authorization"),
+                f"Bearer {DEFAULT_STUB_TOKEN}",
+            )
+
+            # Rotate token on server to cause 401
+            stub.token = "new_token_43_chars_base64url_alphabet_012345"[:43]
+            with self.assertRaises(BridgeUnauthorized):
+                client.get_health()
+
+    def test_five_routes_round_trip_200(self) -> None:
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            # 1. GET /v1/health
+            health = client.get_health()
+            self.assertEqual(health.service, "auralis-bridge")
+            self.assertEqual(health.status, "ok")
+
+            # 2. PUT /v1/presence
+            pres = client.put_presence(identity)
+            self.assertEqual(pres.disposition, "present")
+            self.assertEqual(pres.lease_ms, 15000)
+            self.assertEqual(pres.renew_after_ms, 5000)
+
+            # 3. DELETE /v1/presence
+            del_pres = client.delete_presence(identity)
+            self.assertEqual(del_pres.disposition, "absent")
+
+            # 4. GET /v1/current (null binding/turn)
+            curr_null = client.get_current()
+            self.assertIsNone(curr_null.binding)
+            self.assertIsNone(curr_null.turn)
+
+            # 4b. GET /v1/current (active binding & turn)
+            stub.set_binding(VALID_UUID_1, identity.to_dict())
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "open")
+            curr_active = client.get_current()
+            self.assertIsNotNone(curr_active.binding)
+            self.assertEqual(curr_active.binding.binding_id, VALID_UUID_1)
+            self.assertEqual(curr_active.binding.identity, identity)
+            self.assertIsNotNone(curr_active.turn)
+            self.assertEqual(curr_active.turn.turn_id, VALID_UUID_2)
+            self.assertEqual(curr_active.turn.state, "open")
+
+            # 5. POST /v1/rendering (accepted)
+            render_resp = client.submit_rendering(
+                identity,
+                VALID_UUID_1,
+                VALID_UUID_2,
+                "Hello, this is a plain text rendering.",
+            )
+            self.assertEqual(render_resp.disposition, "accepted")
+            self.assertEqual(render_resp.detail, "accepted")
+            self.assertEqual(render_resp.binding_id, VALID_UUID_1)
+            self.assertEqual(render_resp.turn_id, VALID_UUID_2)
+
+    def test_rendering_adjudication_rejection_reasons(self) -> None:
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        other_identity = AdapterIdentity("s-2", "p-2", "t-2")
+
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            # no_binding
+            stub.clear_binding()
+            resp = client.submit_rendering(identity, VALID_UUID_1, VALID_UUID_2, "text")
+            self.assertEqual(resp.disposition, "rejected")
+            self.assertEqual(resp.reason, "no_binding")
+
+            # binding_not_current
+            stub.set_binding(VALID_UUID_1, identity.to_dict())
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "open")
+            other_binding = "11111111-1111-4111-8111-111111111111"
+            resp = client.submit_rendering(identity, other_binding, VALID_UUID_2, "text")
+            self.assertEqual(resp.disposition, "rejected")
+            self.assertEqual(resp.reason, "binding_not_current")
+
+            # adapter_not_bound
+            resp = client.submit_rendering(other_identity, VALID_UUID_1, VALID_UUID_2, "text")
+            self.assertEqual(resp.disposition, "rejected")
+            self.assertEqual(resp.reason, "adapter_not_bound")
+
+            # turn_not_current
+            other_turn = "22222222-2222-4222-8222-222222222222"
+            resp = client.submit_rendering(identity, VALID_UUID_1, other_turn, "text")
+            self.assertEqual(resp.disposition, "rejected")
+            self.assertEqual(resp.reason, "turn_not_current")
+
+            # turn_canceled
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "canceled")
+            resp = client.submit_rendering(identity, VALID_UUID_1, VALID_UUID_2, "text")
+            self.assertEqual(resp.disposition, "rejected")
+            self.assertEqual(resp.reason, "turn_canceled")
+
+            # fallback_already_began
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "fallback_accepted")
+            resp = client.submit_rendering(identity, VALID_UUID_1, VALID_UUID_2, "text")
+            self.assertEqual(resp.disposition, "rejected")
+            self.assertEqual(resp.reason, "fallback_already_began")
+
+            # empty_rendering
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "open")
+            resp = client.submit_rendering(identity, VALID_UUID_1, VALID_UUID_2, "   ")
+            self.assertEqual(resp.disposition, "rejected")
+            self.assertEqual(resp.reason, "empty_rendering")
+
+
+class TransportErrorsAndDeadlinesTests(unittest.TestCase):
+    """Tests for transport errors, status mappings, and deadline enforcement (§7)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.bridge_path = Path(self.temp_dir.name) / "bridge.json"
+
+    def test_transport_error_status_mapping(self) -> None:
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        error_cases = [
+            (400, "invalid_request"),
+            (404, "not_found"),
+            (405, "method_not_allowed"),
+            (413, "body_too_large"),
+            (415, "unsupported_media_type"),
+        ]
+
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            for status, err_code in error_cases:
+                with self.subTest(status=status, error_code=err_code):
+                    stub.path_status_overrides["/v1/health"] = (status, err_code)
+                    with self.assertRaises(BridgeTransportError) as caught:
+                        client.get_health()
+                    self.assertEqual(caught.exception.status_code, status)
+                    self.assertEqual(caught.exception.error_code, err_code)
+
+    def test_unknown_status_or_error_fails_closed(self) -> None:
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            stub.path_status_overrides["/v1/health"] = (502, "bad_gateway")
+            with self.assertRaises(BridgeTransportError) as caught:
+                client.get_health()
+            self.assertEqual(caught.exception.status_code, 502)
+
+    def test_deadline_budget_enforcement_with_stubbed_clock(self) -> None:
+        # Verify normative constants from the timeout budget table (§1, §4, §8)
+        self.assertEqual(bridge_client.CONNECT_TIMEOUT_SECONDS, 0.250)
+        self.assertEqual(bridge_client.HEALTH_TIMEOUT_SECONDS, 1.000)
+        self.assertEqual(bridge_client.CURRENT_TIMEOUT_SECONDS, 1.000)
+        self.assertEqual(bridge_client.PRESENCE_TIMEOUT_SECONDS, 2.000)
+        self.assertEqual(bridge_client.RENDERING_TIMEOUT_SECONDS, 2.000)
+
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            stub.set_binding(VALID_UUID_1, identity.to_dict())
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "open")
+
+            # Simulated clock that advances past the deadline immediately
+            current_time = 1000.0
+
+            def advancing_clock() -> float:
+                nonlocal current_time
+                t = current_time
+                current_time += 10.0  # jumps by 10s on each check
+                return t
+
+            client = BridgeClient(bridge_file=self.bridge_path, clock=advancing_clock)
+
+            # Route 1: GET /v1/health
+            with self.assertRaises(BridgeTransportError) as caught:
+                client.get_health()
+            self.assertEqual(caught.exception.error_code, "transport_error")
+
+            # Route 2: GET /v1/current
+            with self.assertRaises(BridgeTransportError) as caught:
+                client.get_current()
+            self.assertEqual(caught.exception.error_code, "transport_error")
+
+            # Route 3: PUT /v1/presence
+            with self.assertRaises(BridgeTransportError) as caught:
+                client.put_presence(identity)
+            self.assertEqual(caught.exception.error_code, "transport_error")
+
+            # Route 4: DELETE /v1/presence
+            with self.assertRaises(BridgeTransportError) as caught:
+                client.delete_presence(identity)
+            self.assertEqual(caught.exception.error_code, "transport_error")
+
+            # Route 5: POST /v1/rendering
+            with self.assertRaises(BridgeTransportError) as caught:
+                client.submit_rendering(identity, VALID_UUID_1, VALID_UUID_2, "text")
+            self.assertEqual(caught.exception.error_code, "transport_error")
+
+
+class RetryAndLostResponseTests(unittest.TestCase):
+    """Tests for 500 retry and lost-response reconciliation (§8; KTD1; F8)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.bridge_path = Path(self.temp_dir.name) / "bridge.json"
+
+    def test_500_retry_performs_one_byte_identical_retry_after_health_check(self) -> None:
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            stub.set_binding(VALID_UUID_1, identity.to_dict())
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "open")
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            # Instruct stub to fail the next rendering POST with 500 internal_error
+            stub.fail_next_rendering_500(count=1)
+            stub.requests.clear()
+
+            # Submit rendering: client sends POST (fails 500) -> GET /v1/health (200 ok) -> retry POST (200 accepted)
+            resp = client.submit_rendering(
+                identity, VALID_UUID_1, VALID_UUID_2, "retry text"
+            )
+            self.assertEqual(resp.disposition, "accepted")
+            self.assertEqual(resp.detail, "accepted")
+
+            # Assert wire interaction sequence: POST /v1/rendering, GET /v1/health, POST /v1/rendering
+            self.assertEqual(len(stub.requests), 3)
+            self.assertEqual([r.method for r in stub.requests], ["POST", "GET", "POST"])
+            self.assertEqual(
+                [r.path for r in stub.requests],
+                ["/v1/rendering", "/v1/health", "/v1/rendering"],
+            )
+
+            # Assert byte-identical request payload and headers on retry (§8; F08)
+            self.assertEqual(stub.requests[0].raw_body, stub.requests[2].raw_body)
+            self.assertEqual(stub.requests[0].body, stub.requests[2].body)
+            self.assertEqual(
+                stub.requests[0].headers.get("Authorization"),
+                stub.requests[2].headers.get("Authorization"),
+            )
+
+    def test_500_retry_aborts_when_health_check_fails(self) -> None:
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            stub.set_binding(VALID_UUID_1, identity.to_dict())
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "open")
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            stub.fail_next_rendering_500(count=1)
+            stub.path_status_overrides["/v1/health"] = (500, "internal_error")
+            stub.requests.clear()
+
+            with self.assertRaises(BridgeTransportError) as caught:
+                client.submit_rendering(
+                    identity, VALID_UUID_1, VALID_UUID_2, "retry text"
+                )
+            self.assertEqual(caught.exception.status_code, 500)
+            self.assertEqual(caught.exception.error_code, "internal_error")
+
+            # Only 2 wire requests were made (no retry POST sent)
+            self.assertEqual(len(stub.requests), 2)
+            self.assertEqual([r.method for r in stub.requests], ["POST", "GET"])
+            self.assertEqual(
+                [r.path for r in stub.requests],
+                ["/v1/rendering", "/v1/health"],
+            )
+
+    def test_400_is_never_retried(self) -> None:
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            stub.path_status_overrides["/v1/rendering"] = (400, "invalid_request")
+            stub.requests.clear()
+
+            with self.assertRaises(BridgeTransportError) as caught:
+                client.submit_rendering(identity, VALID_UUID_1, VALID_UUID_2, "text")
+            self.assertEqual(caught.exception.status_code, 400)
+            # Only 1 request reached the stub; no retry
+            self.assertEqual(len(stub.requests), 1)
+
+    def test_lost_response_reconciliation_f8(self) -> None:
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            stub.set_binding(VALID_UUID_1, identity.to_dict())
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "open")
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            # Drop the first rendering response
+            stub.drop_next_rendering_response()
+
+            # Client should retry:
+            # - Attempt 1: stub accepts and transitions turn state to "authored_accepted", but closes connection without returning response
+            # - Attempt 2: retry request arrives; stub adjudicates against turn state "authored_accepted" and returns 200 {"disposition": "rejected", "reason": "duplicate_rendering"}
+            # - Client reconciles retry context + duplicate_rendering -> returns accepted with detail "accepted_on_retry"
+            resp = client.submit_rendering(
+                identity,
+                VALID_UUID_1,
+                VALID_UUID_2,
+                "Rendered plain text.",
+            )
+
+            self.assertEqual(resp.disposition, "accepted")
+            self.assertEqual(resp.detail, "accepted_on_retry")
+            self.assertEqual(resp.binding_id, VALID_UUID_1)
+            self.assertEqual(resp.turn_id, VALID_UUID_2)
+
+    def test_duplicate_rendering_outside_retry_relays_as_rejected(self) -> None:
+        identity = AdapterIdentity("s-1", "p-1", "t-1")
+        with BridgeStub() as stub:
+            stub.write_discovery_file(self.bridge_path)
+            stub.set_binding(VALID_UUID_1, identity.to_dict())
+            stub.set_turn(VALID_UUID_2, VALID_UUID_1, "authored_accepted")
+            client = BridgeClient(bridge_file=self.bridge_path)
+
+            resp = client.submit_rendering(
+                identity,
+                VALID_UUID_1,
+                VALID_UUID_2,
+                "Second submission.",
+            )
+            self.assertEqual(resp.disposition, "rejected")
+            self.assertEqual(resp.reason, "duplicate_rendering")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_mcp_server.py
+++ b/plugins/voice/tests/test_mcp_server.py
@@ -1,0 +1,737 @@
+"""Tests for the MCP authored-rendering surface and presence lifecycle (U3; R20, R21, R121, R122; KTD1, KTD2, KTD4, KTD8, KTD11).
+
+Exercises:
+- MCP JSON-RPC protocol framing and method dispatch (initialize, ping, tools/list, tools/call);
+- AE26 surface reject-then-accept with no repair;
+- Plain text forwarding verbatim with captured identifiers (R20, KTD4);
+- Wire rejection vocabulary relay verbatim;
+- Session mismatch, missing turn record, and identity refusal availability handling;
+- Presence registration, renewal, re-discovery on 401, and delete on shutdown (KTD2);
+- Lost-response reconciliation (F8);
+- Executable entrypoint subprocess test running declared argv from installed-root copy.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from adapter_identity import AdapterIdentity, IdentityRefusal  # noqa: E402
+from bridge_client import BridgeClient  # noqa: E402
+from bridge_stub import DEFAULT_STUB_TOKEN, BridgeStub  # noqa: E402
+from mcp_server import MCPServer, PresenceWorker, run_server  # noqa: E402
+import turn_record  # noqa: E402
+
+VALID_UUID_1 = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+VALID_UUID_2 = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+VALID_UUID_3 = "a1234567-89ab-4cde-8f01-23456789abcd"
+
+
+class MCPProtocolTests(unittest.TestCase):
+    """Protocol compliance tests for stdlib JSON-RPC 2.0 stdio framing (KTD8)."""
+
+    def setUp(self) -> None:
+        self.server = MCPServer(enable_presence=False)
+
+    def test_initialize_echoes_supported_protocol_version(self) -> None:
+        raw_req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        })
+        raw_resp = self.server.handle_line(raw_req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        self.assertEqual(resp["jsonrpc"], "2.0")
+        self.assertEqual(resp["id"], 1)
+        result = resp["result"]
+        self.assertEqual(result["protocolVersion"], "2024-11-05")
+        self.assertIn("tools", result["capabilities"])
+        self.assertEqual(result["serverInfo"]["name"], "auralis-voice")
+        self.assertEqual(result["serverInfo"]["version"], "0.3.0")
+
+    def test_initialize_falls_back_to_newest_version_when_unsupported(self) -> None:
+        raw_req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "initialize",
+            "params": {"protocolVersion": "1990-01-01"},
+        })
+        raw_resp = self.server.handle_line(raw_req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        self.assertEqual(resp["result"]["protocolVersion"], "2024-11-05")
+
+    def test_notifications_initialized_returns_no_response(self) -> None:
+        raw_req = json.dumps({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        })
+        self.assertIsNone(self.server.handle_line(raw_req))
+
+    def test_ping_returns_empty_result(self) -> None:
+        raw_req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "ping",
+        })
+        raw_resp = self.server.handle_line(raw_req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        self.assertEqual(resp["result"], {})
+
+    def test_tools_list_exposes_submit_spoken_rendering_with_closed_schema(self) -> None:
+        raw_req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/list",
+        })
+        raw_resp = self.server.handle_line(raw_req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        tools = resp["result"]["tools"]
+        self.assertEqual(len(tools), 1)
+        tool = tools[0]
+        self.assertEqual(tool["name"], "submit_spoken_rendering")
+        self.assertEqual(
+            tool["inputSchema"],
+            {
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "type": "string",
+                        "description": "The plain spoken text to be rendered as speech.",
+                    },
+                },
+                "required": ["text"],
+                "additionalProperties": False,
+            },
+        )
+
+    def test_unknown_method_returns_method_not_found_error(self) -> None:
+        raw_req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "unknown_tool_or_method",
+        })
+        raw_resp = self.server.handle_line(raw_req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        self.assertEqual(resp["error"]["code"], -32601)
+        self.assertIn("Method not found", resp["error"]["message"])
+
+    def test_unknown_tool_call_returns_tool_not_found(self) -> None:
+        raw_req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {"name": "invalid_tool", "arguments": {"text": "hi"}},
+        })
+        raw_resp = self.server.handle_line(raw_req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        self.assertEqual(resp["error"]["code"], -32601)
+
+    def test_invalid_tool_call_arguments_returns_invalid_params(self) -> None:
+        raw_req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {"name": "submit_spoken_rendering", "arguments": {"not_text": 123}},
+        })
+        raw_resp = self.server.handle_line(raw_req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        self.assertEqual(resp["error"]["code"], -32602)
+
+    def test_malformed_json_returns_parse_error(self) -> None:
+        raw_resp = self.server.handle_line("{ broken json")
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        self.assertEqual(resp["error"]["code"], -32700)
+
+
+class AE26AndSurfaceRenderingTests(unittest.TestCase):
+    """AE26 and surface gating tests against independent bridge_stub."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.state_dir = Path(self.temp_dir.name) / "state"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.record_path = self.state_dir / turn_record.TURN_RECORD_FILENAME
+
+        self.stub = BridgeStub().start()
+        self.addCleanup(self.stub.stop)
+
+        self.identity = AdapterIdentity(
+            agent_session_id="session-ae26",
+            pane_id="w1:p1",
+            terminal_id="term-1",
+        )
+        self.stub.set_binding(VALID_UUID_1, self.identity.to_dict())
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        self.bridge_file = self.stub.write_discovery_file(self.temp_dir.name)
+        self.client = BridgeClient(
+            bridge_file=self.bridge_file,
+        )
+        self.server = MCPServer(
+            bridge_client_instance=self.client,
+            identity_resolver=lambda: self.identity,
+            turn_record_path=self.record_path,
+            enable_presence=False,
+        )
+
+    def _call_submit(self, text: str, req_id: int = 1) -> dict:
+        req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_spoken_rendering",
+                "arguments": {"text": text},
+            },
+        })
+        raw_resp = self.server.handle_line(req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        self.assertFalse(resp.get("result", {}).get("isError", True))
+        content_text = resp["result"]["content"][0]["text"]
+        return json.loads(content_text)
+
+    def test_ae26_reject_then_accept_no_repair(self) -> None:
+        # Initialize turn record with prompt-time captured identifiers
+        turn_record.init_turn(
+            session_id=self.identity.agent_session_id,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+
+        # 1. Submission containing Markdown emphasis and fenced code block
+        rejected_text = "Here is a **bold** proposal:\n```python\nprint('hello')\n```"
+        tool_payload = self._call_submit(rejected_text, req_id=1)
+
+        self.assertEqual(tool_payload["disposition"], "rejected_content")
+        self.assertEqual(tool_payload["reason"], "fenced_code_block")
+        self.assertIn("fenced_code_block", tool_payload["detail"]["detected_classes"])
+
+        # Assert nothing was forwarded to the wire
+        rendering_requests = [
+            r for r in self.stub.requests if r.path == "/v1/rendering" and r.method == "POST"
+        ]
+        self.assertEqual(len(rendering_requests), 0)
+
+        # Assert turn record recorded the rejected submission
+        rec = turn_record.read_turn_record(self.record_path)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(rec.submissions), 1)  # type: ignore[union-attr]
+        self.assertEqual(rec.submissions[0]["disposition"], "rejected_content")  # type: ignore[union-attr]
+        self.assertEqual(rec.submissions[0]["reason"], "fenced_code_block")  # type: ignore[union-attr]
+        # Verify no cleaned text exists in state
+        self.assertEqual(rec.submissions[0]["text"], rejected_text)  # type: ignore[union-attr]
+
+        # 2. Resubmission with plain text on the same turn
+        plain_text = "Here is a bold proposal, and we print hello."
+        accept_payload = self._call_submit(plain_text, req_id=2)
+
+        self.assertEqual(accept_payload["disposition"], "accepted")
+        self.assertEqual(accept_payload["detail"], "accepted")
+
+        # Assert stub received POST /v1/rendering with exact byte-identical text and captured IDs
+        rendering_requests = [
+            r for r in self.stub.requests if r.path == "/v1/rendering" and r.method == "POST"
+        ]
+        self.assertEqual(len(rendering_requests), 1)
+        req_body = rendering_requests[0].body
+        self.assertIsNotNone(req_body)
+        self.assertEqual(req_body["binding_id"], VALID_UUID_1)  # type: ignore[index]
+        self.assertEqual(req_body["turn_id"], VALID_UUID_2)  # type: ignore[index]
+        self.assertEqual(req_body["text"], plain_text)  # type: ignore[index]
+        self.assertEqual(req_body["identity"], self.identity.to_dict())  # type: ignore[index]
+
+        # Assert turn record now carries both submissions
+        rec = turn_record.read_turn_record(self.record_path)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(rec.submissions), 2)  # type: ignore[union-attr]
+        self.assertEqual(rec.submissions[1]["disposition"], "accepted")  # type: ignore[union-attr]
+        self.assertEqual(rec.submissions[1]["text"], plain_text)  # type: ignore[union-attr]
+
+    def test_forwarding_uses_captured_identifiers_not_stub_current(self) -> None:
+        # Turn record holds captured turn VALID_UUID_2
+        turn_record.init_turn(
+            session_id=self.identity.agent_session_id,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+
+        # Advance stub's current turn to VALID_UUID_3
+        self.stub.set_turn(VALID_UUID_3, VALID_UUID_1, state="open")
+
+        # Submit plain text
+        payload = self._call_submit("Plain text targeting captured turn", req_id=3)
+
+        # The submission forwarded captured pair (VALID_UUID_2); stub adjudicated turn_not_current
+        self.assertEqual(payload["disposition"], "rejected_by_core")
+        self.assertEqual(payload["reason"], "turn_not_current")
+
+        rec = turn_record.read_turn_record(self.record_path)
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.submissions[-1]["disposition"], "rejected_by_core")  # type: ignore[union-attr]
+        self.assertEqual(rec.submissions[-1]["reason"], "turn_not_current")  # type: ignore[union-attr]
+
+    def test_wire_rejection_reasons_relayed_verbatim(self) -> None:
+        turn_record.init_turn(
+            session_id=self.identity.agent_session_id,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+
+        wire_reasons = [
+            ("canceled", "turn_canceled"),
+            ("fallback_accepted", "fallback_already_began"),
+            ("authored_accepted", "duplicate_rendering"),
+        ]
+
+        for stub_state, expected_reason in wire_reasons:
+            with self.subTest(stub_state=stub_state, expected_reason=expected_reason):
+                self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state=stub_state)
+                payload = self._call_submit("Plain text", req_id=4)
+                self.assertEqual(payload["disposition"], "rejected_by_core")
+                self.assertEqual(payload["reason"], expected_reason)
+
+    def test_no_turn_record_returns_unavailable_no_current_turn(self) -> None:
+        # No turn record exists in state dir
+        if self.record_path.exists():
+            self.record_path.unlink()
+
+        payload = self._call_submit("Plain text without active record", req_id=5)
+        self.assertEqual(payload["disposition"], "unavailable")
+        self.assertEqual(payload["reason"], "no_current_turn")
+
+        # Zero wire calls
+        rendering_requests = [
+            r for r in self.stub.requests if r.path == "/v1/rendering" and r.method == "POST"
+        ]
+        self.assertEqual(len(rendering_requests), 0)
+
+    def test_record_session_mismatch_returns_unavailable_no_current_turn(self) -> None:
+        # Turn record for a different session
+        turn_record.init_turn(
+            session_id="other-session-id",
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+
+        payload = self._call_submit("Plain text with mismatched session", req_id=6)
+        self.assertEqual(payload["disposition"], "unavailable")
+        self.assertEqual(payload["reason"], "no_current_turn")
+
+    def test_identity_refusal_returns_unavailable_not_bound(self) -> None:
+        turn_record.init_turn(
+            session_id=self.identity.agent_session_id,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+
+        def _refuse_identity() -> AdapterIdentity:
+            raise IdentityRefusal("HERDR_PANE_ID missing")
+
+        unbound_server = MCPServer(
+            bridge_client_instance=self.client,
+            identity_resolver=_refuse_identity,
+            turn_record_path=self.record_path,
+            enable_presence=False,
+        )
+
+        req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_spoken_rendering",
+                "arguments": {"text": "Plain text"},
+            },
+        })
+        raw_resp = unbound_server.handle_line(req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        tool_payload = json.loads(resp["result"]["content"][0]["text"])
+        self.assertEqual(tool_payload["disposition"], "unavailable")
+        self.assertEqual(tool_payload["reason"], "not_bound")
+
+    def test_gating_turn_record_busy_returns_unavailable_without_touching_wire(self) -> None:
+        turn_record.init_turn(
+            session_id=self.identity.agent_session_id,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+
+        with mock.patch("mcp_server.record_submission", side_effect=turn_record.TurnRecordBusy("lock busy")):
+            payload = self._call_submit("Heading:\n# Title", req_id=10)
+
+        self.assertEqual(payload["disposition"], "unavailable")
+        self.assertEqual(payload["reason"], "turn_record_busy")
+        self.assertEqual(self.stub.requests, [])
+
+    def test_accepted_rendering_with_turn_record_busy_after_wire_still_returns_accepted(self) -> None:
+        turn_record.init_turn(
+            session_id=self.identity.agent_session_id,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+
+        with mock.patch("mcp_server.record_submission", side_effect=turn_record.TurnRecordBusy("lock busy")):
+            payload = self._call_submit("Plain text rendering accepted by wire", req_id=11)
+
+        self.assertEqual(payload["disposition"], "accepted")
+        self.assertEqual(payload["detail"], "accepted")
+        rendering_requests = [r for r in self.stub.requests if r.path == "/v1/rendering"]
+        self.assertEqual(len(rendering_requests), 1)
+
+    def test_rejected_rendering_with_turn_record_busy_after_wire_still_returns_rejected(self) -> None:
+        turn_record.init_turn(
+            session_id=self.identity.agent_session_id,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+        self.stub.set_turn(VALID_UUID_3, VALID_UUID_1, state="open")
+
+        with mock.patch("mcp_server.record_submission", side_effect=turn_record.TurnRecordBusy("lock busy")):
+            payload = self._call_submit("Plain text rendering targeting old turn", req_id=12)
+
+        self.assertEqual(payload["disposition"], "rejected_by_core")
+        self.assertEqual(payload["reason"], "turn_not_current")
+
+
+class LostResponseReconciliationSurfaceTests(unittest.TestCase):
+    """Surface-level lost response reconciliation tests (F8; §8)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.state_dir = Path(self.temp_dir.name) / "state"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.record_path = self.state_dir / turn_record.TURN_RECORD_FILENAME
+
+        self.stub = BridgeStub().start()
+        self.addCleanup(self.stub.stop)
+
+        self.identity = AdapterIdentity(
+            agent_session_id="session-f8",
+            pane_id="w1:p1",
+            terminal_id="term-1",
+        )
+        self.stub.set_binding(VALID_UUID_1, self.identity.to_dict())
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        self.bridge_file = self.stub.write_discovery_file(self.temp_dir.name)
+        self.client = BridgeClient(
+            bridge_file=self.bridge_file,
+        )
+        self.server = MCPServer(
+            bridge_client_instance=self.client,
+            identity_resolver=lambda: self.identity,
+            turn_record_path=self.record_path,
+            enable_presence=False,
+        )
+
+    def test_lost_response_reconciles_to_accepted_on_retry(self) -> None:
+        turn_record.init_turn(
+            session_id=self.identity.agent_session_id,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.record_path,
+        )
+
+        # Instruct stub to accept the first request but drop the HTTP response
+        self.stub.drop_next_rendering_response()
+
+        req = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_spoken_rendering",
+                "arguments": {"text": "Plain text with lost response"},
+            },
+        })
+        raw_resp = self.server.handle_line(req)
+        self.assertIsNotNone(raw_resp)
+        resp = json.loads(raw_resp)  # type: ignore[arg-type]
+        tool_payload = json.loads(resp["result"]["content"][0]["text"])
+
+        # Tool result reports accepted with detail accepted_on_retry
+        self.assertEqual(tool_payload["disposition"], "accepted")
+        self.assertEqual(tool_payload["detail"], "accepted_on_retry")
+
+        # Turn record records disposition accepted
+        rec = turn_record.read_turn_record(self.record_path)
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.submissions[-1]["disposition"], "accepted")  # type: ignore[union-attr]
+        self.assertEqual(rec.submissions[-1]["detail"], {"detail": "accepted_on_retry"})  # type: ignore[union-attr]
+
+
+class PresenceLifecycleTests(unittest.TestCase):
+    """Presence background worker tests (KTD2; §6.2, §6.3)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.stub = BridgeStub().start()
+        self.addCleanup(self.stub.stop)
+        self.identity = AdapterIdentity(
+            agent_session_id="session-presence",
+            pane_id="w1:p1",
+            terminal_id="term-1",
+        )
+        self.bridge_file = self.stub.write_discovery_file(self.temp_dir.name)
+        self.client = BridgeClient(
+            bridge_file=self.bridge_file,
+        )
+
+    def test_presence_registration_renewal_and_deletion(self) -> None:
+        worker = PresenceWorker(
+            bridge_client_instance=self.client,
+            identity_resolver=lambda: self.identity,
+        )
+        # Initial registration
+        self.assertTrue(worker.tick())
+        self.assertEqual(worker.registration_count, 1)
+        self.assertEqual(worker.renewal_count, 0)
+
+        put_requests = [
+            r for r in self.stub.requests if r.path == "/v1/presence" and r.method == "PUT"
+        ]
+        self.assertEqual(len(put_requests), 1)
+        self.assertEqual(put_requests[0].body["identity"], self.identity.to_dict())  # type: ignore[index]
+
+        # Renewal tick
+        self.assertTrue(worker.tick())
+        self.assertEqual(worker.registration_count, 1)
+        self.assertEqual(worker.renewal_count, 1)
+
+        # Deletion on stop / shutdown
+        self.assertTrue(worker.delete_presence())
+        del_requests = [
+            r for r in self.stub.requests if r.path == "/v1/presence" and r.method == "DELETE"
+        ]
+        self.assertEqual(len(del_requests), 1)
+        self.assertEqual(del_requests[0].body["identity"], self.identity.to_dict())  # type: ignore[index]
+
+    def test_presence_re_discovery_on_token_rotation(self) -> None:
+        worker = PresenceWorker(
+            bridge_client_instance=self.client,
+            identity_resolver=lambda: self.identity,
+        )
+        self.assertTrue(worker.tick())
+
+        # Rotate token on stub
+        new_token = "new_token_43_chars_base64url_alphabet_01234"
+        self.stub.token = new_token
+        # First tick gets 401 Unauthorized and resets client connection
+        self.assertFalse(worker.tick())
+
+        # Write updated discovery file
+        self.stub.write_discovery_file(self.temp_dir.name)
+        # Next tick re-discovers new token and succeeds
+        self.assertTrue(worker.tick())
+
+    def test_presence_re_discovery_on_connection_refusal(self) -> None:
+        worker = PresenceWorker(
+            bridge_client_instance=self.client,
+            identity_resolver=lambda: self.identity,
+        )
+        self.assertTrue(worker.tick())
+        self.assertEqual(worker.registration_count, 1)
+
+        # Stop the stub to simulate connection refusal / bridge down
+        self.stub.stop()
+
+        # Tick fails and resets connection + registered_identity
+        self.assertFalse(worker.tick())
+        self.assertIsNone(worker.registered_identity)
+
+        # Restart stub on a new port and write new discovery file
+        self.stub = BridgeStub().start()
+        self.stub.set_binding(VALID_UUID_1, self.identity.to_dict())
+        self.stub.write_discovery_file(self.temp_dir.name)
+
+        # Next tick re-reads discovery, connects to new stub, and registers anew
+        self.assertTrue(worker.tick())
+        self.assertEqual(worker.registration_count, 2)
+
+
+class ExecutableEntrypointTests(unittest.TestCase):
+    """Declared MCP server entrypoint subprocess test (AGENTS.md executable entrypoint rule)."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+
+        # Set up installed-root copy of plugins/voice
+        repo_voice_root = Path(__file__).resolve().parents[1]
+        self.installed_root = Path(self.temp_dir.name) / "voice"
+        shutil.copytree(repo_voice_root, self.installed_root)
+
+        # Set up state dir and home dir
+        self.state_dir = Path(self.temp_dir.name) / "state"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.home_dir = Path(self.temp_dir.name) / "home"
+        self.home_dir.mkdir(parents=True, exist_ok=True)
+
+        # Set up bridge stub and write bridge.json into simulated HOME
+        self.stub = BridgeStub().start()
+        self.addCleanup(self.stub.stop)
+        bridge_dir = self.home_dir / "Library" / "Application Support" / "Auralis"
+        self.stub.write_discovery_file(bridge_dir)
+
+        # Set up mock herdr executable
+        self.herdr_path = Path(self.temp_dir.name) / "mock_herdr"
+        mock_herdr_code = (
+            "#!/bin/sh\n"
+            'echo \'{"result": {"type": "agent_list", "agents": [{"pane_id": "pane-subproc-1", "terminal_id": "term-subproc-1", "agent_session": {"value": "session-subproc-1"}}]}}\'\n'
+        )
+        self.herdr_path.write_text(mock_herdr_code, encoding="utf-8")
+        os.chmod(self.herdr_path, 0o755)
+
+        # Set stub binding and turn
+        self.identity_dict = {
+            "agent_session_id": "session-subproc-1",
+            "pane_id": "pane-subproc-1",
+            "terminal_id": "term-subproc-1",
+        }
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        # Initialize turn record in VOICE_STATE_DIR
+        turn_record.init_turn(
+            session_id="session-subproc-1",
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+
+    def test_declared_mcp_server_entrypoint_subprocess(self) -> None:
+        server_script = self.installed_root / "scripts" / "mcp_server.py"
+        self.assertTrue(server_script.is_file())
+
+        env = dict(os.environ)
+        env["HOME"] = str(self.home_dir)
+        env["VOICE_STATE_DIR"] = str(self.state_dir)
+        env["HERDR_PANE_ID"] = "pane-subproc-1"
+        env["HERDR_BIN_PATH"] = str(self.herdr_path)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+        proc = subprocess.Popen(
+            ["python3", str(server_script)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
+        )
+
+        def send_and_recv(msg: dict) -> dict:
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            proc.stdin.write(json.dumps(msg) + "\n")
+            proc.stdin.flush()
+            line = proc.stdout.readline()
+            if not line:
+                stderr_text = proc.stderr.read() if proc.stderr else ""
+                self.fail(f"server closed stdout unexpectedly; stderr:\n{stderr_text}")
+            return json.loads(line)
+
+        # 1. initialize
+        init_resp = send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05"},
+        })
+        self.assertEqual(init_resp["result"]["protocolVersion"], "2024-11-05")
+        self.assertEqual(init_resp["result"]["serverInfo"]["name"], "auralis-voice")
+
+        # 2. tools/list
+        list_resp = send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+        })
+        tools = list_resp["result"]["tools"]
+        self.assertEqual(len(tools), 1)
+        self.assertEqual(tools[0]["name"], "submit_spoken_rendering")
+
+        # 3. tools/call (rejected Markdown)
+        call_rej_resp = send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_spoken_rendering",
+                "arguments": {"text": "Heading:\n# Title\nSome **bold** prose."},
+            },
+        })
+        rej_payload = json.loads(call_rej_resp["result"]["content"][0]["text"])
+        self.assertEqual(rej_payload["disposition"], "rejected_content")
+        self.assertEqual(rej_payload["reason"], "markdown_formatting")
+
+        # 4. tools/call (accepted plain text)
+        call_acc_resp = send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_spoken_rendering",
+                "arguments": {"text": "Title. Some bold prose."},
+            },
+        })
+        acc_payload = json.loads(call_acc_resp["result"]["content"][0]["text"])
+        self.assertEqual(acc_payload["disposition"], "accepted")
+
+        # 5. Clean termination on stdin EOF
+        assert proc.stdin is not None
+        proc.stdin.close()
+        exit_code = proc.wait(timeout=5.0)
+        if proc.stdout is not None:
+            proc.stdout.close()
+        if proc.stderr is not None:
+            proc.stderr.close()
+        self.assertEqual(exit_code, 0)
+
+        # Verify turn record was updated by the subprocess
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(rec.submissions), 2)  # type: ignore[union-attr]
+        self.assertEqual(rec.submissions[0]["disposition"], "rejected_content")  # type: ignore[union-attr]
+        self.assertEqual(rec.submissions[1]["disposition"], "accepted")  # type: ignore[union-attr]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_pre_tool_use_hook.py
+++ b/plugins/voice/tests/test_pre_tool_use_hook.py
@@ -1,0 +1,223 @@
+"""Tests for the Claude PreToolUse hook (U4; KTD7, KTD11; X1).
+
+Exercises:
+- Auralis-originated turn tool observation recording (observe-only, no stdout output ever);
+- Policy tool allow-list filtering;
+- Non-originated turn: no observation recorded;
+- Session ID mismatch / missing turn record: no observation recorded;
+- Turn record lock busy / exceptions: silent exit 0;
+- Malformed inputs: silent exit 0.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "com.infiquetra.claude" / "hooks"))
+
+import pre_tool_use_hook  # noqa: E402
+import turn_record  # noqa: E402
+import voice_policy  # noqa: E402
+
+AGENT_SESSION_ID = "session-test-pretool-1"
+
+
+class PreToolUseHookTests(unittest.TestCase):
+    """Test suite for pre_tool_use_hook.py."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        self.env_patcher = mock.patch.dict(
+            os.environ, {"VOICE_STATE_DIR": str(self.state_dir)}
+        )
+        self.env_patcher.start()
+        self.addCleanup(self.env_patcher.stop)
+
+    def run_hook(self, stdin_text: str) -> tuple[int, str]:
+        """Run pre_tool_use_hook.main() with injected stdin and captured stdout."""
+        stdin_stream = io.StringIO(stdin_text)
+        stdout_stream = io.StringIO()
+        with (
+            mock.patch.object(sys, "stdin", stdin_stream),
+            mock.patch.object(sys, "stdout", stdout_stream),
+        ):
+            code = pre_tool_use_hook.main()
+        return code, stdout_stream.getvalue()
+
+    def test_originated_turn_records_observation(self) -> None:
+        # Initialize an Auralis-originated turn
+        turn_record.init_turn(
+            session_id=AGENT_SESSION_ID,
+            binding_id="b1111111-1111-4111-8111-111111111111",
+            turn_id="t1111111-1111-4111-8111-111111111111",
+            origin=turn_record.ORIGIN_AURALIS,
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+
+        payload = {
+            "session_id": AGENT_SESSION_ID,
+            "tool_name": "Bash",
+            "tool_input": {"command": "git status"},
+            "tool_use_id": "toolu_01ABC",
+        }
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "", "PreToolUse hook must never emit output")
+
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(rec.tool_observations), 1)  # type: ignore[union-attr]
+        obs = rec.tool_observations[0]  # type: ignore[union-attr]
+        self.assertEqual(obs["tool_name"], "Bash")
+        self.assertEqual(obs["tool_input"], {"command": "git status"})
+        self.assertEqual(obs["tool_use_id"], "toolu_01ABC")
+
+    def test_allowlist_filtering_records_only_allowed_tools(self) -> None:
+        turn_record.init_turn(
+            session_id=AGENT_SESSION_ID,
+            origin=turn_record.ORIGIN_AURALIS,
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+
+        # Set allow-list in policy
+        voice_policy.write_policy(
+            tool_allowlist=["Read", "Write"],
+            path=self.state_dir / voice_policy.POLICY_FILENAME,
+        )
+
+        # 1. Tool not in allow-list -> not recorded
+        payload_bash = {
+            "session_id": AGENT_SESSION_ID,
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_use_id": "toolu_bash",
+        }
+        code, stdout_text = self.run_hook(json.dumps(payload_bash))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(rec.tool_observations), 0)  # type: ignore[union-attr]
+
+        # 2. Tool in allow-list -> recorded
+        payload_read = {
+            "session_id": AGENT_SESSION_ID,
+            "tool_name": "Read",
+            "tool_input": {"file": "main.py"},
+            "tool_use_id": "toolu_read",
+        }
+        code, stdout_text = self.run_hook(json.dumps(payload_read))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(rec.tool_observations), 1)  # type: ignore[union-attr]
+        self.assertEqual(rec.tool_observations[0]["tool_name"], "Read")  # type: ignore[union-attr]
+
+    def test_non_originated_turn_records_nothing(self) -> None:
+        turn_record.init_turn(
+            session_id=AGENT_SESSION_ID,
+            origin=turn_record.ORIGIN_NOT_ORIGINATED,
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+
+        payload = {
+            "session_id": AGENT_SESSION_ID,
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_use_id": "toolu_01",
+        }
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(rec.tool_observations), 0)  # type: ignore[union-attr]
+
+    def test_session_id_mismatch_records_nothing(self) -> None:
+        turn_record.init_turn(
+            session_id="session-other",
+            origin=turn_record.ORIGIN_AURALIS,
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+
+        payload = {
+            "session_id": AGENT_SESSION_ID,
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_use_id": "toolu_01",
+        }
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(len(rec.tool_observations), 0)  # type: ignore[union-attr]
+
+    def test_no_turn_record_exits_zero_with_no_output(self) -> None:
+        payload = {
+            "session_id": AGENT_SESSION_ID,
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_use_id": "toolu_01",
+        }
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+    def test_turn_record_busy_exits_zero_and_drops_observation(self) -> None:
+        turn_record.init_turn(
+            session_id=AGENT_SESSION_ID,
+            origin=turn_record.ORIGIN_AURALIS,
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+
+        with mock.patch.object(
+            turn_record,
+            "record_tool_observation",
+            side_effect=turn_record.TurnRecordBusy("turn_record_busy"),
+        ):
+            payload = {
+                "session_id": AGENT_SESSION_ID,
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"},
+                "tool_use_id": "toolu_01",
+            }
+            code, stdout_text = self.run_hook(json.dumps(payload))
+            self.assertEqual(code, 0)
+            self.assertEqual(stdout_text, "")
+
+    def test_malformed_input_exits_zero_with_no_output(self) -> None:
+        for malformed in [
+            "",
+            "not json",
+            "[]",
+            json.dumps({"session_id": AGENT_SESSION_ID}),
+            json.dumps({"session_id": AGENT_SESSION_ID, "tool_name": "Bash"}),
+            json.dumps({"session_id": "", "tool_name": "Bash", "tool_use_id": "1"}),
+        ]:
+            with self.subTest(malformed=malformed):
+                code, stdout_text = self.run_hook(malformed)
+                self.assertEqual(code, 0)
+                self.assertEqual(stdout_text, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_r122_adapter_boundary.py
+++ b/plugins/voice/tests/test_r122_adapter_boundary.py
@@ -1,0 +1,406 @@
+"""Integration test for R122 at the adapter boundary across production processes (U4; R122, R22, R23, R121; KTD1, KTD3, KTD4, KTD6, KTD11).
+
+Exercises the complete adapter-side lifecycle with real subprocesses and real pipes:
+1. The BridgeStub on loopback port hosts an open turn bound to the adapter identity;
+2. Real ``user_prompt_submit_hook.py`` runs as a subprocess, captures the (binding_id, turn_id)
+   pair into the turn record, and injects context;
+3. Real ``mcp_server.py`` runs as a subprocess at its declared argv and receives a Markdown
+   rendering via ``tools/call submit_spoken_rendering``; the gate rejects it with a named
+   ``rejected_content`` reason, and nothing is forwarded to the bridge;
+4. No replacement rendering is submitted;
+5. Real ``stop_hook.py`` runs as a subprocess for the completing turn;
+6. The resulting turn record on disk contains the full audit trail: the prompt-time captured
+   identifiers, the named content rejection, and the reconciled ``fallback`` outcome, with
+   no local speak child spawned.
+
+This proves the adapter-side half of R122 entirely through production entrypoints.
+The Core-side half (turn marked fallback_accepted in Core) is proven by the joint AE36 test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bridge_stub import DEFAULT_STUB_TOKEN, BridgeStub  # noqa: E402
+import turn_record  # noqa: E402
+
+VALID_UUID_1 = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+VALID_UUID_2 = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+
+AGENT_SESSION_ID = "session-r122-proc-1"
+PANE_ID = "pane-r122-proc-1"
+TERMINAL_ID = "term-r122-proc-1"
+
+
+class R122AdapterBoundaryTests(unittest.TestCase):
+    """Adapter-boundary lifecycle test across production subprocesses."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+
+        self.home_dir = self.root / "home"
+        self.home_dir.mkdir(parents=True, exist_ok=True)
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        # Mirror installed plugin directory structure
+        self.package_source = Path(__file__).resolve().parents[1]
+        self.installed_root = self.root / "installed_plugin"
+        shutil.copytree(self.package_source, self.installed_root)
+
+        # Stand up BridgeStub
+        self.stub = BridgeStub()
+        self.stub.start()
+        self.addCleanup(self.stub.stop)
+
+        # Write discovery bridge.json (mode 0600)
+        self.bridge_dir = self.home_dir / "Library" / "Application Support" / "Auralis"
+        self.bridge_dir.mkdir(parents=True, exist_ok=True)
+        self.bridge_file = self.bridge_dir / "bridge.json"
+        bridge_payload = {
+            "schema": 1,
+            "host": "127.0.0.1",
+            "port": self.stub.port,
+            "token": DEFAULT_STUB_TOKEN,
+        }
+        self.bridge_file.write_text(json.dumps(bridge_payload), encoding="utf-8")
+        os.chmod(self.bridge_file, stat.S_IRUSR | stat.S_IWUSR)
+
+        # Write mock Herdr script
+        self.herdr_path = self.root / "fake_herdr"
+        herdr_envelope = {
+            "result": {
+                "type": "agent_list",
+                "agents": [
+                    {
+                        "pane_id": PANE_ID,
+                        "terminal_id": TERMINAL_ID,
+                        "agent_session": {"value": AGENT_SESSION_ID},
+                    }
+                ],
+            }
+        }
+        mock_herdr_code = (
+            f"#!/usr/bin/env python3\n"
+            f"import sys\n"
+            f"sys.stdout.write({json.dumps(json.dumps(herdr_envelope))} + '\\n')\n"
+        )
+        self.herdr_path.write_text(mock_herdr_code, encoding="utf-8")
+        os.chmod(self.herdr_path, 0o755)
+
+        # Subprocess environment
+        self.env = dict(os.environ)
+        self.env["HOME"] = str(self.home_dir)
+        self.env["VOICE_STATE_DIR"] = str(self.state_dir)
+        self.env["HERDR_PANE_ID"] = PANE_ID
+        self.env["HERDR_BIN_PATH"] = str(self.herdr_path)
+        self.env["PYTHONDONTWRITEBYTECODE"] = "1"
+
+        self.identity_dict = {
+            "agent_session_id": AGENT_SESSION_ID,
+            "pane_id": PANE_ID,
+            "terminal_id": TERMINAL_ID,
+        }
+
+    def test_r122_adapter_boundary_rejection_no_replacement_settles_fallback(
+        self,
+    ) -> None:
+        # Configure bridge with an active binding epoch and open turn
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        # ---------------------------------------------------------------------
+        # Step 1: Real UserPromptSubmit hook subprocess runs
+        # ---------------------------------------------------------------------
+        prompt_script = (
+            self.installed_root
+            / "com.infiquetra.claude"
+            / "hooks"
+            / "user_prompt_submit_hook.py"
+        )
+        self.assertTrue(prompt_script.is_file())
+
+        prompt_payload = {
+            "session_id": AGENT_SESSION_ID,
+            "prompt": "Operator spoken prompt transcribed by Auralis",
+        }
+        prompt_proc = subprocess.run(
+            [sys.executable, str(prompt_script)],
+            input=json.dumps(prompt_payload),
+            capture_output=True,
+            text=True,
+            env=self.env,
+            check=True,
+        )
+        self.assertEqual(prompt_proc.returncode, 0)
+        prompt_output = json.loads(prompt_proc.stdout)
+        self.assertIn(
+            "This turn originated through Auralis voice.",
+            prompt_output["hookSpecificOutput"]["additionalContext"],
+        )
+
+        # Verify prompt hook captured identifiers into the turn record
+        rec_after_prompt = turn_record.read_turn_record(
+            self.state_dir / turn_record.TURN_RECORD_FILENAME
+        )
+        self.assertIsNotNone(rec_after_prompt)
+        assert rec_after_prompt is not None
+        self.assertEqual(rec_after_prompt.session_id, AGENT_SESSION_ID)
+        self.assertEqual(rec_after_prompt.binding_id, VALID_UUID_1)
+        self.assertEqual(rec_after_prompt.turn_id, VALID_UUID_2)
+        self.assertEqual(rec_after_prompt.origin, turn_record.ORIGIN_AURALIS)
+        self.assertIsNone(rec_after_prompt.outcome)
+        self.assertEqual(rec_after_prompt.submissions, [])
+
+        # ---------------------------------------------------------------------
+        # Step 2: Real MCP Server subprocess runs and rejects Markdown rendering
+        # ---------------------------------------------------------------------
+        server_script = self.installed_root / "scripts" / "mcp_server.py"
+        self.assertTrue(server_script.is_file())
+
+        server_proc = subprocess.Popen(
+            [sys.executable, str(server_script)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self.env,
+        )
+
+        def send_and_recv(msg: dict) -> dict:
+            assert server_proc.stdin is not None
+            assert server_proc.stdout is not None
+            server_proc.stdin.write(json.dumps(msg) + "\n")
+            server_proc.stdin.flush()
+            line = server_proc.stdout.readline()
+            if not line:
+                stderr_text = server_proc.stderr.read() if server_proc.stderr else ""
+                self.fail(f"server closed stdout unexpectedly; stderr:\n{stderr_text}")
+            return json.loads(line)
+
+        # Initialize MCP session
+        init_resp = send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05"},
+        })
+        self.assertEqual(init_resp["result"]["protocolVersion"], "2024-11-05")
+
+        # Submit Markdown formatting (R121 rejection)
+        rej_resp = send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_spoken_rendering",
+                "arguments": {
+                    "text": "Here is the summary:\n- Item 1: **bold**\n- Item 2: `code`"
+                },
+            },
+        })
+        rej_content = json.loads(rej_resp["result"]["content"][0]["text"])
+        self.assertEqual(rej_content["disposition"], "rejected_content")
+        self.assertEqual(rej_content["reason"], "markdown_formatting")
+
+        # Assert nothing reached the wire / POST /v1/rendering
+        rendering_requests = [
+            req for req in self.stub.requests if req.path == "/v1/rendering"
+        ]
+        self.assertEqual(rendering_requests, [])
+
+        # Close MCP server
+        assert server_proc.stdin is not None
+        server_proc.stdin.close()
+        exit_code = server_proc.wait(timeout=5.0)
+        if server_proc.stdout:
+            server_proc.stdout.close()
+        if server_proc.stderr:
+            server_proc.stderr.close()
+        self.assertEqual(exit_code, 0)
+
+        # Verify turn record contains the rejected submission
+        rec_after_mcp = turn_record.read_turn_record(
+            self.state_dir / turn_record.TURN_RECORD_FILENAME
+        )
+        self.assertIsNotNone(rec_after_mcp)
+        assert rec_after_mcp is not None
+        self.assertEqual(len(rec_after_mcp.submissions), 1)
+        self.assertEqual(rec_after_mcp.submissions[0]["disposition"], "rejected_content")
+        self.assertEqual(rec_after_mcp.submissions[0]["reason"], "markdown_formatting")
+
+        # ---------------------------------------------------------------------
+        # Step 3: No replacement is submitted. Turn completes.
+        # Step 4: Real Stop hook subprocess runs
+        # ---------------------------------------------------------------------
+        stop_script = (
+            self.installed_root
+            / "com.infiquetra.claude"
+            / "hooks"
+            / "stop_hook.py"
+        )
+        self.assertTrue(stop_script.is_file())
+
+        stop_payload = {
+            "session_id": AGENT_SESSION_ID,
+            "last_assistant_message": "Here is the summary:\n- Item 1: **bold**\n- Item 2: `code`",
+        }
+        stop_proc = subprocess.run(
+            [sys.executable, str(stop_script)],
+            input=json.dumps(stop_payload),
+            capture_output=True,
+            text=True,
+            env=self.env,
+            check=True,
+        )
+        self.assertEqual(stop_proc.returncode, 0)
+
+        # ---------------------------------------------------------------------
+        # Step 5: Assert final turn record state on disk
+        # ---------------------------------------------------------------------
+        final_rec = turn_record.read_turn_record(
+            self.state_dir / turn_record.TURN_RECORD_FILENAME
+        )
+        self.assertIsNotNone(final_rec)
+        assert final_rec is not None
+        self.assertEqual(final_rec.session_id, AGENT_SESSION_ID)
+        self.assertEqual(final_rec.binding_id, VALID_UUID_1)
+        self.assertEqual(final_rec.turn_id, VALID_UUID_2)
+        self.assertEqual(final_rec.origin, turn_record.ORIGIN_AURALIS)
+        self.assertEqual(final_rec.outcome, turn_record.OUTCOME_FALLBACK)
+        self.assertEqual(len(final_rec.submissions), 1)
+        self.assertEqual(final_rec.submissions[0]["disposition"], "rejected_content")
+
+        # Verify no local speak payload files were spawned
+        speak_files = list(self.state_dir.glob("speak-*.json"))
+        self.assertEqual(speak_files, [])
+
+    def test_r122_adapter_boundary_rejection_then_resubmission_settles_authored(
+        self,
+    ) -> None:
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        # 1. Prompt hook
+        prompt_script = (
+            self.installed_root
+            / "com.infiquetra.claude"
+            / "hooks"
+            / "user_prompt_submit_hook.py"
+        )
+        subprocess.run(
+            [sys.executable, str(prompt_script)],
+            input=json.dumps({"session_id": AGENT_SESSION_ID, "prompt": "Prompt"}),
+            capture_output=True,
+            text=True,
+            env=self.env,
+            check=True,
+        )
+
+        # 2. MCP Server: reject Markdown, then accept plain text resubmission
+        server_script = self.installed_root / "scripts" / "mcp_server.py"
+        server_proc = subprocess.Popen(
+            [sys.executable, str(server_script)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=self.env,
+        )
+
+        def send_and_recv(msg: dict) -> dict:
+            assert server_proc.stdin is not None
+            assert server_proc.stdout is not None
+            server_proc.stdin.write(json.dumps(msg) + "\n")
+            server_proc.stdin.flush()
+            line = server_proc.stdout.readline()
+            return json.loads(line)
+
+        send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05"},
+        })
+
+        # Rejected call
+        rej_resp = send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_spoken_rendering",
+                "arguments": {"text": "# Title with markdown"},
+            },
+        })
+        rej_content = json.loads(rej_resp["result"]["content"][0]["text"])
+        self.assertEqual(rej_content["disposition"], "rejected_content")
+
+        # Accepted resubmission
+        acc_resp = send_and_recv({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_spoken_rendering",
+                "arguments": {"text": "Title with plain spoken text."},
+            },
+        })
+        acc_content = json.loads(acc_resp["result"]["content"][0]["text"])
+        self.assertEqual(acc_content["disposition"], "accepted")
+
+        # Close server
+        assert server_proc.stdin is not None
+        server_proc.stdin.close()
+        server_proc.wait(timeout=5.0)
+        if server_proc.stdout:
+            server_proc.stdout.close()
+        if server_proc.stderr:
+            server_proc.stderr.close()
+
+        # 3. Stop hook
+        stop_script = (
+            self.installed_root
+            / "com.infiquetra.claude"
+            / "hooks"
+            / "stop_hook.py"
+        )
+        subprocess.run(
+            [sys.executable, str(stop_script)],
+            input=json.dumps({
+                "session_id": AGENT_SESSION_ID,
+                "last_assistant_message": "Title with plain spoken text.",
+            }),
+            capture_output=True,
+            text=True,
+            env=self.env,
+            check=True,
+        )
+
+        # 4. Assert final outcome is authored
+        final_rec = turn_record.read_turn_record(
+            self.state_dir / turn_record.TURN_RECORD_FILENAME
+        )
+        self.assertIsNotNone(final_rec)
+        assert final_rec is not None
+        self.assertEqual(final_rec.outcome, turn_record.OUTCOME_AUTHORED)
+        self.assertEqual(len(final_rec.submissions), 2)
+        self.assertEqual(final_rec.submissions[0]["disposition"], "rejected_content")
+        self.assertEqual(final_rec.submissions[1]["disposition"], "accepted")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_rendering_gate.py
+++ b/plugins/voice/tests/test_rendering_gate.py
@@ -1,0 +1,411 @@
+"""Tests for the plain-spoken-text rendering gate (R121, R20; KTD1; AE26).
+
+These tests hold the gate to its self-contained normative grammar:
+- Every row of the normative class table has at least one rejecting scenario;
+- Every line-anchored class has a 3-space-indented variant;
+- Every class has a rule-not-spelling scenario;
+- Every stated non-class has an accepting scenario;
+- Precedence: fenced code block takes precedence over markdown formatting;
+- R20 public surface guard: no text transformation function is exported.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import rendering_gate  # noqa: E402
+
+
+class AE26CoreGateTests(unittest.TestCase):
+    """The AE26 core: gate rejects fences and markdown, naming reason, class, line."""
+
+    def test_gate_rejects_fenced_code_block(self) -> None:
+        text = "Here is the plan:\n```python\nprint('hello')\n```"
+        verdict = rendering_gate.evaluate(text)
+        self.assertFalse(verdict.is_plain)
+        self.assertEqual(verdict.verdict, rendering_gate.VERDICT_REJECTED)
+        self.assertEqual(verdict.reason, rendering_gate.REASON_FENCED_CODE_BLOCK)
+        self.assertIsNotNone(verdict.detail)
+        self.assertIn(rendering_gate.CLASS_FENCED_CODE_BLOCK, verdict.detected_classes)
+        self.assertEqual(verdict.first_offending_line, 2)
+
+    def test_gate_rejects_markdown_emphasis(self) -> None:
+        text = "This is *important* and needs review."
+        verdict = rendering_gate.evaluate(text)
+        self.assertFalse(verdict.is_plain)
+        self.assertEqual(verdict.verdict, rendering_gate.VERDICT_REJECTED)
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIsNotNone(verdict.detail)
+        self.assertIn(rendering_gate.CLASS_EMPHASIS_STRONG, verdict.detected_classes)
+        self.assertEqual(verdict.first_offending_line, 1)
+
+    def test_gate_accepts_plain_spoken_text(self) -> None:
+        text = "The unit tests pass and the adapter is ready for review."
+        verdict = rendering_gate.evaluate(text)
+        self.assertTrue(verdict.is_plain)
+        self.assertEqual(verdict.verdict, rendering_gate.VERDICT_PLAIN)
+        self.assertIsNone(verdict.reason)
+        self.assertIsNone(verdict.detail)
+        self.assertEqual(verdict.detected_classes, [])
+        self.assertIsNone(verdict.first_offending_line)
+
+
+class ClassTableRejectingTests(unittest.TestCase):
+    """Every row of the class table has at least one rejecting scenario."""
+
+    def test_fenced_code_block_backticks(self) -> None:
+        verdict = rendering_gate.evaluate("```\ncode\n```")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_FENCED_CODE_BLOCK)
+        self.assertIn(rendering_gate.CLASS_FENCED_CODE_BLOCK, verdict.detected_classes)
+
+    def test_indented_code_block(self) -> None:
+        verdict = rendering_gate.evaluate("    def foo(): return 42")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_INDENTED_CODE_BLOCK, verdict.detected_classes)
+        self.assertEqual(verdict.first_offending_line, 1)
+
+    def test_atx_heading(self) -> None:
+        verdict = rendering_gate.evaluate("# Heading 1")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_ATX_HEADING, verdict.detected_classes)
+
+    def test_setext_heading(self) -> None:
+        verdict = rendering_gate.evaluate("Section Title\n===")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_SETEXT_HEADING, verdict.detected_classes)
+
+    def test_list_marker(self) -> None:
+        verdict = rendering_gate.evaluate("- First item\n- Second item")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_LIST_MARKER, verdict.detected_classes)
+
+    def test_blockquote(self) -> None:
+        verdict = rendering_gate.evaluate("> This is quoted text.")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_BLOCKQUOTE, verdict.detected_classes)
+
+    def test_horizontal_rule(self) -> None:
+        verdict = rendering_gate.evaluate("---")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_HORIZONTAL_RULE, verdict.detected_classes)
+
+    def test_table_pipe_row(self) -> None:
+        verdict = rendering_gate.evaluate("| col1 | col2 |\n| --- | --- |")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_TABLE_PIPE_ROW, verdict.detected_classes)
+
+    def test_link_reference_definition(self) -> None:
+        verdict = rendering_gate.evaluate("[homepage]: https://example.com")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(
+            rendering_gate.CLASS_LINK_REFERENCE_DEFINITION, verdict.detected_classes
+        )
+
+    def test_hard_line_break_trailing_spaces(self) -> None:
+        verdict = rendering_gate.evaluate("First line with hard break  \nSecond line")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_HARD_LINE_BREAK, verdict.detected_classes)
+        self.assertEqual(verdict.first_offending_line, 1)
+
+    def test_hard_line_break_backslash(self) -> None:
+        verdict = rendering_gate.evaluate("First line with backslash\\\nSecond line")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_HARD_LINE_BREAK, verdict.detected_classes)
+        self.assertEqual(verdict.first_offending_line, 1)
+
+    def test_raw_html_tag_and_comment(self) -> None:
+        verdict1 = rendering_gate.evaluate("Please see <div class='highlight'>text</div>")
+        self.assertEqual(verdict1.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_RAW_HTML, verdict1.detected_classes)
+
+        verdict2 = rendering_gate.evaluate("Secret <!-- comment --> note")
+        self.assertEqual(verdict2.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_RAW_HTML, verdict2.detected_classes)
+
+    def test_backslash_escape(self) -> None:
+        verdict = rendering_gate.evaluate("An escaped asterisk \\* looks like this")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_BACKSLASH_ESCAPE, verdict.detected_classes)
+
+    def test_emphasis_strong(self) -> None:
+        verdict = rendering_gate.evaluate("Some **bold** text here")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_EMPHASIS_STRONG, verdict.detected_classes)
+
+    def test_strikethrough(self) -> None:
+        verdict = rendering_gate.evaluate("Some ~~deleted~~ text here")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_STRIKETHROUGH, verdict.detected_classes)
+
+    def test_inline_code_span(self) -> None:
+        verdict = rendering_gate.evaluate("Run `pytest` to test")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_INLINE_CODE_SPAN, verdict.detected_classes)
+
+    def test_inline_link_image(self) -> None:
+        verdict = rendering_gate.evaluate("Click [here](https://example.com) for info")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_INLINE_LINK_IMAGE, verdict.detected_classes)
+
+    def test_reference_link(self) -> None:
+        verdict = rendering_gate.evaluate("See [documentation][ref] for details")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_REFERENCE_LINK, verdict.detected_classes)
+
+    def test_autolink(self) -> None:
+        verdict = rendering_gate.evaluate("Check <https://example.com> now")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_AUTOLINK, verdict.detected_classes)
+
+
+class LineAnchoredThreeSpaceIndentedTests(unittest.TestCase):
+    """Every line-anchored class has a 3-space-indented variant plus seam check."""
+
+    def test_three_space_indented_list_marker(self) -> None:
+        verdict = rendering_gate.evaluate("   - indented bullet")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_LIST_MARKER, verdict.detected_classes)
+
+    def test_three_space_indented_atx_heading(self) -> None:
+        verdict = rendering_gate.evaluate("   ## Indented Heading")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_ATX_HEADING, verdict.detected_classes)
+
+    def test_three_space_indented_blockquote(self) -> None:
+        verdict = rendering_gate.evaluate("   > indented quote")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_BLOCKQUOTE, verdict.detected_classes)
+
+    def test_three_space_indented_fence(self) -> None:
+        verdict = rendering_gate.evaluate("   ```bash\necho 1\n   ```")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_FENCED_CODE_BLOCK)
+        self.assertIn(rendering_gate.CLASS_FENCED_CODE_BLOCK, verdict.detected_classes)
+
+    def test_three_space_indented_horizontal_rule(self) -> None:
+        verdict = rendering_gate.evaluate("   ---")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_HORIZONTAL_RULE, verdict.detected_classes)
+
+    def test_three_space_indented_setext_underline(self) -> None:
+        verdict = rendering_gate.evaluate("Header\n   ===")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(rendering_gate.CLASS_SETEXT_HEADING, verdict.detected_classes)
+
+    def test_three_space_indented_link_ref_def(self) -> None:
+        verdict = rendering_gate.evaluate("   [ref]: https://example.com")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_MARKDOWN_FORMATTING)
+        self.assertIn(
+            rendering_gate.CLASS_LINK_REFERENCE_DEFINITION, verdict.detected_classes
+        )
+
+    def test_three_space_vs_four_space_seam_scenario(self) -> None:
+        three_spaces = "   - item"
+        verdict3 = rendering_gate.evaluate(three_spaces)
+        self.assertIn(rendering_gate.CLASS_LIST_MARKER, verdict3.detected_classes)
+        self.assertNotIn(rendering_gate.CLASS_INDENTED_CODE_BLOCK, verdict3.detected_classes)
+
+        four_spaces = "    - item"
+        verdict4 = rendering_gate.evaluate(four_spaces)
+        self.assertIn(rendering_gate.CLASS_INDENTED_CODE_BLOCK, verdict4.detected_classes)
+
+
+class RuleNotSpellingTests(unittest.TestCase):
+    """Every rejecting class has a rule-not-spelling scenario."""
+
+    def test_ordered_list_marker_non_one(self) -> None:
+        verdict = rendering_gate.evaluate("7. Seventh item")
+        self.assertIn(rendering_gate.CLASS_LIST_MARKER, verdict.detected_classes)
+
+    def test_multi_digit_ordered_marker_parenthesis(self) -> None:
+        verdict = rendering_gate.evaluate("12) Twelfth item")
+        self.assertIn(rendering_gate.CLASS_LIST_MARKER, verdict.detected_classes)
+
+    def test_bullet_marker_at_end_of_line(self) -> None:
+        verdict = rendering_gate.evaluate("-")
+        self.assertIn(rendering_gate.CLASS_LIST_MARKER, verdict.detected_classes)
+
+    def test_empty_atx_heading(self) -> None:
+        verdict = rendering_gate.evaluate("##")
+        self.assertIn(rendering_gate.CLASS_ATX_HEADING, verdict.detected_classes)
+
+    def test_tab_delimited_atx_heading(self) -> None:
+        verdict = rendering_gate.evaluate("#\tTab heading")
+        self.assertIn(rendering_gate.CLASS_ATX_HEADING, verdict.detected_classes)
+
+    def test_fence_run_of_four_backticks(self) -> None:
+        verdict = rendering_gate.evaluate("````python\ncode\n````")
+        self.assertEqual(verdict.reason, rendering_gate.REASON_FENCED_CODE_BLOCK)
+        self.assertIn(rendering_gate.CLASS_FENCED_CODE_BLOCK, verdict.detected_classes)
+
+    def test_tab_indented_code_line(self) -> None:
+        verdict = rendering_gate.evaluate("\tdef helper(): pass")
+        self.assertIn(rendering_gate.CLASS_INDENTED_CODE_BLOCK, verdict.detected_classes)
+
+    def test_one_character_setext_underline(self) -> None:
+        verdict = rendering_gate.evaluate("Paragraph line\n=")
+        self.assertIn(rendering_gate.CLASS_SETEXT_HEADING, verdict.detected_classes)
+
+    def test_blockquote_no_space_after_gt(self) -> None:
+        verdict = rendering_gate.evaluate(">quote with no space")
+        self.assertIn(rendering_gate.CLASS_BLOCKQUOTE, verdict.detected_classes)
+
+    def test_spaced_horizontal_rule(self) -> None:
+        verdict = rendering_gate.evaluate("- - -")
+        self.assertIn(rendering_gate.CLASS_HORIZONTAL_RULE, verdict.detected_classes)
+
+    def test_underscore_horizontal_rule(self) -> None:
+        verdict = rendering_gate.evaluate("___")
+        self.assertIn(rendering_gate.CLASS_HORIZONTAL_RULE, verdict.detected_classes)
+
+    def test_pipe_row_no_leading_or_trailing_pipe(self) -> None:
+        verdict = rendering_gate.evaluate("cell | cell")
+        self.assertIn(rendering_gate.CLASS_TABLE_PIPE_ROW, verdict.detected_classes)
+
+    def test_link_ref_def_multi_word_label(self) -> None:
+        verdict = rendering_gate.evaluate("[multi word label]: https://example.com")
+        self.assertIn(
+            rendering_gate.CLASS_LINK_REFERENCE_DEFINITION, verdict.detected_classes
+        )
+
+    def test_hard_break_three_trailing_spaces(self) -> None:
+        verdict = rendering_gate.evaluate("First line   \nSecond line")
+        self.assertIn(rendering_gate.CLASS_HARD_LINE_BREAK, verdict.detected_classes)
+
+    def test_raw_html_attribute_tag_and_non_tag_openers(self) -> None:
+        v_attr = rendering_gate.evaluate("<div class='custom'>content</div>")
+        self.assertIn(rendering_gate.CLASS_RAW_HTML, v_attr.detected_classes)
+
+        v_decl = rendering_gate.evaluate("<!DOCTYPE html>")
+        self.assertIn(rendering_gate.CLASS_RAW_HTML, v_decl.detected_classes)
+
+        v_pi = rendering_gate.evaluate("<?xml version='1.0'?>")
+        self.assertIn(rendering_gate.CLASS_RAW_HTML, v_pi.detected_classes)
+
+    def test_backslash_escape_bracket(self) -> None:
+        verdict = rendering_gate.evaluate(r"An escaped bracket \[ here")
+        self.assertIn(rendering_gate.CLASS_BACKSLASH_ESCAPE, verdict.detected_classes)
+
+    def test_three_asterisk_emphasis_run(self) -> None:
+        verdict = rendering_gate.evaluate("***bold and italic***")
+        self.assertIn(rendering_gate.CLASS_EMPHASIS_STRONG, verdict.detected_classes)
+
+    def test_one_tilde_strikethrough(self) -> None:
+        verdict = rendering_gate.evaluate("~one tilde strike~")
+        self.assertIn(rendering_gate.CLASS_STRIKETHROUGH, verdict.detected_classes)
+
+    def test_two_backtick_code_span(self) -> None:
+        verdict = rendering_gate.evaluate("``code with ` backtick``")
+        self.assertIn(rendering_gate.CLASS_INLINE_CODE_SPAN, verdict.detected_classes)
+
+    def test_inline_link_empty_bracket_text(self) -> None:
+        verdict = rendering_gate.evaluate("[](https://example.com/empty)")
+        self.assertIn(rendering_gate.CLASS_INLINE_LINK_IMAGE, verdict.detected_classes)
+
+    def test_reference_link_multi_word_label(self) -> None:
+        verdict = rendering_gate.evaluate("[text][multi word label]")
+        self.assertIn(rendering_gate.CLASS_REFERENCE_LINK, verdict.detected_classes)
+
+    def test_autolink_mailto_no_slashes(self) -> None:
+        verdict = rendering_gate.evaluate("<mailto:ops@example.com>")
+        self.assertIn(rendering_gate.CLASS_AUTOLINK, verdict.detected_classes)
+
+
+class StatedNonClassesAcceptingTests(unittest.TestCase):
+    """Every stated non-class passes as plain spoken text."""
+
+    def test_arithmetic_asterisks(self) -> None:
+        self.assertTrue(rendering_gate.evaluate("The total is 2 * 3 items.").is_plain)
+        self.assertTrue(rendering_gate.evaluate("Calculate 2 * 3 * 4").is_plain)
+
+    def test_identifier_underscores(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate("Check the snake_case variable in the module.").is_plain
+        )
+        self.assertTrue(
+            rendering_gate.evaluate("Function get_user_by_id returns the user.").is_plain
+        )
+
+    def test_mid_sentence_hyphens(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate(
+                "This is a high-level single-operator developer tool."
+            ).is_plain
+        )
+
+    def test_spaced_comparison_angle_brackets(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate("Ensure that x < y and threshold > 0.").is_plain
+        )
+
+    def test_bare_bracketed_aside(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate(
+                "The report stated that all tests passed [sic] yesterday."
+            ).is_plain
+        )
+
+    def test_colon_labelled_line(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate("note: all checks passed successfully.").is_plain
+        )
+
+    def test_bare_spoken_url(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate(
+                "You can view results at https://example.com/status."
+            ).is_plain
+        )
+
+    def test_ampersand_in_prose_before_semicolon(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate("AT&T; announced their quarterly results.").is_plain
+        )
+
+    def test_backslash_before_letter_or_digit(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate(r"Check directory C:\Users\jefcox\workspace").is_plain
+        )
+        self.assertTrue(rendering_gate.evaluate(r"Item \100 in the list").is_plain)
+
+    def test_trailing_spaces_on_final_line(self) -> None:
+        self.assertTrue(
+            rendering_gate.evaluate("This is the final line of text.   ").is_plain
+        )
+
+    def test_trailing_spaces_before_blank_line(self) -> None:
+        text = "First paragraph with spaces.   \n\nSecond paragraph."
+        self.assertTrue(rendering_gate.evaluate(text).is_plain)
+
+    def test_multi_paragraph_separated_by_blank_lines(self) -> None:
+        text = (
+            "Here is the first paragraph of speech.\n\n"
+            "Here is the second paragraph.\n\n"
+            "And here is the conclusion."
+        )
+        self.assertTrue(rendering_gate.evaluate(text).is_plain)
+
+
+class PrecedenceAndSurfaceTests(unittest.TestCase):
+    """Precedence rules and public surface constraints."""
+
+    def test_fenced_code_block_takes_precedence_over_emphasis(self) -> None:
+        text = "Here is *bold* text and code:\n```bash\necho 'hi'\n```"
+        verdict = rendering_gate.evaluate(text)
+        self.assertFalse(verdict.is_plain)
+        self.assertEqual(verdict.reason, rendering_gate.REASON_FENCED_CODE_BLOCK)
+        self.assertIn(rendering_gate.CLASS_FENCED_CODE_BLOCK, verdict.detected_classes)
+        self.assertIn(rendering_gate.CLASS_EMPHASIS_STRONG, verdict.detected_classes)
+
+    def test_public_surface_has_no_transformation_function(self) -> None:
+        forbidden = ("clean", "strip", "transform", "reformat", "sanitize", "repair")
+        for name in dir(rendering_gate):
+            if any(f in name.lower() for f in forbidden):
+                self.fail(f"rendering_gate must not export transformation function {name!r} (R20)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_settings.py
+++ b/plugins/voice/tests/test_settings.py
@@ -28,6 +28,8 @@ _RESOLVERS = {
     settings.PLAYBACK_BIN: settings.playback_bin,
     settings.STATE_DIR: settings.state_dir,
     settings.RETENTION: settings.retention,
+    settings.HERDR_PANE_ID: settings.herdr_pane_id,
+    settings.HERDR_BIN_PATH: settings.herdr_bin_path,
 }
 
 
@@ -197,6 +199,8 @@ class NoSecretsTests(unittest.TestCase):
                 "VOICE_PLAYBACK_BIN",
                 "VOICE_STATE_DIR",
                 "VOICE_RETENTION",
+                "HERDR_PANE_ID",
+                "HERDR_BIN_PATH",
             ),
         )
 
@@ -218,6 +222,52 @@ class NoSecretsTests(unittest.TestCase):
             os.environ, {settings.HERMES_PROFILE: "second"}, clear=True
         ):
             self.assertEqual(settings.hermes_profile(), "second")
+
+
+class HerdrSettingTests(unittest.TestCase):
+    """The Herdr environment settings resolve stated values and carry no default (KTD9; §5)."""
+
+    def test_herdr_settings_are_refused_by_name_when_unset(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(settings.SettingsRefusal) as caught:
+                settings.herdr_pane_id()
+            self.assertEqual(caught.exception.name, "HERDR_PANE_ID")
+            self.assertIn("not set", caught.exception.reason)
+
+            with self.assertRaises(settings.SettingsRefusal) as caught:
+                settings.herdr_bin_path()
+            self.assertEqual(caught.exception.name, "HERDR_BIN_PATH")
+            self.assertIn("not set", caught.exception.reason)
+
+    def test_herdr_settings_are_refused_by_name_when_empty(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {
+                settings.HERDR_PANE_ID: "",
+                settings.HERDR_BIN_PATH: "   ",
+            },
+            clear=True,
+        ):
+            with self.assertRaises(settings.SettingsRefusal) as caught:
+                settings.herdr_pane_id()
+            self.assertEqual(caught.exception.name, "HERDR_PANE_ID")
+            self.assertIn("empty", caught.exception.reason)
+
+            with self.assertRaises(settings.SettingsRefusal) as caught:
+                settings.herdr_bin_path()
+            self.assertEqual(caught.exception.name, "HERDR_BIN_PATH")
+            self.assertIn("empty", caught.exception.reason)
+
+    def test_herdr_settings_resolve_when_stated(self) -> None:
+        env = {
+            settings.HERDR_PANE_ID: "w1:p2",
+            settings.HERDR_BIN_PATH: "/usr/local/bin/herdr",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(settings.herdr_pane_id(), "w1:p2")
+            self.assertEqual(
+                settings.herdr_bin_path(), "/usr/local/bin/herdr"
+            )
 
 
 if __name__ == "__main__":

--- a/plugins/voice/tests/test_stop_hook.py
+++ b/plugins/voice/tests/test_stop_hook.py
@@ -1,10 +1,13 @@
-"""Tests for the Claude ``Stop`` hook and its descriptor (R1, R3; KTD1, KTD2, KTD12).
+"""Tests for the Claude ``Stop`` hook and its descriptor (R1, R3, R22, R23, R122; KTD1, KTD2, KTD6, KTD11, KTD12).
 
 The spawn seam is injected at the Popen level through U1's real
 ``process.spawn_detached``, so the suite asserts the detached-child
 contract (argv, closed stdin, new session, no wait) against a fake rather
 than a wall clock or a platform binary. U2 never imports or executes
 ``speak.py``: the hook hands the text off by argv and file.
+
+Wire-bound tests assert KTD6 bridged reconciliation (authored vs fallback)
+and local speech suppression against a local BridgeStub and Herdr fixture.
 """
 
 from __future__ import annotations
@@ -12,6 +15,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import stat
 import subprocess
 import sys
 import tempfile
@@ -22,17 +26,24 @@ from unittest.mock import patch
 _PACKAGE = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_PACKAGE / "scripts"))
 sys.path.insert(0, str(_PACKAGE / "com.infiquetra.claude" / "hooks"))
+sys.path.insert(0, str(_PACKAGE / "tests"))
 
 import binding  # noqa: E402
+from bridge_stub import DEFAULT_STUB_TOKEN, BridgeStub  # noqa: E402
 import process  # noqa: E402
 import stop_hook  # noqa: E402
+import turn_record  # noqa: E402
 
 AGENT = "example-agent"
 BOUND_SESSION = "example-session-bound"
 OTHER_SESSION = "example-session-other"
 PANE_ID = "example-pane-one"
+TERMINAL_ID = "example-term-one"
 BOUND_AT = "2026-08-25T00:00:00+00:00"
 RESPONSE_TEXT = "Example response text for the spoken loop."
+
+VALID_UUID_1 = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+VALID_UUID_2 = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
 
 
 class _FakeChild:
@@ -70,9 +81,18 @@ class StopHookTestCase(unittest.TestCase):
     def setUp(self) -> None:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
-        self.state_dir = Path(temporary.name)
+        self.root = Path(temporary.name)
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.home_dir = self.root / "home"
+        self.home_dir.mkdir(parents=True, exist_ok=True)
+
         environment = patch.dict(
-            os.environ, {"VOICE_STATE_DIR": str(self.state_dir)}
+            os.environ,
+            {
+                "VOICE_STATE_DIR": str(self.state_dir),
+                "HOME": str(self.home_dir),
+            },
         )
         environment.start()
         self.addCleanup(environment.stop)
@@ -193,9 +213,6 @@ class DetachedSpawnTests(StopHookTestCase):
         files = self.speak_files()
         self.assertEqual(len(files), 2)
         self.assertEqual(len(self.seam.calls), 2)
-        # Payload names carry unique random uuids, so chronological call
-        # order and lexicographic file order are unrelated: compare the
-        # spawned paths and the files on disk as sets, never by position.
         spawned_paths = sorted(command[2] for command, _kwargs in self.seam.calls)
         self.assertEqual(spawned_paths, [str(path) for path in files])
         for path in files:
@@ -205,8 +222,6 @@ class DetachedSpawnTests(StopHookTestCase):
             )
 
     def test_the_spawn_is_recorded_whether_or_not_speak_has_landed(self) -> None:
-        # U3's speak.py lands concurrently; the hook spawns by argv either
-        # way and never checks existence, so the seam records the call.
         self.bind()
         self.assertEqual(self.run_hook_payload(), 0)
         self.assertEqual(len(self.seam.calls), 1)
@@ -220,7 +235,6 @@ class SpawnFailureCleanupTests(StopHookTestCase):
         self.attempts: list[list[str]] = []
 
     def failing_spawn(self, error: Exception):
-        """Route the real ``spawn_detached`` through a Popen seam that refuses."""
         attempts = self.attempts
 
         def refuse(command, **kwargs):
@@ -263,9 +277,7 @@ class SpawnFailureCleanupTests(StopHookTestCase):
 
     def test_a_cleanup_failure_still_exits_zero(self) -> None:
         self.bind()
-        with (
-            patch.object(Path, "unlink", side_effect=OSError("disk gone")),
-        ):
+        with patch.object(Path, "unlink", side_effect=OSError("disk gone")):
             result = self.run_hook_payload(
                 spawn_side_effect=self.failing_spawn(OSError("spawn refused"))
             )
@@ -312,38 +324,214 @@ class NeverBreakTheTurnTests(StopHookTestCase):
         self.assertEqual(self.seam.calls, [])
 
 
+class WireBoundReconciliationTests(StopHookTestCase):
+    """Tests for the KTD6 bridged reconciliation and local speech suppression branch."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Set up BridgeStub
+        self.stub = BridgeStub()
+        self.stub.start()
+        self.addCleanup(self.stub.stop)
+
+        # Write discovery bridge.json
+        self.bridge_dir = self.home_dir / "Library" / "Application Support" / "Auralis"
+        self.bridge_dir.mkdir(parents=True, exist_ok=True)
+        self.bridge_file = self.bridge_dir / "bridge.json"
+        bridge_payload = {
+            "schema": 1,
+            "host": "127.0.0.1",
+            "port": self.stub.port,
+            "token": DEFAULT_STUB_TOKEN,
+        }
+        self.bridge_file.write_text(json.dumps(bridge_payload), encoding="utf-8")
+        os.chmod(self.bridge_file, stat.S_IRUSR | stat.S_IWUSR)
+
+        # Mock Herdr script
+        self.herdr_path = self.root / "fake_herdr"
+        herdr_envelope = {
+            "result": {
+                "type": "agent_list",
+                "agents": [
+                    {
+                        "pane_id": PANE_ID,
+                        "terminal_id": TERMINAL_ID,
+                        "agent_session": {"value": BOUND_SESSION},
+                    }
+                ],
+            }
+        }
+        mock_herdr_code = (
+            f"#!/usr/bin/env python3\n"
+            f"import sys\n"
+            f"sys.stdout.write({json.dumps(json.dumps(herdr_envelope))} + '\\n')\n"
+        )
+        self.herdr_path.write_text(mock_herdr_code, encoding="utf-8")
+        os.chmod(self.herdr_path, 0o755)
+
+        self.env_patcher_bridge = patch.dict(
+            os.environ,
+            {
+                "HERDR_PANE_ID": PANE_ID,
+                "HERDR_BIN_PATH": str(self.herdr_path),
+            },
+        )
+        self.env_patcher_bridge.start()
+        self.addCleanup(self.env_patcher_bridge.stop)
+
+        self.identity_dict = {
+            "agent_session_id": BOUND_SESSION,
+            "pane_id": PANE_ID,
+            "terminal_id": TERMINAL_ID,
+        }
+
+    def test_wire_bound_with_accepted_rendering_settles_authored_and_suppresses_speech(
+        self,
+    ) -> None:
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="authored_accepted")
+
+        # Initialize turn record with an accepted submission
+        turn_record.init_turn(
+            session_id=BOUND_SESSION,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+        turn_record.record_submission(
+            session_id=BOUND_SESSION,
+            text="Spoken rendering",
+            disposition="accepted",
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+
+        # Also have local legacy binding present
+        self.bind(session_id=BOUND_SESSION)
+
+        result = self.run_hook_payload()
+        self.assertEqual(result, 0)
+        # Suppresses local speak spawn
+        self.assertEqual(self.seam.calls, [])
+        self.assertEqual(self.speak_files(), [])
+
+        # Reconciled outcome is authored
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.outcome, turn_record.OUTCOME_AUTHORED)  # type: ignore[union-attr]
+
+    def test_wire_bound_without_accepted_rendering_settles_fallback_and_suppresses_speech(
+        self,
+    ) -> None:
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        # Initialize turn record with a rejected submission (R122 path)
+        turn_record.init_turn(
+            session_id=BOUND_SESSION,
+            binding_id=VALID_UUID_1,
+            turn_id=VALID_UUID_2,
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+        turn_record.record_submission(
+            session_id=BOUND_SESSION,
+            text="**Markdown**",
+            disposition="rejected_content",
+            reason="markdown_formatting",
+            path=self.state_dir / turn_record.TURN_RECORD_FILENAME,
+        )
+
+        # Also have local legacy binding present
+        self.bind(session_id=BOUND_SESSION)
+
+        result = self.run_hook_payload()
+        self.assertEqual(result, 0)
+        # Suppresses local speak spawn
+        self.assertEqual(self.seam.calls, [])
+        self.assertEqual(self.speak_files(), [])
+
+        # Reconciled outcome is fallback
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.outcome, turn_record.OUTCOME_FALLBACK)  # type: ignore[union-attr]
+
+    def test_wire_bound_with_no_turn_record_still_suppresses_speech(self) -> None:
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.bind(session_id=BOUND_SESSION)
+
+        result = self.run_hook_payload()
+        self.assertEqual(result, 0)
+        self.assertEqual(self.seam.calls, [])
+        self.assertEqual(self.speak_files(), [])
+
+    def test_bridge_unavailable_falls_back_to_legacy_speak_path(self) -> None:
+        self.stub.stop()
+        self.bind(session_id=BOUND_SESSION)
+
+        result = self.run_hook_payload()
+        self.assertEqual(result, 0)
+        # Spawns through legacy path
+        self.assertEqual(len(self.seam.calls), 1)
+        self.assertEqual(len(self.speak_files()), 1)
+
+    def test_bridge_bound_to_different_session_falls_back_to_legacy_speak_path(
+        self,
+    ) -> None:
+        other_identity = {
+            "agent_session_id": "session-other",
+            "pane_id": "pane-other",
+            "terminal_id": "term-other",
+        }
+        self.stub.set_binding(VALID_UUID_1, other_identity)
+        self.bind(session_id=BOUND_SESSION)
+
+        result = self.run_hook_payload()
+        self.assertEqual(result, 0)
+        # Spawns through legacy path
+        self.assertEqual(len(self.seam.calls), 1)
+        self.assertEqual(len(self.speak_files()), 1)
+
+    def test_turn_record_busy_on_wire_bound_still_suppresses_speech(self) -> None:
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.bind(session_id=BOUND_SESSION)
+
+        with patch.object(
+            turn_record,
+            "settle_outcome",
+            side_effect=turn_record.TurnRecordBusy("turn_record_busy"),
+        ):
+            result = self.run_hook_payload()
+            self.assertEqual(result, 0)
+            self.assertEqual(self.seam.calls, [])
+            self.assertEqual(self.speak_files(), [])
+
+
 class DescriptorAndLayoutTests(StopHookTestCase):
     """The client extension matches the repository's extension convention."""
 
-    def test_hooks_json_declares_the_stop_entry(self) -> None:
+    def test_hooks_json_declares_the_required_entries(self) -> None:
         descriptor_path = (
             _PACKAGE / "com.infiquetra.claude" / "hooks" / "hooks.json"
         )
         descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
-        self.assertIn("Stop", descriptor["hooks"])
-        entries = [
-            entry
-            for group in descriptor["hooks"]["Stop"]
-            for entry in group["hooks"]
-        ]
-        commands = [
-            entry["command"] for entry in entries if entry.get("type") == "command"
-        ]
-        # ``${CLAUDE_PLUGIN_ROOT}`` is the *installed package root*, which is
-        # plugins/voice/ -- not this client extension. Claude installs the
-        # package root so the portable core travels with the hook, so the
-        # command has to walk down into the extension. Asserting the resolved
-        # path exists as well as its spelling: a command that merely looks
-        # plausible fails only after a successful install.
-        self.assertIn(
-            'python3 "${CLAUDE_PLUGIN_ROOT}/com.infiquetra.claude/hooks/stop_hook.py"',
-            commands,
-        )
-        for command in commands:
-            relative = command.split("${CLAUDE_PLUGIN_ROOT}/", 1)[1].rstrip('"')
-            self.assertTrue((_PACKAGE / relative).is_file())
-        for entry in entries:
-            self.assertEqual(entry["timeout"], 5)
+
+        for hook_name in ("UserPromptSubmit", "PreToolUse", "Stop"):
+            with self.subTest(hook_name=hook_name):
+                self.assertIn(hook_name, descriptor["hooks"])
+                entries = [
+                    entry
+                    for group in descriptor["hooks"][hook_name]
+                    for entry in group["hooks"]
+                ]
+                commands = [
+                    entry["command"]
+                    for entry in entries
+                    if entry.get("type") == "command"
+                ]
+                for command in commands:
+                    relative = command.split("${CLAUDE_PLUGIN_ROOT}/", 1)[1].rstrip('"')
+                    self.assertTrue((_PACKAGE / relative).is_file())
+                for entry in entries:
+                    self.assertEqual(entry["timeout"], 5)
 
     def test_the_client_manifest_exists_with_an_identity(self) -> None:
         manifest_path = _PACKAGE / "com.infiquetra.claude" / "plugin.json"

--- a/plugins/voice/tests/test_turn_record.py
+++ b/plugins/voice/tests/test_turn_record.py
@@ -1,0 +1,393 @@
+"""Tests for the per-turn state and mutation record (R23, R122; KTD11).
+
+Covers:
+- Turn initialization replacing previous turn's record;
+- Submissions and tool observations appending;
+- Outcome settling once ('authored' vs 'fallback');
+- Session mismatch refusal;
+- Absent and corrupt store states;
+- Deterministic concurrency / interleaving proof (KTD11 flock transactions);
+- 500 ms acquisition deadline timeout raising TurnRecordBusy.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import turn_record  # noqa: E402
+
+SESSION_ONE = "claude-session-001"
+SESSION_TWO = "claude-session-002"
+BINDING_ID = "00000000-0000-4000-8000-000000000001"
+TURN_ID = "00000000-0000-4000-8000-000000000002"
+
+
+class TurnRecordTestCase(unittest.TestCase):
+    """Common fixture: one fresh temporary state directory per test."""
+
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.state_dir = Path(temporary.name)
+        environment = patch.dict(
+            os.environ, {"VOICE_STATE_DIR": str(self.state_dir)}
+        )
+        environment.start()
+        self.addCleanup(environment.stop)
+
+    def record_path(self) -> Path:
+        return self.state_dir / turn_record.TURN_RECORD_FILENAME
+
+    def lock_path(self) -> Path:
+        return self.state_dir / turn_record.TURN_RECORD_LOCK_FILENAME
+
+
+class TurnLifecycleTests(TurnRecordTestCase):
+    """Basic lifecycle: init, submit, observe tools, settle outcome."""
+
+    def test_init_turn_creates_record_and_replaces_previous(self) -> None:
+        record1 = turn_record.init_turn(
+            session_id=SESSION_ONE,
+            binding_id=BINDING_ID,
+            turn_id=TURN_ID,
+            origin=turn_record.ORIGIN_AURALIS,
+        )
+        self.assertEqual(record1.session_id, SESSION_ONE)
+        self.assertEqual(record1.binding_id, BINDING_ID)
+        self.assertEqual(record1.turn_id, TURN_ID)
+        self.assertEqual(record1.origin, turn_record.ORIGIN_AURALIS)
+        self.assertEqual(record1.submissions, [])
+        self.assertEqual(record1.tool_observations, [])
+        self.assertIsNone(record1.outcome)
+
+        # Initializing a new turn replaces the record
+        new_turn_id = "00000000-0000-4000-8000-000000000003"
+        record2 = turn_record.init_turn(
+            session_id=SESSION_ONE,
+            binding_id=BINDING_ID,
+            turn_id=new_turn_id,
+        )
+        self.assertEqual(record2.turn_id, new_turn_id)
+        current = turn_record.read_turn_record()
+        self.assertIsNotNone(current)
+        self.assertEqual(current.turn_id, new_turn_id)
+
+    def test_record_submission_appends(self) -> None:
+        turn_record.init_turn(SESSION_ONE, BINDING_ID, TURN_ID)
+
+        turn_record.record_submission(
+            session_id=SESSION_ONE,
+            text="First rejected submission *markdown*",
+            disposition="rejected_content",
+            reason="markdown_formatting",
+            detail={"detected_classes": ["emphasis_strong"], "first_offending_line": 1},
+        )
+
+        turn_record.record_submission(
+            session_id=SESSION_ONE,
+            text="Second clean plain submission.",
+            disposition="accepted",
+            reason=None,
+            detail=None,
+        )
+
+        current = turn_record.read_turn_record()
+        self.assertIsNotNone(current)
+        self.assertEqual(len(current.submissions), 2)
+        self.assertEqual(current.submissions[0]["disposition"], "rejected_content")
+        self.assertEqual(current.submissions[0]["reason"], "markdown_formatting")
+        self.assertEqual(current.submissions[1]["disposition"], "accepted")
+        self.assertIsNone(current.submissions[1]["reason"])
+
+    def test_record_tool_observation_appends(self) -> None:
+        turn_record.init_turn(SESSION_ONE, BINDING_ID, TURN_ID)
+
+        turn_record.record_tool_observation(
+            session_id=SESSION_ONE,
+            tool_name="read_file",
+            tool_input={"path": "main.py"},
+            tool_use_id="toolu_01",
+        )
+
+        turn_record.record_tool_observation(
+            session_id=SESSION_ONE,
+            tool_name="grep_search",
+            tool_input={"query": "hello"},
+            tool_use_id="toolu_02",
+        )
+
+        current = turn_record.read_turn_record()
+        self.assertIsNotNone(current)
+        self.assertEqual(len(current.tool_observations), 2)
+        self.assertEqual(current.tool_observations[0]["tool_name"], "read_file")
+        self.assertEqual(current.tool_observations[1]["tool_name"], "grep_search")
+
+    def test_settle_outcome_settles_once(self) -> None:
+        turn_record.init_turn(SESSION_ONE, BINDING_ID, TURN_ID)
+        self.assertIsNone(turn_record.read_turn_record().outcome)
+
+        settled = turn_record.settle_outcome(SESSION_ONE, turn_record.OUTCOME_AUTHORED)
+        self.assertEqual(settled.outcome, turn_record.OUTCOME_AUTHORED)
+
+        # Attempting to settle again does not overwrite first outcome
+        settled_again = turn_record.settle_outcome(
+            SESSION_ONE, turn_record.OUTCOME_FALLBACK
+        )
+        self.assertEqual(settled_again.outcome, turn_record.OUTCOME_AUTHORED)
+        self.assertEqual(
+            turn_record.read_turn_record().outcome, turn_record.OUTCOME_AUTHORED
+        )
+
+    def test_session_mismatch_refused_by_name(self) -> None:
+        turn_record.init_turn(SESSION_ONE, BINDING_ID, TURN_ID)
+
+        with self.assertRaises(turn_record.TurnRecordSessionMismatch):
+            turn_record.record_submission(
+                session_id=SESSION_TWO,
+                text="text",
+                disposition="accepted",
+            )
+
+        with self.assertRaises(turn_record.TurnRecordSessionMismatch):
+            turn_record.record_tool_observation(
+                session_id=SESSION_TWO,
+                tool_name="read_file",
+                tool_input={},
+                tool_use_id="id",
+            )
+
+        with self.assertRaises(turn_record.TurnRecordSessionMismatch):
+            turn_record.settle_outcome(
+                session_id=SESSION_TWO,
+                outcome=turn_record.OUTCOME_AUTHORED,
+            )
+
+
+class TurnRecordStoreStateTests(TurnRecordTestCase):
+    """Store read, absent, and corrupt state behaviors."""
+
+    def test_absent_store_reports_absent(self) -> None:
+        report = turn_record.read_turn_record_report()
+        self.assertEqual(report.status, turn_record.STATUS_ABSENT)
+        self.assertIsNone(report.record)
+        self.assertIsNone(turn_record.read_turn_record())
+
+    def test_corrupt_store_reports_corrupt(self) -> None:
+        cases = {
+            "invalid json": "not json {",
+            "not dict": json.dumps(["not", "an", "object"]),
+            "session_id not string": json.dumps({"session_id": 123}),
+            "submissions not list": json.dumps(
+                {"session_id": SESSION_ONE, "submissions": "bad"}
+            ),
+            "tool_observations not list": json.dumps(
+                {"session_id": SESSION_ONE, "tool_observations": "bad"}
+            ),
+        }
+        for name, contents in cases.items():
+            with self.subTest(name=name):
+                self.record_path().write_text(contents, encoding="utf-8")
+                report = turn_record.read_turn_record_report()
+                self.assertEqual(report.status, turn_record.STATUS_CORRUPT)
+                self.assertIsNone(report.record)
+                self.assertIsNone(turn_record.read_turn_record())
+
+
+class ConcurrencyAndInterleavingTests(TurnRecordTestCase):
+    """KTD11 flock concurrency proofs: deterministic serialization and timeout budget."""
+
+    def test_deterministic_interleaving_prevents_lost_updates(self) -> None:
+        """Two concurrent mutate calls from separate threads with event-controlled pauses.
+
+        Writer 1 enters critical section and waits on writer2_retry_attempted.
+        Writer 2 begins mutate() in another thread. When writer 2's flock acquisition
+        fails because writer 1 holds the lock, writer 2's sleep hook sets
+        writer2_retry_attempted, deterministically proving exclusion.
+        Writer 1 then unblocks, completes mutation, releases the lock, and sets
+        writer1_finished.
+        Writer 2 then acquires the lock and enters writer2_fn, verifying that
+        writer 1 has finished. Writer 2 reads writer 1's write, resulting in
+        both updates persisting with no lost updates.
+        """
+        turn_record.init_turn(SESSION_ONE, BINDING_ID, TURN_ID)
+
+        writer1_in_critical = threading.Event()
+        writer2_retry_attempted = threading.Event()
+        writer1_finished = threading.Event()
+        writer2_in_critical = threading.Event()
+
+        def writer1_fn(current: turn_record.TurnRecord | None) -> turn_record.TurnRecord:
+            writer1_in_critical.set()
+            self.assertTrue(
+                writer2_retry_attempted.wait(timeout=5.0),
+                "writer 2 must attempt lock and fail while writer 1 holds it",
+            )
+            assert current is not None
+            sub = {
+                "text": "writer1",
+                "disposition": "rejected_content",
+                "timestamp": "2026-08-27T00:00:00",
+            }
+            return turn_record.TurnRecord(
+                session_id=current.session_id,
+                binding_id=current.binding_id,
+                turn_id=current.turn_id,
+                origin=current.origin,
+                submissions=current.submissions + [sub],
+                tool_observations=current.tool_observations,
+                outcome=current.outcome,
+                created_at=current.created_at,
+                updated_at="2026-08-27T00:00:00",
+            )
+
+        def writer2_fn(current: turn_record.TurnRecord | None) -> turn_record.TurnRecord:
+            self.assertTrue(
+                writer1_finished.is_set(),
+                "writer 2 must not enter critical section until writer 1 has finished",
+            )
+            writer2_in_critical.set()
+            assert current is not None
+            sub = {
+                "text": "writer2",
+                "disposition": "accepted",
+                "timestamp": "2026-08-27T00:00:01",
+            }
+            return turn_record.TurnRecord(
+                session_id=current.session_id,
+                binding_id=current.binding_id,
+                turn_id=current.turn_id,
+                origin=current.origin,
+                submissions=current.submissions + [sub],
+                tool_observations=current.tool_observations,
+                outcome=current.outcome,
+                created_at=current.created_at,
+                updated_at="2026-08-27T00:00:01",
+            )
+
+        def writer2_sleep(_interval: float) -> None:
+            writer2_retry_attempted.set()
+            time.sleep(0.001)
+
+        t1_error: list[Exception] = []
+        t2_error: list[Exception] = []
+
+        def run_writer1() -> None:
+            try:
+                turn_record.mutate(writer1_fn)
+                writer1_finished.set()
+            except Exception as e:
+                t1_error.append(e)
+
+        def run_writer2() -> None:
+            try:
+                turn_record.mutate(
+                    writer2_fn,
+                    sleep=writer2_sleep,
+                    timeout_seconds=5.0,
+                )
+            except Exception as e:
+                t2_error.append(e)
+
+        t1 = threading.Thread(target=run_writer1)
+        t2 = threading.Thread(target=run_writer2)
+
+        t1.start()
+        self.assertTrue(writer1_in_critical.wait(timeout=5.0))
+
+        t2.start()
+
+        t1.join(timeout=5.0)
+        t2.join(timeout=5.0)
+
+        self.assertEqual(t1_error, [])
+        self.assertEqual(t2_error, [])
+        self.assertTrue(writer2_in_critical.is_set())
+
+        final_record = turn_record.read_turn_record()
+        self.assertIsNotNone(final_record)
+        # BOTH updates must be present!
+        sub_texts = [s["text"] for s in final_record.submissions]
+        self.assertEqual(sub_texts, ["writer1", "writer2"])
+
+    def test_lock_acquisition_timeout_raises_turn_record_busy(self) -> None:
+        """Holding the lock past acquisition budget raises TurnRecordBusy without writing."""
+        turn_record.init_turn(SESSION_ONE, BINDING_ID, TURN_ID)
+
+        # Hold the lock file exclusively with a separate file descriptor
+        lock_fd = os.open(self.lock_path(), os.O_RDWR | os.O_CREAT, 0o600)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+        mutation_ran = False
+
+        def failing_fn(current: turn_record.TurnRecord | None) -> turn_record.TurnRecord | None:
+            nonlocal mutation_ran
+            mutation_ran = True
+            return current
+
+        current_time = 0.0
+
+        def stub_clock() -> float:
+            nonlocal current_time
+            current_time += 0.2
+            return current_time
+
+        try:
+            with self.assertRaises(turn_record.TurnRecordBusy):
+                turn_record.mutate(
+                    failing_fn,
+                    timeout_seconds=0.5,
+                    retry_interval=0.01,
+                    clock=stub_clock,
+                    sleep=lambda _: None,
+                )
+            self.assertFalse(
+                mutation_ran,
+                "mutation function must not run if lock is not acquired",
+            )
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+
+    def test_stubbed_clock_acquisition_budget_refusal(self) -> None:
+        """Clock advances past budget immediately, proving named turn_record_busy refusal."""
+        turn_record.init_turn(SESSION_ONE, BINDING_ID, TURN_ID)
+
+        lock_fd = os.open(self.lock_path(), os.O_RDWR | os.O_CREAT, 0o600)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+        current_time = 1000.0
+
+        def stub_clock() -> float:
+            nonlocal current_time
+            # Advance clock past budget on subsequent check
+            current_time += 1.0
+            return current_time
+
+        try:
+            with self.assertRaises(turn_record.TurnRecordBusy) as ctx:
+                turn_record.mutate(
+                    lambda r: r,
+                    timeout_seconds=0.5,
+                    retry_interval=0.01,
+                    clock=stub_clock,
+                    sleep=lambda _: None,
+                )
+            self.assertIn("turn_record_busy", str(ctx.exception))
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_user_prompt_submit_hook.py
+++ b/plugins/voice/tests/test_user_prompt_submit_hook.py
@@ -1,0 +1,294 @@
+"""Tests for the Claude UserPromptSubmit hook (U4; R106, R107; KTD3, KTD4, KTD5, KTD11).
+
+Exercises:
+- Auralis-originated turn: context injection (origin, expectation, tool pointer, plain text rule),
+  identifier pair capture into turn record, and armed one-shot consumption on transmission;
+- Un-armed subsequent turn: preferences without brief directive;
+- Bound but non-originated turn: explicit negative injection, no policy transmitted, one-shot preserved;
+- Unbound / bridge unavailable / identity resolution failure / session mismatch: silent exit 0;
+- Turn record busy: no injection, exit 0;
+- Malformed inputs: silent exit 0.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "com.infiquetra.claude" / "hooks"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bridge_stub import DEFAULT_STUB_TOKEN, BridgeStub  # noqa: E402
+import turn_record  # noqa: E402
+import user_prompt_submit_hook  # noqa: E402
+import voice_policy  # noqa: E402
+
+VALID_UUID_1 = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+VALID_UUID_2 = "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d"
+
+AGENT_SESSION_ID = "session-test-prompt-1"
+PANE_ID = "pane-test-prompt-1"
+TERMINAL_ID = "term-test-prompt-1"
+
+
+class UserPromptSubmitHookTests(unittest.TestCase):
+    """Test suite for user_prompt_submit_hook.py."""
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+
+        self.home_dir = self.root / "home"
+        self.home_dir.mkdir(parents=True, exist_ok=True)
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        # Set up BridgeStub
+        self.stub = BridgeStub()
+        self.stub.start()
+        self.addCleanup(self.stub.stop)
+
+        # Write discovery bridge.json (mode 0600)
+        self.bridge_dir = self.home_dir / "Library" / "Application Support" / "Auralis"
+        self.bridge_dir.mkdir(parents=True, exist_ok=True)
+        self.bridge_file = self.bridge_dir / "bridge.json"
+        bridge_payload = {
+            "schema": 1,
+            "host": "127.0.0.1",
+            "port": self.stub.port,
+            "token": DEFAULT_STUB_TOKEN,
+        }
+        self.bridge_file.write_text(json.dumps(bridge_payload), encoding="utf-8")
+        os.chmod(self.bridge_file, stat.S_IRUSR | stat.S_IWUSR)
+
+        # Write mock Herdr script
+        self.herdr_path = self.root / "fake_herdr"
+        herdr_envelope = {
+            "result": {
+                "type": "agent_list",
+                "agents": [
+                    {
+                        "pane_id": PANE_ID,
+                        "terminal_id": TERMINAL_ID,
+                        "agent_session": {"value": AGENT_SESSION_ID},
+                    }
+                ],
+            }
+        }
+        mock_herdr_code = (
+            f"#!/usr/bin/env python3\n"
+            f"import sys\n"
+            f"sys.stdout.write({json.dumps(json.dumps(herdr_envelope))} + '\\n')\n"
+        )
+        self.herdr_path.write_text(mock_herdr_code, encoding="utf-8")
+        os.chmod(self.herdr_path, 0o755)
+
+        # Environment patch
+        self.env_patcher = mock.patch.dict(
+            os.environ,
+            {
+                "HOME": str(self.home_dir),
+                "VOICE_STATE_DIR": str(self.state_dir),
+                "HERDR_PANE_ID": PANE_ID,
+                "HERDR_BIN_PATH": str(self.herdr_path),
+            },
+        )
+        self.env_patcher.start()
+        self.addCleanup(self.env_patcher.stop)
+
+        # Default identity dictionary matching Herdr fixture
+        self.identity_dict = {
+            "agent_session_id": AGENT_SESSION_ID,
+            "pane_id": PANE_ID,
+            "terminal_id": TERMINAL_ID,
+        }
+
+    def run_hook(self, stdin_text: str) -> tuple[int, str]:
+        """Run user_prompt_submit_hook.main() with injected stdin and captured stdout."""
+        stdin_stream = io.StringIO(stdin_text)
+        stdout_stream = io.StringIO()
+        with (
+            mock.patch.object(sys, "stdin", stdin_stream),
+            mock.patch.object(sys, "stdout", stdout_stream),
+        ):
+            code = user_prompt_submit_hook.main()
+        return code, stdout_stream.getvalue()
+
+    def test_originated_turn_injects_context_and_captures_identifiers_and_consumes_brief(
+        self,
+    ) -> None:
+        # 1. Stub has binding + open turn
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        # 2. Write policy with preferences and armed brief_next_turn
+        voice_policy.write_policy(
+            preferences=["Speak naturally without lists.", "Keep answers under 3 sentences."],
+            brief_next_turn=True,
+            path=self.state_dir / voice_policy.POLICY_FILENAME,
+        )
+
+        # 3. Run hook
+        payload = {"session_id": AGENT_SESSION_ID, "prompt": "Explain photosynthesis"}
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+
+        # 4. Verify context output
+        self.assertTrue(stdout_text.strip())
+        output = json.loads(stdout_text)
+        self.assertIn("hookSpecificOutput", output)
+        hook_out = output["hookSpecificOutput"]
+        self.assertEqual(hook_out["hookEventName"], "UserPromptSubmit")
+        context = hook_out["additionalContext"]
+
+        self.assertIn("This turn originated through Auralis voice.", context)
+        self.assertIn("A spoken rendering is expected for this turn.", context)
+        self.assertIn("submit_spoken_rendering", context)
+        self.assertIn("plain spoken text only", context)
+        self.assertIn("Brief Next Turn override active", context)
+        self.assertIn("Speak naturally without lists.", context)
+        self.assertIn("Keep answers under 3 sentences.", context)
+
+        # 5. Verify turn record created on disk (KTD4, KTD11)
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.session_id, AGENT_SESSION_ID)  # type: ignore[union-attr]
+        self.assertEqual(rec.binding_id, VALID_UUID_1)  # type: ignore[union-attr]
+        self.assertEqual(rec.turn_id, VALID_UUID_2)  # type: ignore[union-attr]
+        self.assertEqual(rec.origin, turn_record.ORIGIN_AURALIS)  # type: ignore[union-attr]
+
+        # 6. Verify brief_next_turn was consumed on transmission (KTD5, R107)
+        pol = voice_policy.read_policy(self.state_dir / voice_policy.POLICY_FILENAME)
+        self.assertFalse(pol.brief_next_turn)
+
+        # 7. Run a second turn: preferences remain, brief directive is gone
+        self.stub.set_turn("b2345678-89ab-4cde-8f01-23456789abcd", VALID_UUID_1, state="open")
+        code2, stdout_text2 = self.run_hook(json.dumps(payload))
+        self.assertEqual(code2, 0)
+        output2 = json.loads(stdout_text2)
+        context2 = output2["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("This turn originated through Auralis voice.", context2)
+        self.assertNotIn("Brief Next Turn override active", context2)
+        self.assertIn("Speak naturally without lists.", context2)
+
+    def test_bound_turn_not_originated_injects_explicit_negative_signal_and_preserves_policy(
+        self,
+    ) -> None:
+        # Stub has binding epoch, but no active turn (or state != open)
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.clear_turn()
+
+        # Arm brief_next_turn in policy
+        voice_policy.write_policy(
+            preferences=["Speak concisely."],
+            brief_next_turn=True,
+            path=self.state_dir / voice_policy.POLICY_FILENAME,
+        )
+
+        payload = {"session_id": AGENT_SESSION_ID, "prompt": "Typed in terminal"}
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+
+        output = json.loads(stdout_text)
+        context = output["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("This turn did not originate through Auralis voice.", context)
+        self.assertIn("No spoken rendering is expected.", context)
+        self.assertNotIn("Speak concisely.", context)
+        self.assertNotIn("Brief Next Turn override active", context)
+
+        # Verify brief_next_turn was NOT consumed
+        pol = voice_policy.read_policy(self.state_dir / voice_policy.POLICY_FILENAME)
+        self.assertTrue(pol.brief_next_turn)
+
+        # Verify turn record initialized as not_originated
+        rec = turn_record.read_turn_record(self.state_dir / turn_record.TURN_RECORD_FILENAME)
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec.session_id, AGENT_SESSION_ID)  # type: ignore[union-attr]
+        self.assertEqual(rec.origin, turn_record.ORIGIN_NOT_ORIGINATED)  # type: ignore[union-attr]
+        self.assertIsNone(rec.turn_id)  # type: ignore[union-attr]
+
+    def test_unbound_session_emits_no_context(self) -> None:
+        # Stub has no binding
+        self.stub.clear_binding()
+        self.stub.clear_turn()
+
+        payload = {"session_id": AGENT_SESSION_ID, "prompt": "Hello"}
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+    def test_bridge_bound_to_different_identity_emits_no_context(self) -> None:
+        # Stub has binding for different session
+        other_identity = {
+            "agent_session_id": "session-other",
+            "pane_id": "pane-other",
+            "terminal_id": "term-other",
+        }
+        self.stub.set_binding(VALID_UUID_1, other_identity)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        payload = {"session_id": AGENT_SESSION_ID, "prompt": "Hello"}
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+    def test_bridge_unavailable_emits_no_context(self) -> None:
+        # Stop stub server
+        self.stub.stop()
+
+        payload = {"session_id": AGENT_SESSION_ID, "prompt": "Hello"}
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+    def test_identity_resolution_failure_emits_no_context(self) -> None:
+        # Invalid Herdr path
+        with mock.patch.dict(os.environ, {"HERDR_BIN_PATH": "/nonexistent/herdr"}):
+            payload = {"session_id": AGENT_SESSION_ID, "prompt": "Hello"}
+            code, stdout_text = self.run_hook(json.dumps(payload))
+            self.assertEqual(code, 0)
+            self.assertEqual(stdout_text, "")
+
+    def test_session_id_mismatch_emits_no_context(self) -> None:
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        # Payload has different session_id than Herdr fixture
+        payload = {"session_id": "mismatched-session-id", "prompt": "Hello"}
+        code, stdout_text = self.run_hook(json.dumps(payload))
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout_text, "")
+
+    def test_turn_record_busy_emits_no_context(self) -> None:
+        self.stub.set_binding(VALID_UUID_1, self.identity_dict)
+        self.stub.set_turn(VALID_UUID_2, VALID_UUID_1, state="open")
+
+        with mock.patch.object(
+            turn_record,
+            "init_turn",
+            side_effect=turn_record.TurnRecordBusy("turn_record_busy"),
+        ):
+            payload = {"session_id": AGENT_SESSION_ID, "prompt": "Hello"}
+            code, stdout_text = self.run_hook(json.dumps(payload))
+            self.assertEqual(code, 0)
+            self.assertEqual(stdout_text, "")
+
+    def test_malformed_stdin_exits_zero_with_no_output(self) -> None:
+        for malformed in ["", "not json", "[]", "123", json.dumps({"session_id": ""})]:
+            with self.subTest(malformed=malformed):
+                code, stdout_text = self.run_hook(malformed)
+                self.assertEqual(code, 0)
+                self.assertEqual(stdout_text, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/voice/tests/test_voice_policy.py
+++ b/plugins/voice/tests/test_voice_policy.py
@@ -1,0 +1,187 @@
+"""Tests for the voice policy store and instruction renderer (R25, R107; KTD5).
+
+Covers:
+- Storing and reading operator preferences and one-shot brief-next-turn override;
+- Atomic one-shot arming and consuming;
+- Corrupt and absent store states reported by name;
+- Rendering instructions containing stated preferences verbatim without content alterations;
+- CLI verbs 'voice policy show' and 'voice policy brief-next-turn'.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import voice_cli  # noqa: E402
+import voice_policy  # noqa: E402
+
+
+class VoicePolicyStoreTestCase(unittest.TestCase):
+    """Common fixture: one fresh temporary state directory per test."""
+
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.state_dir = Path(temporary.name)
+        environment = patch.dict(
+            os.environ, {"VOICE_STATE_DIR": str(self.state_dir)}
+        )
+        environment.start()
+        self.addCleanup(environment.stop)
+
+    def policy_path(self) -> Path:
+        return self.state_dir / voice_policy.POLICY_FILENAME
+
+
+class PolicyStoreReadWriteTests(VoicePolicyStoreTestCase):
+    """Store read, write, absent, and corrupt state behaviors."""
+
+    def test_absent_store_reports_absent_and_returns_default(self) -> None:
+        report = voice_policy.read_policy_report()
+        self.assertEqual(report.status, voice_policy.STATUS_ABSENT)
+        self.assertEqual(report.policy.preferences, ())
+        self.assertFalse(report.policy.brief_next_turn)
+        self.assertEqual(report.policy.tool_allowlist, ())
+
+        policy = voice_policy.read_policy()
+        self.assertEqual(policy, voice_policy.VoicePolicy())
+
+    def test_corrupt_store_reports_corrupt_and_returns_default(self) -> None:
+        cases = {
+            "invalid json": "not json {",
+            "not dict": json.dumps(["list", "of", "items"]),
+            "preferences not list": json.dumps({"preferences": "single string"}),
+            "preferences elements not strings": json.dumps({"preferences": [1, 2, 3]}),
+            "brief not bool": json.dumps({"brief_next_turn": "true"}),
+            "tool_allowlist not list": json.dumps({"tool_allowlist": 123}),
+            "tool_allowlist elements not strings": json.dumps({"tool_allowlist": [None]}),
+        }
+        for name, contents in cases.items():
+            with self.subTest(name=name):
+                self.policy_path().write_text(contents, encoding="utf-8")
+                report = voice_policy.read_policy_report()
+                self.assertEqual(report.status, voice_policy.STATUS_CORRUPT)
+                self.assertEqual(report.policy, voice_policy.VoicePolicy())
+                self.assertEqual(voice_policy.read_policy(), voice_policy.VoicePolicy())
+
+    def test_write_and_read_policy_round_trips(self) -> None:
+        prefs = ["Be concise.", "No markdown."]
+        tools = ["read_file", "grep_search"]
+        written = voice_policy.write_policy(
+            preferences=prefs,
+            brief_next_turn=True,
+            tool_allowlist=tools,
+        )
+        self.assertEqual(written.preferences, tuple(prefs))
+        self.assertTrue(written.brief_next_turn)
+        self.assertEqual(written.tool_allowlist, tuple(tools))
+
+        report = voice_policy.read_policy_report()
+        self.assertEqual(report.status, voice_policy.STATUS_OK)
+        self.assertEqual(report.policy, written)
+
+
+class BriefNextTurnOverrideTests(VoicePolicyStoreTestCase):
+    """Arming and consuming the one-shot Brief Next Turn override."""
+
+    def test_arm_and_consume_brief_next_turn(self) -> None:
+        voice_policy.write_policy(preferences=["Speak warmly."])
+        self.assertFalse(voice_policy.read_policy().brief_next_turn)
+
+        armed = voice_policy.arm_brief_next_turn()
+        self.assertTrue(armed.brief_next_turn)
+        self.assertTrue(voice_policy.read_policy().brief_next_turn)
+
+        # First consume consumes the armed override
+        consumed = voice_policy.consume_brief_next_turn()
+        self.assertTrue(consumed)
+        self.assertFalse(voice_policy.read_policy().brief_next_turn)
+
+        # Second consume reports unarmed
+        consumed_again = voice_policy.consume_brief_next_turn()
+        self.assertFalse(consumed_again)
+        self.assertFalse(voice_policy.read_policy().brief_next_turn)
+
+    def test_arm_when_absent_creates_file_and_arms(self) -> None:
+        self.assertFalse(self.policy_path().exists())
+        armed = voice_policy.arm_brief_next_turn()
+        self.assertTrue(self.policy_path().exists())
+        self.assertTrue(armed.brief_next_turn)
+
+
+class RenderInstructionsTests(VoicePolicyStoreTestCase):
+    """Instruction rendering contains preferences verbatim without content transforms."""
+
+    def test_render_instructions_with_preferences_and_brief(self) -> None:
+        prefs = ["Always speak casually.", "Avoid acronyms."]
+        policy = voice_policy.VoicePolicy(
+            preferences=tuple(prefs), brief_next_turn=True
+        )
+
+        instructions = voice_policy.render_instructions(policy)
+        self.assertIn(voice_policy.BRIEF_INSTRUCTION, instructions)
+        for pref in prefs:
+            self.assertIn(pref, instructions)
+
+    def test_render_instructions_without_brief(self) -> None:
+        prefs = ["Speak clearly."]
+        policy = voice_policy.VoicePolicy(
+            preferences=tuple(prefs), brief_next_turn=False
+        )
+
+        instructions = voice_policy.render_instructions(policy)
+        self.assertNotIn(voice_policy.BRIEF_INSTRUCTION, instructions)
+        self.assertIn("Speak clearly.", instructions)
+
+    def test_render_instructions_with_explicit_brief_flag(self) -> None:
+        policy = voice_policy.VoicePolicy(preferences=("Preference 1",), brief_next_turn=False)
+        rendered_brief = voice_policy.render_instructions(policy, brief=True)
+        self.assertIn(voice_policy.BRIEF_INSTRUCTION, rendered_brief)
+
+        rendered_not_brief = voice_policy.render_instructions(policy, brief=False)
+        self.assertNotIn(voice_policy.BRIEF_INSTRUCTION, rendered_not_brief)
+
+
+class VoiceCliPolicyTests(VoicePolicyStoreTestCase):
+    """CLI policy verbs round-trip through voice_cli.main()."""
+
+    def test_cli_policy_show_and_brief_next_turn(self) -> None:
+        voice_policy.write_policy(preferences=["Keep it short."])
+
+        # Show policy via CLI
+        stdout = io.StringIO()
+        with patch("sys.stdout", stdout):
+            code = voice_cli.main(["policy", "show"])
+        self.assertEqual(code, 0)
+        output = json.loads(stdout.getvalue())
+        self.assertEqual(output["preferences"], ["Keep it short."])
+        self.assertFalse(output["brief_next_turn"])
+
+        # Arm brief next turn via CLI
+        stdout = io.StringIO()
+        with patch("sys.stdout", stdout):
+            code = voice_cli.main(["policy", "brief-next-turn"])
+        self.assertEqual(code, 0)
+        self.assertIn("armed brief next turn override", stdout.getvalue())
+        self.assertTrue(voice_policy.read_policy().brief_next_turn)
+
+        # Verify show now reports armed brief_next_turn
+        stdout = io.StringIO()
+        with patch("sys.stdout", stdout):
+            code = voice_cli.main(["policy", "show"])
+        self.assertEqual(code, 0)
+        output = json.loads(stdout.getvalue())
+        self.assertTrue(output["brief_next_turn"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_claude_plugin_packaging.py
+++ b/tests/test_claude_plugin_packaging.py
@@ -159,6 +159,17 @@ class DeclaredComponentPathTests(unittest.TestCase):
             "belong in the portable core",
         )
 
+    def test_the_mcp_servers_declaration_points_into_the_client_extension(self) -> None:
+        mcp_servers = _load(CLAUDE_MANIFEST).get("mcpServers")
+        self.assertIsInstance(mcp_servers, str, "the mcpServers path must be declared")
+        resolved = (PLUGIN_ROOT / mcp_servers).resolve()
+        self.assertTrue(
+            resolved.is_relative_to(EXTENSION.resolve()),
+            f"mcpServers path {mcp_servers!r} must live under "
+            f"{EXTENSION.relative_to(ROOT)}; Claude-specific behaviour does not "
+            "belong in the portable core",
+        )
+
     def test_no_claude_convention_directory_sits_at_the_portable_root(self) -> None:
         for name in CLAUDE_CONVENTION_DIRS:
             with self.subTest(directory=name):
@@ -213,6 +224,36 @@ class HookRuntimePathTests(unittest.TestCase):
             "the hook resolves the portable core outside the installed root",
         )
         self.assertTrue((core / "speak.py").is_file())
+
+
+class MCPRuntimePathTests(unittest.TestCase):
+    """The MCP server declaration paths and command resolution."""
+
+    def test_the_mcp_server_command_resolves_from_the_installed_plugin_root(
+        self,
+    ) -> None:
+        # ``${CLAUDE_PLUGIN_ROOT}`` expands to the installed package root.
+        # The declared command and args must be byte-for-byte the literals
+        # U3's executable-entrypoint scenario launches so declaration and proof
+        # cannot drift apart.
+        mcp_file = PLUGIN_ROOT / _load(CLAUDE_MANIFEST)["mcpServers"]
+        self.assertTrue(mcp_file.is_file(), f"{mcp_file} is missing")
+        servers = _load(mcp_file)
+        self.assertTrue(servers, "the mcpServers descriptor declares no server")
+        for name, config in servers.items():
+            with self.subTest(server=name):
+                command = config.get("command")
+                self.assertEqual(command, "python3")
+                args = config.get("args")
+                self.assertIsInstance(args, list)
+                self.assertEqual(args, ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp_server.py"])
+                for arg in args:
+                    self.assertIn("${CLAUDE_PLUGIN_ROOT}", arg)
+                    relative = arg.split("${CLAUDE_PLUGIN_ROOT}", 1)[1].lstrip("/")
+                    self.assertTrue(
+                        (PLUGIN_ROOT / relative).is_file(),
+                        f"{relative} does not exist under the installed root",
+                    )
 
 
 class MarketplaceEntryTests(unittest.TestCase):
@@ -276,6 +317,11 @@ class MarketplaceEntryTests(unittest.TestCase):
             len(set(sites.values())),
             1,
             f"version sites disagree: {sites}",
+        )
+        self.assertEqual(
+            list(sites.values())[0],
+            "0.3.0",
+            f"version must be 0.3.0, got {sites}",
         )
 
 


### PR DESCRIPTION
Releases capability slice **C3 — Claude adapter** of the Auralis V1 run onto `main`.

Closes #46

## Typed Saga Code Review outcome

| field | value |
|---|---|
| reviewed revision | `faf5236282199dd3f3fe3f2c98530f994dabc652` |
| outcome | **accepted** (cycle 2) |
| lenses | 11 selected, 11 attempted, **0 failing** |
| cycle history | cycle 1 `repairs_requested` → cycle 2 `accepted` |
| artifact | 31,418 bytes, sha256 `ad8433590f2a9c1ff492e608ed53a2cd5cf11c1ed75f1391bc8196d1ff0ee843` |

Cycle 2 followed repair-cycle consensus: only the previously failing lenses were rerun, and the ten accepted lenses received revision-bound delta checks against the new target.

## Exact-tree provenance

This branch is cut from `main` and carries the accepted tree exactly. Versus the accepted revision `faf5236`, **one file differs**:

- `docs/evidence/voice/auralis-c3-acceptance.md` — the review's own routed fix `fix-4d99d5abe366` (`autofix_class: safe_auto`, `requires_verification: false`)

That fix was required to close the review: the acceptance ledger named a test method that did not exist (`test_r122_rejected_rendering_with_no_replacement_settles_as_fallback`). The real method is `test_r122_adapter_boundary_rejection_no_replacement_settles_fallback`. The **ledger** was corrected, not the reviewed test. All three test ids the ledger names now resolve.

No other reviewed code is altered.

## What ships

Five implementation units, file sets disjoint by design:

| unit | surface |
|---|---|
| U1 | `bridge_client.py`, `adapter_identity.py`, `settings.py`, shared `bridge_stub.py` |
| U2 | `rendering_gate.py`, `voice_policy.py`, `turn_record.py`, `voice_cli.py` |
| U3 | `mcp_server.py` — MCP authored-rendering surface and presence lifecycle |
| U4 | `user_prompt_submit_hook.py`, `pre_tool_use_hook.py`, `stop_hook.py`, `hooks.json` |
| U5 | packaging, versions, README, journal, acceptance evidence |

Plan accepted after **four** document-review cycles (all twelve findings closed); all four review artifacts are included.

## Two conditions the review attached, both honoured

**The Markdown gate implements normative rows, not test spellings.** `rendering_gate.py` uses `^[ ]{0,3}(?:[-+*]|\d{1,9}[.)])([ \t]|$)` for list markers and `^[ ]{0,3}#{1,6}([ \t]|$)` for ATX headings, so `2.`, `12)`, a bare `-`, an empty `##` and tab-delimited forms all reject.

**R122's boundary is stated honestly.** `test_r122_adapter_boundary.py` proves only the adapter-side half; the Core-side `fallback_accepted` half is a named cross-repository obligation owned by `infiquetra/auralis` (acceptance example AE36), not claimed here.

## Frozen wire contract

Five routes, unchanged: `GET /v1/health`, `PUT /v1/presence`, `DELETE /v1/presence`, `GET /v1/current`, `POST /v1/rendering`.

## Requirements and acceptance

R20–R23, R25, R106, R107, R121, R122. Acceptance example AE26.

## Verification

```
PYTHONDONTWRITEBYTECODE=1 python3 scripts/check_repo.py            exit 0
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -q  773 tests OK
python3 -m pytest plugins/voice/tests -q                            456 passed, 282 subtests
```

Parent: infiquetra/auralis#3
