### PR TITLE
chore: ignore the .qwen client runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ vault_pass.txt
 .saga/
 .serena/
 .hermes/
+.qwen/
 memories/
 sessions/
 state.db


### PR DESCRIPTION
Qwen writes `.qwen/tmp/` into whatever directory it runs in, so any Qwen-assisted
session leaves this repository showing an untracked `.qwen/` entry. It is client
runtime state, not repository content.

Adds it to the existing "Local agent runtime state" block beside `.claude/`,
`.saga/`, `.serena/`, and `.hermes/`, which are ignored for exactly the same reason.

Verified that no tracked file becomes ignored by this change:

```
git ls-files -i -c --exclude-standard   # empty
```

https://claude.ai/code/session_013iRNTHQnxRhcfyqamwF1Bs